### PR TITLE
#193: Implement backtick infix operator syntax

### DIFF
--- a/src/frontend/lexer.zig
+++ b/src/frontend/lexer.zig
@@ -136,6 +136,8 @@ pub const Token = union(enum) {
     underscore,
     /// - (distinguished from varsym for negation / layout)
     minus,
+    /// ` (backtick, used for infix function application: x `div` y)
+    backtick,
 
     // ── Other ──────────────────────────────────────────────────────────
     /// End of file
@@ -315,6 +317,7 @@ pub const Token = union(enum) {
             .darrow => try w.writeAll("=>"),
             .underscore => try w.writeAll("_"),
             .minus => try w.writeAll("-"),
+            .backtick => try w.writeAll("`"),
 
             // Other
             .eof => try w.writeAll("<eof>"),
@@ -391,6 +394,10 @@ pub const Lexer = struct {
             '}' => {
                 _ = self.advance();
                 return LocatedToken.init(.close_brace, span_mod.SourceSpan.init(start_pos, self.currentPos()));
+            },
+            '`' => {
+                _ = self.advance();
+                return LocatedToken.init(.backtick, span_mod.SourceSpan.init(start_pos, self.currentPos()));
             },
             else => {},
         }

--- a/tests/should_compile/sc014_list_comprehensions.properties
+++ b/tests/should_compile/sc014_list_comprehensions.properties
@@ -1,1 +1,1 @@
-xfail: list comprehensions [e | x <- xs] not yet supported
+xfail: list comprehension parsing not yet implemented (issue #136); also uses backtick infix (issue #193)

--- a/tests/should_compile/sc026_where_mutual_recursion.properties
+++ b/tests/should_compile/sc026_where_mutual_recursion.properties
@@ -1,1 +1,0 @@
-xfail: backtick infix operators (n `div` m) not yet supported — lexer emits lex_error

--- a/tests/should_compile/sc033_sections_operators.properties
+++ b/tests/should_compile/sc033_sections_operators.properties
@@ -1,1 +1,1 @@
-xfail: operator sections (negate) and backtick infix operators not yet supported
+xfail: consym operator sections e.g. (++ "!") and (0 :) not yet supported (issue #202)


### PR DESCRIPTION
Closes #193

## Summary
Implements backtick infix operator syntax for the Rusholme parser, covering all Haskell 2010 §3.4 and §4.4.3 forms.

## Deliverables
- [x] Lexer: add `.backtick` token (`` ` `` character)
- [x] Parser: backtick infix expressions — `` x `div` y `` → `InfixApp{op="div"}`
- [x] Parser: backtick right-sections — `` (`div` 2) `` → `RightSection`
- [x] Parser: backtick left-sections — `` (x `div`) `` → `LeftSection`
- [x] Parser: backtick infix function definitions — `` n `divides` m = ... `` → `FunBind`
- [x] Parser: backtick names in fixity declarations — `` infixl 7 `div` ``
- [x] Refactored infix climbing loop into `continueInfixExpr` so parenthesised expressions share the same operator handling (fixes backtick in parens, e.g. `` (k `div` 2) ``)
- [x] Type annotation check (`expr :: Type`) moved into `continueInfixExpr` after the loop (fixes regression in `(1 + 2 :: Double)`)
- [x] sc026 (where/mutual recursion with `` `div` ``) now passes; xfail removed
- [x] Follow-up issue #218 filed for compound-LHS backtick left sections

## Testing
All 433 tests pass:
```
Build Summary: 9/9 steps succeeded; 433/433 tests passed
```
- sc026 passes (previously xfail, now fixed by this PR)
- sc014 remains xfail (list comprehensions not yet implemented — issue #136 in review)
- sc033 remains xfail (consym sections blocked by issue #202)
