### PR TITLE
#177: astTypeToHType incomplete — App, Paren, Forall, n-tuples not handled

### DIFF
--- a/src/naming/known.zig
+++ b/src/naming/known.zig
@@ -64,6 +64,9 @@ pub const Con = struct {
     pub const Nil = name("[]", 207);
     pub const Cons = name("(:)", 208);
     pub const Tuple2 = name("(,)", 209);
+    pub const Tuple3 = name("(,,)", 210);
+    pub const Tuple4 = name("(,,,)", 211);
+    pub const Tuple5 = name("(,,,,)", 212);
 };
 
 /// The start of the non-reserved unique ID range.


### PR DESCRIPTION
Closes #177

## Summary

Implements the missing variants in `astTypeToHType` that were previously falling back to fresh metavariables:
- `.App`: Type applications like `Maybe Int`, `Either String Bool`
- `.Forall`: Explicit forall annotations like `forall a b. (a -> b) -> [a] -> [b]`
- n-ary tuples beyond 2-tuples: `Tuple3`, `Tuple4`, `Tuple5`

The `.Paren` variant was already implemented correctly (simply recursing into the inner type).

## Changes

**src/naming/known.zig**:
- Added `Tuple3`, `Tuple4`, `Tuple5` constructors to `Known.Con`

**src/typechecker/infer.zig**:
- Implemented `.App` in `astTypeToHTypeWithScope`: Converts head to HType, then processes remaining parts as arguments, building a Con with the head's name and the collected args
- Implemented `.Forall` in `astTypeToHTypeWithScope`: Creates nested `HType.ForAll` nodes for each type variable (processed in reverse to nest correctly)
- Rewrote `.Tuple` handling in `astTypeToHTypeWithScope` to Support 1-5 element tuples with appropriate constructor names
- Updated tuple pattern handling in `inferPat` to support 1-5 element tuples  
- Updated tuple expression handling in `infer` to support 1-5 element tuples
- Added 7 new tests covering each variant

## Testing

All 358 tests pass, including:
- `astTypeToHType: type application Maybe Int`
- `astTypeToHType: type application Either String Bool`
- `astTypeToHType: forall a b. (a -> b) -> [a] -> [b]`
- `astTypeToHType: tuple types Tuple3, Tuple4, Tuple5`
- `astTypeToHType: parenthesised types are passed through`
- `inferModule with type application in signature`

## Notes

- Tuples larger than 5 elements still fall back to fresh metavariables (M1 limitation)
- `.IParam` still falls back to fresh meta (not in this issue's scope)
