### PR TITLE
Add VTT parser as test case (closes #250)

### DIFF
--- a/tests/parser_test_runner.zig
+++ b/tests/parser_test_runner.zig
@@ -225,6 +225,7 @@ test "should_compile: sc040_type_annotations_exprs" { try testShouldCompile(std.
 test "should_compile: sc041_ghc_real_world_001" { try testShouldCompile(std.testing.allocator, "sc041_ghc_real_world_001"); }
 test "should_compile: sc042_ghc_real_world_002" { try testShouldCompile(std.testing.allocator, "sc042_ghc_real_world_002"); }
 test "should_compile: sc043_infix_constructors_in_types" { try testShouldCompile(std.testing.allocator, "sc043_infix_constructors_in_types"); }
+test "should_compile: sc044_vtt_parser" { try testShouldCompile(std.testing.allocator, "sc044_vtt_parser"); }
 
 // ── should_fail test declarations ─────────────────────────────────────────
 

--- a/tests/should_compile/sc044_vtt_parser.hs
+++ b/tests/should_compile/sc044_vtt_parser.hs
@@ -1,0 +1,79 @@
+-- VTT parser - real-world Haskell program
+-- This parses WebVTT subtitle files
+-- Original source: https://github.com/adinapoli/rusholme/issues/250
+
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+
+import Data.Attoparsec.Text hiding (take)
+import Data.Attoparsec.Combinator
+import qualified Data.Text as T
+import Data.Char
+import Text.Printf (printf)
+import System.Environment (getArgs)
+import Control.Applicative
+import Control.Monad
+import Data.Time
+import Text.RawString.QQ
+import qualified Data.HashMap.Strict as HM
+import qualified Data.List as L
+
+data Subtitle = Subtitle
+  { captionIdx :: Int
+  , startTime :: String
+  , endTime :: String
+  , text :: T.Text
+  } deriving (Show)
+
+parseVTT :: T.Text -> Either String [Subtitle]
+parseVTT vtt = parseOnly vttParser vtt
+
+vttParser :: Parser [Subtitle]
+vttParser = do
+  _ <- string "WEBVTT" >> endOfLine -- ignore header
+  subtitles <- many subtitleParser
+  pure subtitles
+
+subtitleParser :: Parser Subtitle
+subtitleParser = do
+  skipWhile (not . isDigit)
+  captionIndex <- decimal @Int <* endOfLine
+  _ <- decimal @Int <* char ":" -- hours
+  m <- decimal @Int <* char ":" -- minutes
+  s <- double <* string " --> " -- seconds and arrow separator
+  _ <- decimal @Int <* char ":" -- hours (again)
+  m' <- decimal @Int <* char ":" -- minutes (again)
+  s' <- double <* optional endOfLine -- seconds (again) and optional end of line
+  let startTime = formatTime m s
+      endTime = formatTime m' s'
+      formatTime m s = printf "%02d:%06.3f" m s :: String
+  text <- manyTill anyChar (try endOfLine <|> endOfInput)
+  return $ Subtitle captionIndex startTime endTime (T.pack text)
+
+-- Example usage:
+main :: IO ()
+main = do
+  vttFile <- head <$> getArgs
+  vtt <- readFile vttFile
+  case parseVTT (T.pack vtt) of
+    Left err -> putStrLn err
+    Right subtitles -> print subtitles
+  case parseOnly (many subtitleParser) mySub of
+    Left err -> putStrLn err
+    Right subtitles -> print subtitles
+
+mySub :: T.Text
+mySub = [r|
+
+288
+00:15:44.039 --> 00:15:49.210
+it would make sense to try and get all of our denominators as seven. Right?
+
+289
+00:15:49.599 --> 00:15:51.900
+What have I got to do to 14 to get it back to seven?
+
+46
+00:02:14.750 --> 00:02:17.399
+You could have quite simply put zero|]


### PR DESCRIPTION
Closes #250

## Summary
Add the VTT parser (from issue #250) as a test case sc044_vtt_parser.hs to verify that the program now parses correctly.

## Deliverables
- [x] Add sc044_vtt_parser.hs to tests/should_compile/
- [x] Add test declaration to parser_test_runner.zig
- [x] Verify all 475 tests pass

## Notes
The VTT parser was previously failing to parse due to missing support for:
- LANGUAGE pragmas (implemented in PR #260)
- Quasi-quotation syntax (implemented in PR #259)
- TypeApplications extension (already implemented)

All those features are now implemented and the VTT parser parses successfully.
