### PR TITLE
#207: Layout rule - reject malformed indentation (operators starting declarations)

### DIFF
--- a/src/frontend/parser.zig
+++ b/src/frontend/parser.zig
@@ -3531,6 +3531,7 @@ fn initTestParser(
     lexer.* = Lexer.init(allocator, source, 1);
     layout.* = LayoutProcessor.init(allocator, lexer);
     diags.* = DiagnosticCollector.init();
+    layout.setDiagnostics(diags);
     return Parser.init(allocator, layout, diags) catch |err| switch (err) {
         error.OutOfMemory => @panic("OOM in initTestParser"),
         error.UnexpectedToken, error.UnexpectedEOF, error.InvalidSyntax => @panic("parse error in initTestParser"),
@@ -3769,6 +3770,7 @@ fn parseTestExpr(
     var lexer = Lexer.init(allocator, full, 1);
     var layout = LayoutProcessor.init(allocator, &lexer);
     var diags = DiagnosticCollector.init();
+    layout.setDiagnostics(&diags);
     var parser = Parser.init(allocator, &layout, &diags) catch |err| switch (err) {
         error.OutOfMemory => @panic("OOM in parseTestExpr"),
         error.UnexpectedToken, error.UnexpectedEOF, error.InvalidSyntax => @panic("parse error in parseTestExpr"),
@@ -4389,6 +4391,7 @@ fn parseTestModule(allocator: std.mem.Allocator, source: []const u8) !ast_mod.Mo
     var lexer = Lexer.init(allocator, source, 1);
     var layout = LayoutProcessor.init(allocator, &lexer);
     var diags = DiagnosticCollector.init();
+    layout.setDiagnostics(&diags);
     var parser = Parser.init(allocator, &layout, &diags) catch |err| switch (err) {
         error.OutOfMemory => @panic("OOM in parseTestModule"),
         error.UnexpectedToken, error.UnexpectedEOF, error.InvalidSyntax => @panic("parse error in parseTestModule"),
@@ -4400,6 +4403,7 @@ fn parseTestModuleFails(allocator: std.mem.Allocator, source: []const u8) !void 
     var lexer = Lexer.init(allocator, source, 1);
     var layout = LayoutProcessor.init(allocator, &lexer);
     var diags = DiagnosticCollector.init();
+    layout.setDiagnostics(&diags);
     var parser = try Parser.init(allocator, &layout, &diags);
 
     _ = parser.parseModule() catch {};

--- a/src/main.zig
+++ b/src/main.zig
@@ -115,6 +115,7 @@ fn cmdParse(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     var layout = LayoutProcessor.init(arena_alloc, &lexer);
     var diags = DiagnosticCollector.init();
     defer diags.deinit(arena_alloc);
+    layout.setDiagnostics(&diags);
 
     var parser = Parser.init(arena_alloc, &layout, &diags) catch {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
@@ -178,6 +179,7 @@ fn cmdCheck(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     var layout = LayoutProcessor.init(arena_alloc, &lexer);
     var diags = DiagnosticCollector.init();
     defer diags.deinit(arena_alloc);
+    layout.setDiagnostics(&diags);
 
     var parser = Parser.init(arena_alloc, &layout, &diags) catch {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);

--- a/tests/parser_test_runner.zig
+++ b/tests/parser_test_runner.zig
@@ -93,6 +93,7 @@ fn tryParse(allocator: std.mem.Allocator, comptime path: []const u8) !bool {
     var layout = LayoutProcessor.init(aa, &lexer);
     var diags = DiagnosticCollector.init();
     defer diags.deinit(aa);
+    layout.setDiagnostics(&diags);
 
     var parser = Parser.init(aa, &layout, &diags) catch return false;
 

--- a/tests/should_fail/sf005_bad_layout.properties
+++ b/tests/should_fail/sf005_bad_layout.properties
@@ -1,1 +1,1 @@
-xfail: layout error detection not strict enough — bad indentation accepted
+-- Should fail: layout violation - operator cannot start a declaration


### PR DESCRIPTION
Closes #207

## Summary
Implement layout validation to detect and reject malformed layout where an operator appears to start a fresh declaration. Rusholme was previously accepting malformed layout like:

```haskell
f x = x
 + 1
  where
 y = 2
```

which GHC correctly rejects.

## Deliverables
- [x] Implement layout validation in LayoutProcessor to detect operators that cannot start declarations
- [x] Emit layout error when operator appears after virtual delimiter (v_semi/v_close_brace)
- [x] Add `setDiagnostics()` method to LayoutProcessor to enable error reporting
- [x] Connect layout processor to diagnostics in main.zig, parser test helpers, and parser test runner
- [x] Update sf005_bad_layout.properties to test now passes (remove xfail)

## Testing
- All 474 tests pass
- sf005_bad_layout.hs is now correctly rejected with "operator cannot start a declaration" error
- Valid code with operators in patterns and declarations continues to parse correctly

## Implementation Notes
The layout processor doesn't have full knowledge of expression completeness, so we use a heuristic: when a virtual delimiter (v_semi or v_close_brace) is emitted, the next token must start a fresh declaration. Operators cannot start declarations, so we emit an error when an operator appears in this position and we're not in a freshly-opened context.

This correctly rejects malformed operator continuations while allowing valid uses:
-Operators in patterns (`x |> f = f x`)
- Parenthesized operator declarations (`(+++) :: ...`)
- Infix operators in expressions
