### PR TITLE
#135: Implement parser: record syntax

### DIFF
--- a/src/frontend/ast.zig
+++ b/src/frontend/ast.zig
@@ -327,6 +327,14 @@ pub const FieldUpdate = struct {
     expr: Expr,
 };
 
+/// Field pattern in record patterns: Point { x = a }
+/// Field punning is supported: Point { x } is equivalent to Point { x = x }
+pub const FieldPattern = struct {
+    field_name: []const u8,
+    /// None for field punning (x -> x = x), Some for explicit pattern (x = p)
+    pat: ?Pattern,
+};
+
 /// Case alternative
 pub const Alt = struct {
     pattern: Pattern,
@@ -379,6 +387,9 @@ pub const Pattern = union(enum) {
     Bang: struct { pat: *const Pattern, span: SourceSpan },
     /// N+K pattern (deprecated)
     NPlusK: struct { name: []const u8, name_span: SourceSpan, k: i32, span: SourceSpan },
+    /// Record pattern: Point { x = a, y = b }
+    /// Field punning is supported: Point { x } is equivalent to Point { x = x }
+    RecPat: struct { con: QName, fields: []const FieldPattern, span: SourceSpan },
 
     pub fn getSpan(self: Pattern) SourceSpan {
         return switch (self) {
@@ -394,6 +405,7 @@ pub const Pattern = union(enum) {
             .Paren => |p| p.span,
             .Bang => |b| b.span,
             .NPlusK => |npk| npk.span,
+            .RecPat => |rp| rp.span,
         };
     }
 };


### PR DESCRIPTION
Closes #135

## Summary
Implemented record parsing for Rusholme's parser, adding support for:
- Record construction: `Point { x = 1, y = 2 }`
- Field punning: `Person { name, age = 25 }`
- Record update: `rec { x = 10 }`
- Record patterns: `getX (Point { x = n }) = n`
- Record declarations: `data Point = Point { x :: Int, y :: Int }`

## Deliverables
- [x] Parse record construction: `Point { x = 1, y = 2 }`
- [x] Support field punning: `Person { name, age = 25 }`
- [x] Parse record update: `rec { x = 10 }`
- [x] Handle record patterns in function bindings: `f (Point { x = a }) = a`
- [x] Support record patterns in case expressions
- [x] Source spans for records and fields
- [x] Parse record declarations in `data` and `newtype`
- [x] Add `RecPat` variant to AST `Pattern` union
- [x] Update renamer and typechecker to handle record patterns
- [x] Fix pretty-printer to display record fields in single `{ ... }` block

## Testing
All 458 tests pass. Unblocks several previously xfail tests:
- `sc004_record_syntax`: Record syntax in data declarations
- `sc011_newtype`: Record syntax in newtype declarations
- `sc030_record_wildcards_update`: Record update and field access
