### PR TITLE
fix: remove invalid upload-dir from GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -40,18 +40,20 @@ jobs:
       - name: Build website
         working-directory: ./website
         run: npm run build
-      
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
+      - name: Copy files for Pages upload
+        run: |
+          mkdir -p _site
+          cp website/index.html _site/
+          cp website/logo.png _site/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload index.html and logo (copied from assets by build script)
-          path: |
-            ./website/index.html
-            ./website/logo.png
-          upload-dir: ./
+          path: _site/
 
   deploy:
     environment:


### PR DESCRIPTION
The GitHub Pages workflow had two issues:

1. `upload-dir` parameter is not supported by `actions/upload-pages-artifact@v3`
2. The workflow was uploading the entire `website/` directory including `node_modules`, `package.json`, etc.

This fix:
- Removes the invalid `upload-dir` parameter
- Creates a dedicated `_site/` directory containing only the files needed for Pages deployment (index.html and logo.png)

See: https://github.com/adinapoli/rusholme/actions/runs/22068058628