### PR TITLE
Add pre-commit hook to prevent direct commits to main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# Pre-commit hooks for Rusholme
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: no-commit-to-branch

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
 
             # Development tools
             git
+            pre-commit
           ] ++ pkgs.lib.optionals (!isDarwin) [
             # Linux-only tools
             valgrind


### PR DESCRIPTION
## Summary
Add pre-commit hook to prevent direct commits to `main` branch. This uses the pre-commit framework with the `no-commit-to-branch` hook, which blocks commits to both `main` and `master` by default.

## Changes
- Add `pre-commit` to `flake.nix` devShell buildInputs
- Add `.pre-commit-config.yaml` with `no-commit-to-branch` hook

## Usage
After `nix develop`, run:
```bash
pre-commit install
```

This will prevent anyone from committing directly to the `main` branch locally.

## Testing
Verified the hook successfully blocks commits to `main` while allowing commits on feature branches.

## Note
As noted in the upstream tutorial, this can be bypassed locally (developers can uninstall the hook). For stronger enforcement, GitHub branch protection rules should be configured as a follow-up.
