### PR TITLE
feat: add Cachix binary cache integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,25 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            substituters = https://cache.nixos.org https://adinapoli-rusholme.cachix.org
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= adinapoli-rusholme.cachix.org-1:TPBkX8B1CfCiqiMRQbq1rg12C8Lgaczubka/fO/cHeo=
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v15
+        # Only push on main branch, PRs just pull from cache
+        if: github.ref == 'refs/heads/main'
+        with:
+          name: adinapoli-rusholme
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          skipPush: true
 
       - name: Build
         run: nix develop --command zig build --summary all
 
       - name: Test
         run: nix develop --command zig build test --summary all
+
+      - name: Push to Cachix
+        # Push after successful build on main branch
+        if: github.ref == 'refs/heads/main'
+        run: nix flake archive --json | jq -r '.path,(.inputs | to_entries[].value.path)' | cachix push adinapoli-rusholme

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ zig build test --summary all
 zig build run
 ```
 
+## Binary Cache (Cachix)
+
+Rusholme uses [Cachix](https://cachix.org/) for binary caching to speed up builds.
+To use the cache locally, create or edit `~/.config/nix/nix.conf`:
+
+```conf
+substituters = https://cache.nixos.org https://adinapoli-rusholme.cachix.org
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= adinapoli-rusholme.cachix.org-1:TPBkX8B1CfCiqiMRQbq1rg12C8Lgaczubka/fO/cHeo=
+```
+
 > **⚠️ Note on `zig build` vs `zig build test`**
 >
 > Zig uses lazy compilation — `zig build` only compiles code paths reachable


### PR DESCRIPTION
This PR adds Cachix binary caching to speed up Nix builds in CI and locally.

**Changes:**

1. **CI workflow** ():
   - Adds Cachix substituter and public key to Nix config
   - Sets up Cachix action to push binary artifacts on main branch builds
   - PR builds can pull from cache (read-only) for speed

2. **README**:
   - Documents how to configure local Nix to use the Cachix cache

**To complete setup, add the secret:**

Go to https://app.cachix.org/api/v1/cache/adinapoli-rusholme/auth-token to generate your auth token, then:

1. Navigate to: repo Settings → Secrets and variables → Actions
2. Add repository secret: `CACHIX_AUTH_TOKEN`
3. Paste the token value

**Benefits:**

- Faster CI builds (substitute pre-built binaries)
- Faster local development in `nix develop`
- Free 5 GB tier for open source projects