### PR TITLE
Fix #298: Emit DataDecls in Core IR

### DIFF
--- a/src/core/ast.zig
+++ b/src/core/ast.zig
@@ -150,8 +150,20 @@ pub const Expr = union(enum) {
     Coercion: Coercion,
 };
 
-/// A Core program is a list of top-level bindings.
-pub const CoreProgram = []const Bind;
+/// A Core-level data declaration.
+pub const CoreDataDecl = struct {
+    name: Name,
+    tyvars: []const Name,
+    /// Data constructors, represented as typed Ids.
+    constructors: []const Id,
+    span: SourceSpan,
+};
+
+/// A Core program consists of data declarations and top-level bindings.
+pub const CoreProgram = struct {
+    data_decls: []const CoreDataDecl,
+    binds: []const Bind,
+};
 
 // ── Tests ──────────────────────────────────────────────────────────────
 

--- a/src/core/pretty.zig
+++ b/src/core/pretty.zig
@@ -200,8 +200,36 @@ pub fn CorePrinter(comptime WriterType: type) type {
             }
         }
 
+        pub fn printDataDecl(self: *Self, dd: ast.CoreDataDecl) anyerror!void {
+            try self.write("data ");
+            try self.printName(dd.name);
+            for (dd.tyvars) |tv| {
+                try self.writeByte(' ');
+                try self.printName(tv);
+            }
+            if (dd.constructors.len > 0) {
+                try self.write(" = ");
+                for (dd.constructors, 0..) |con, i| {
+                    if (i > 0) try self.write(" | ");
+                    try self.printId(con, true);
+                }
+            }
+        }
+
         pub fn printProgram(self: *Self, program: ast.CoreProgram) anyerror!void {
-            for (program, 0..) |bind, i| {
+            for (program.data_decls, 0..) |dd, i| {
+                if (i > 0) {
+                    try self.newline();
+                }
+                try self.printDataDecl(dd);
+                try self.newline();
+            }
+
+            if (program.data_decls.len > 0 and program.binds.len > 0) {
+                try self.newline();
+            }
+
+            for (program.binds, 0..) |bind, i| {
                 if (i > 0) {
                     try self.newline();
                     try self.newline();

--- a/src/main.zig
+++ b/src/main.zig
@@ -330,7 +330,7 @@ fn cmdCore(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     var stdout = &stdout_fw.interface;
 
     var pp = rusholme.core.pretty.CorePrinter(*Io.Writer).init(stdout);
-    try stdout.print("=== Core Program ({} bindings) ===\n", .{core_prog.len});
+    try stdout.print("=== Core Program ({} data, {} bindings) ===\n", .{ core_prog.data_decls.len, core_prog.binds.len });
     try pp.printProgram(core_prog);
     try stdout.print("\n", .{});
 


### PR DESCRIPTION
This PR fixes #298 by plumbing DataDecls through the Renamer and Desugarer, so they are explicitly represented in the Core IR as `CoreDataDecl`s. This allows `rhc core` to print algebraic data types correctly instead of outputting 0 bindings.

Changes:
- Added `RDataDecl` and `RConDecl` to `RenamedModule`.
- Updated `infer.zig` to generate `TyScheme`s for data constructors and assign them fresh rigid type variables.
- Changed `CoreProgram` to a struct containing both `binds` and `data_decls`.
- Updated `rhc core` formatting to reflect data types.