### PR TITLE
sync: Mark #107, #108, #110 as done (zero-leak epic cleanup)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # Rusholme Roadmap
 
 > Auto-generated from GitHub issues. Each issue links to its tracker.
-> **Starting points** (zero dependencies): #1✓, #2✓, #17✓, #22✓, #24✓, #27✓, #53✓, #85✓, #58, #62⚡, #66, #68, #107
+> **Starting points** (zero dependencies): #1✓, #2✓, #17✓, #22✓, #24✓, #27✓, #53✓, #85✓, #58, #62⚡, #66, #68, #107✓
 
 **Recent Progress (2026-02-16):**
 - ✓ #85: Lexer support for numeric literals (Dec, Hex, Oct, Bin, Float)
@@ -57,10 +57,10 @@
 
 | # | Issue | Deps | Status |
 |---|-------|------|--------|
-| [#107](https://github.com/adinapoli/rusholme/issues/107) | Research: Zero-leak enforcement strategy (GPA vs Valgrind vs hybrid) | — | :white_circle: |
-| [#108](https://github.com/adinapoli/rusholme/issues/108) | Enforce std.testing.allocator in all tests and add GPA to main.zig | [#107](https://github.com/adinapoli/rusholme/issues/107) | :white_circle: |
+| [#107](https://github.com/adinapoli/rusholme/issues/107) | Research: Zero-leak enforcement strategy (GPA vs Valgrind vs hybrid) | — | :green_circle: |
+| [#108](https://github.com/adinapoli/rusholme/issues/108) | Enforce std.testing.allocator in all tests and add GPA to main.zig | [#107](https://github.com/adinapoli/rusholme/issues/107) | :green_circle: |
 | [#109](https://github.com/adinapoli/rusholme/issues/109) | Add Valgrind CI step for C interop leak detection | [#107](https://github.com/adinapoli/rusholme/issues/107) | :white_circle: |
-| [#110](https://github.com/adinapoli/rusholme/issues/110) | Document zero-leak policy in CONTRIBUTING.md and DESIGN.md | [#107](https://github.com/adinapoli/rusholme/issues/107) | :white_circle: |
+| [#110](https://github.com/adinapoli/rusholme/issues/110) | Document zero-leak policy in CONTRIBUTING.md and DESIGN.md | [#107](https://github.com/adinapoli/rusholme/issues/107) | :green_circle: |
 
 ---
 


### PR DESCRIPTION
## Summary

Marks three zero-leak epic issues as :green_circle: in ROADMAP.md. These were already completed:

- **#107** — Research: Zero-leak enforcement strategy → decision doc exists at `docs/decisions/002-zero-leak-strategy.md`
- **#108** — GPA in main.zig + std.testing.allocator in tests → already in place
- **#110** — Document zero-leak policy in CONTRIBUTING.md → section already exists

All three GitHub issues have been closed.

**#109** (Valgrind CI) remains :white_circle: — explicitly deferred per the decision doc until LLVM backend is active.