### PR TITLE
Fix: Dynamic milestone progress & auto-deploy website

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,12 +1,11 @@
 name: Deploy Website
 
 on:
-  # Run on pushes to main branch
+  # Run on every push to main — milestone progress is computed from
+  # ROADMAP.md and GitHub issue state, so any merge can change the site.
   push:
     branches:
       - main
-    paths:
-      - 'website/**'
   # Allow manual trigger from GitHub UI
   workflow_dispatch:
 

--- a/website/index.html
+++ b/website/index.html
@@ -549,18 +549,18 @@
                 </a>
             </div>
 
-            <!-- Milestones -->
+            <!-- Milestones (dynamically generated from ROADMAP.md at build time) -->
             <div class="grid md:grid-cols-5 gap-4 mb-16">
-                <div class="card-hover p-6 bg-gray-900 rounded-2xl border border-gray-800">
+                                <div class="card-hover p-6 bg-gray-900 rounded-2xl border border-gray-800">
                     <div class="text-4xl mb-4">🚀</div>
                     <h3 class="font-bold text-lg text-white mb-1">M0</h3>
                     <p class="text-sm text-gray-500 mb-4">Infrastructure</p>
-                    <div class="flex items-center gap-2 text-sm text-green-500 font-semibold">
-                        <i data-lucide="check-circle-2" class="w-4 h-4"></i>
-                        100% complete
+                    <div class="flex items-center gap-2 text-sm text-blue-500 font-semibold">
+                        <i data-lucide="clock" class="w-4 h-4"></i>
+                        ~79% complete
                     </div>
                     <div class="mt-4 h-2 bg-gray-800 rounded-full overflow-hidden">
-                        <div class="h-full bg-gradient-to-r from-green-500 to-emerald-500 progress-bar" style="width: 100%"></div>
+                        <div class="h-full bg-gradient-to-r from-blue-500 to-indigo-500 progress-bar" style="width: 79%"></div>
                     </div>
                 </div>
 
@@ -570,10 +570,10 @@
                     <p class="text-sm text-gray-500 mb-4">Hello World</p>
                     <div class="flex items-center gap-2 text-sm text-blue-500 font-semibold">
                         <i data-lucide="clock" class="w-4 h-4"></i>
-                        ~35% complete
+                        ~46% complete
                     </div>
                     <div class="mt-4 h-2 bg-gray-800 rounded-full overflow-hidden">
-                        <div class="h-full bg-gradient-to-r from-blue-500 to-indigo-500 progress-bar" style="width: 35%"></div>
+                        <div class="h-full bg-gradient-to-r from-blue-500 to-indigo-500 progress-bar" style="width: 46%"></div>
                     </div>
                 </div>
 
@@ -631,70 +631,10 @@
         </svg>
       </div>
       <div class="flex-1">
-        <a href="https://github.com/adinapoli/rusholme/issues/85" target="_blank" class="text-white hover:text-[#f7a41d] font-medium">
-          #85: Lexer: Numeric Literals (Hex, Oct, Bin, Dec, Float)
+        <a href="https://github.com/adinapoli/rusholme/issues/142" target="_blank" class="text-white hover:text-[#f7a41d] font-medium">
+          #142: Implement rhc CLI with parse subcommand
         </a>
-        <p class="text-xs text-gray-500 mt-1">Closed 5 hours ago</p>
-      </div>
-    </div><div class="flex items-start gap-3">
-      <div class="w-6 h-6 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
-          <polyline points="20 6 9 17 4 12"></polyline>
-        </svg>
-      </div>
-      <div class="flex-1">
-        <a href="https://github.com/adinapoli/rusholme/issues/26" target="_blank" class="text-white hover:text-[#f7a41d] font-medium">
-          #26: Implement full Haskell 2010 layout rule
-        </a>
-        <p class="text-xs text-gray-500 mt-1">Closed 3 hours ago</p>
-      </div>
-    </div><div class="flex items-start gap-3">
-      <div class="w-6 h-6 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
-          <polyline points="20 6 9 17 4 12"></polyline>
-        </svg>
-      </div>
-      <div class="flex-1">
-        <a href="https://github.com/adinapoli/rusholme/issues/25" target="_blank" class="text-white hover:text-[#f7a41d] font-medium">
-          #25: Implement core lexer (keywords, identifiers, literals, symbols)
-        </a>
-        <p class="text-xs text-gray-500 mt-1">Closed 4 hours ago</p>
-      </div>
-    </div><div class="flex items-start gap-3">
-      <div class="w-6 h-6 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
-          <polyline points="20 6 9 17 4 12"></polyline>
-        </svg>
-      </div>
-      <div class="flex-1">
-        <a href="https://github.com/adinapoli/rusholme/issues/23" target="_blank" class="text-white hover:text-[#f7a41d] font-medium">
-          #23: Define lexer token types for Haskell
-        </a>
-        <p class="text-xs text-gray-500 mt-1">Closed 18 hours ago</p>
-      </div>
-    </div><div class="flex items-start gap-3">
-      <div class="w-6 h-6 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
-          <polyline points="20 6 9 17 4 12"></polyline>
-        </svg>
-      </div>
-      <div class="flex-1">
-        <a href="https://github.com/adinapoli/rusholme/issues/18" target="_blank" class="text-white hover:text-[#f7a41d] font-medium">
-          #18: Define Diagnostic ADT (errors as structured data, not strings)
-        </a>
-        <p class="text-xs text-gray-500 mt-1">Closed 18 hours ago</p>
-      </div>
-    </div><div class="flex items-start gap-3">
-      <div class="w-6 h-6 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
-          <polyline points="20 6 9 17 4 12"></polyline>
-        </svg>
-      </div>
-      <div class="flex-1">
-        <a href="https://github.com/adinapoli/rusholme/issues/1" target="_blank" class="text-white hover:text-[#f7a41d] font-medium">
-          #1: Set up GitHub Actions CI via Nix flake
-        </a>
-        <p class="text-xs text-gray-500 mt-1">Closed 20 hours ago</p>
+        <p class="text-xs text-gray-500 mt-1">Closed 5 minutes ago</p>
       </div>
     </div>
                 </div>

--- a/website/template.html
+++ b/website/template.html
@@ -549,72 +549,9 @@
                 </a>
             </div>
 
-            <!-- Milestones -->
+            <!-- Milestones (dynamically generated from ROADMAP.md at build time) -->
             <div class="grid md:grid-cols-5 gap-4 mb-16">
-                <div class="card-hover p-6 bg-gray-900 rounded-2xl border border-gray-800">
-                    <div class="text-4xl mb-4">🚀</div>
-                    <h3 class="font-bold text-lg text-white mb-1">M0</h3>
-                    <p class="text-sm text-gray-500 mb-4">Infrastructure</p>
-                    <div class="flex items-center gap-2 text-sm text-green-500 font-semibold">
-                        <i data-lucide="check-circle-2" class="w-4 h-4"></i>
-                        100% complete
-                    </div>
-                    <div class="mt-4 h-2 bg-gray-800 rounded-full overflow-hidden">
-                        <div class="h-full bg-gradient-to-r from-green-500 to-emerald-500 progress-bar" style="width: 100%"></div>
-                    </div>
-                </div>
-
-                <div class="card-hover p-6 bg-gray-900 rounded-2xl border border-gray-800">
-                    <div class="text-4xl mb-4">👋</div>
-                    <h3 class="font-bold text-lg text-white mb-1">M1</h3>
-                    <p class="text-sm text-gray-500 mb-4">Hello World</p>
-                    <div class="flex items-center gap-2 text-sm text-blue-500 font-semibold">
-                        <i data-lucide="clock" class="w-4 h-4"></i>
-                        ~35% complete
-                    </div>
-                    <div class="mt-4 h-2 bg-gray-800 rounded-full overflow-hidden">
-                        <div class="h-full bg-gradient-to-r from-blue-500 to-indigo-500 progress-bar" style="width: 35%"></div>
-                    </div>
-                </div>
-
-                <div class="card-hover p-6 bg-gray-900 rounded-2xl border border-gray-800 opacity-60">
-                    <div class="text-4xl mb-4">📋</div>
-                    <h3 class="font-bold text-lg text-white mb-1">M2</h3>
-                    <p class="text-sm text-gray-500 mb-4">Basic Programs</p>
-                    <div class="flex items-center gap-2 text-sm text-gray-500 font-semibold">
-                        <i data-lucide="circle" class="w-4 h-4"></i>
-                        Not started
-                    </div>
-                    <div class="mt-4 h-2 bg-gray-800 rounded-full overflow-hidden">
-                        <div class="h-full bg-gray-700 progress-bar" style="width: 0%"></div>
-                    </div>
-                </div>
-
-                <div class="card-hover p-6 bg-gray-900 rounded-2xl border border-gray-800 opacity-60">
-                    <div class="text-4xl mb-4">⚙️</div>
-                    <h3 class="font-bold text-lg text-white mb-1">M3</h3>
-                    <p class="text-sm text-gray-500 mb-4">Optimisations</p>
-                    <div class="flex items-center gap-2 text-sm text-gray-500 font-semibold">
-                        <i data-lucide="circle" class="w-4 h-4"></i>
-                        Not started
-                    </div>
-                    <div class="mt-4 h-2 bg-gray-800 rounded-full overflow-hidden">
-                        <div class="h-full bg-gray-700 progress-bar" style="width: 0%"></div>
-                    </div>
-                </div>
-
-                <div class="card-hover p-6 bg-gray-900 rounded-2xl border border-gray-800 opacity-60">
-                    <div class="text-4xl mb-4">✨</div>
-                    <h3 class="font-bold text-lg text-white mb-1">M4</h3>
-                    <p class="text-sm text-gray-500 mb-4">Polish</p>
-                    <div class="flex items-center gap-2 text-sm text-gray-500 font-semibold">
-                        <i data-lucide="circle" class="w-4 h-4"></i>
-                        Not started
-                    </div>
-                    <div class="mt-4 h-2 bg-gray-800 rounded-full overflow-hidden">
-                        <div class="h-full bg-gray-700 progress-bar" style="width: 0%"></div>
-                    </div>
-                </div>
+                <!-- MILESTONE_CARDS_PLACEHOLDER -->
             </div>
 
             <!-- Recent progress -->


### PR DESCRIPTION
## Summary

Two fixes for the project website:

1. **Dynamic milestone progress**: Milestone cards (M0–M4) are now computed at build time from `ROADMAP.md` instead of being hardcoded. The build script parses the roadmap, counts `:green_circle:` vs total issues per milestone section, and generates the cards with correct percentages and colors.

2. **Deploy trigger fix**: Removed the `paths: ['website/**']` filter from the deploy workflow. Since milestone progress depends on `ROADMAP.md` and GitHub issue state, the site should rebuild on every push to `main`, not just when `website/` files change.

### Current computed progress
- **M0**: 15/19 (79%)
- **M1**: 23/50 (46%)
- **M2–M4**: 0%

### Files changed
- `.github/workflows/deploy-website.yml` — removed paths filter
- `website/build.js` — added `computeMilestoneProgress()` and `generateMilestoneCardsHTML()`
- `website/template.html` — replaced 5 hardcoded milestone cards with `<!-- MILESTONE_CARDS_PLACEHOLDER -->`
- `website/index.html` — regenerated output

## Testing
- `npm run build` in `website/` succeeds with correct percentages logged
- `zig build test --summary all` — 221/221 tests pass
