### PR TITLE
#359: Desugar list literals and parenthesised expressions to Core

### DIFF
--- a/src/core/desugar.zig
+++ b/src/core/desugar.zig
@@ -4,6 +4,7 @@ const renamer_mod = @import("../renamer/renamer.zig");
 const infer_mod = @import("../typechecker/infer.zig");
 const htype_mod = @import("../typechecker/htype.zig");
 const env_mod = @import("../typechecker/env.zig");
+const Known = @import("../naming/known.zig");
 const Name = ast_mod.Name;
 const SourceSpan = ast_mod.SourceSpan;
 const SourcePos = ast_mod.SourcePos;
@@ -337,8 +338,74 @@ pub fn desugarExpr(ctx: *DesugarCtx, expr: renamer_mod.RExpr) std.mem.Allocator.
                 .span = syntheticSpan(),
             } };
         },
-        // Fallbacks for unhandled AST nodes
-        else => std.debug.panic("desugarExpr: unhandled RExpr variant {}", .{std.meta.activeTag(expr)}),
+        .List => |elems| {
+            // [e1, e2, ..., en] desugars to (:) e1 ((:) e2 (... ((:) en []) ...))
+            const cons_ty = blk: {
+                const scheme = ctx.types.schemes.get(Known.Con.Cons.unique) orelse
+                    std.debug.panic("Missing type scheme for (:) constructor", .{});
+                break :blk try schemeToCore(alloc, scheme);
+            };
+            const nil_ty = blk: {
+                const scheme = ctx.types.schemes.get(Known.Con.Nil.unique) orelse
+                    std.debug.panic("Missing type scheme for [] constructor", .{});
+                break :blk try schemeToCore(alloc, scheme);
+            };
+
+            // Start with Nil: []
+            var result = try alloc.create(ast_mod.Expr);
+            result.* = .{ .Var = .{ .name = Known.Con.Nil, .ty = nil_ty, .span = syntheticSpan() } };
+
+            // Right-fold: iterate elements from right to left
+            var i = elems.len;
+            while (i > 0) {
+                i -= 1;
+                const elem = try desugarExpr(ctx, elems[i]);
+
+                // Build: (:) elem result
+                // First apply Cons to the element: ((:) elem)
+                const cons_var = try alloc.create(ast_mod.Expr);
+                cons_var.* = .{ .Var = .{ .name = Known.Con.Cons, .ty = cons_ty, .span = syntheticSpan() } };
+
+                const app1 = try alloc.create(ast_mod.Expr);
+                app1.* = .{ .App = .{ .fn_expr = cons_var, .arg = elem, .span = syntheticSpan() } };
+
+                // Then apply to the tail: ((:) elem) result
+                const app2 = try alloc.create(ast_mod.Expr);
+                app2.* = .{ .App = .{ .fn_expr = app1, .arg = result, .span = syntheticSpan() } };
+
+                result = app2;
+            }
+
+            node.* = result.*;
+        },
+        .Paren => |inner| {
+            // Parenthesised expression — just unwrap.
+            const inner_result = try desugarExpr(ctx, inner.*);
+            node.* = inner_result.*;
+        },
+
+        // ── Not yet implemented ─────────────────────────────────────────
+        //
+        // Each unsupported case has a tracking issue. See #309 for ListComp;
+        // the remaining variants are tracked in:
+        // https://github.com/adinapoli/rusholme/issues/361
+        .InfixApp,
+        .LeftSection,
+        .RightSection,
+        .Case,
+        .Do,
+        .Tuple,
+        .EnumFrom,
+        .EnumFromThen,
+        .EnumFromTo,
+        .EnumFromThenTo,
+        .TypeAnn,
+        .TypeApp,
+        .Negate,
+        .RecordCon,
+        .RecordUpdate,
+        .Field,
+        => std.debug.panic("desugarExpr: unhandled RExpr variant {}", .{std.meta.activeTag(expr)}),
     }
 
     return node;
@@ -405,4 +472,145 @@ test "desugarExpr: Var and Lit" {
     try testing.expectEqualStrings("x", c_var.Var.name.base);
     try testing.expect(c_var.Var.ty == .TyCon);
     try testing.expectEqualStrings("Int", c_var.Var.ty.TyCon.name.base);
+}
+
+test "desugarExpr: List desugars to Cons/Nil chain" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var types = infer_mod.ModuleTypes{
+        .schemes = .{},
+        .local_binders = .{},
+    };
+    defer types.deinit(alloc);
+
+    var diags = DiagnosticCollector.init();
+    defer diags.deinit(alloc);
+
+    // Build (:) scheme: forall a. a -> [a] -> [a]
+    {
+        const a_id: u64 = 10000;
+        const a_name = Name{ .base = "a", .unique = .{ .value = a_id } };
+        const a_rigid = htype_mod.HType{ .Rigid = a_name };
+        const list_a_args = try alloc.dupe(htype_mod.HType, &.{a_rigid});
+        const list_a = htype_mod.HType{ .Con = .{ .name = Known.Type.List, .args = list_a_args } };
+
+        const a_ptr = try alloc.create(htype_mod.HType);
+        a_ptr.* = a_rigid;
+        const list_a_ptr = try alloc.create(htype_mod.HType);
+        list_a_ptr.* = list_a;
+        const list_a_ptr2 = try alloc.create(htype_mod.HType);
+        list_a_ptr2.* = list_a;
+
+        // [a] -> [a]
+        const inner_fun_ptr = try alloc.create(htype_mod.HType);
+        inner_fun_ptr.* = .{ .Fun = .{ .arg = list_a_ptr, .res = list_a_ptr2 } };
+        // a -> [a] -> [a]
+        const cons_body = htype_mod.HType{ .Fun = .{ .arg = a_ptr, .res = inner_fun_ptr } };
+
+        const binders = try alloc.dupe(u64, &.{a_id});
+        try types.schemes.put(alloc, Known.Con.Cons.unique, .{ .binders = binders, .constraints = &.{}, .body = cons_body });
+    }
+
+    // Build [] scheme: forall a. [a]
+    {
+        const a_id: u64 = 10001;
+        const a_name = Name{ .base = "a", .unique = .{ .value = a_id } };
+        const a_rigid = htype_mod.HType{ .Rigid = a_name };
+        const list_a_args = try alloc.dupe(htype_mod.HType, &.{a_rigid});
+        const nil_body = htype_mod.HType{ .Con = .{ .name = Known.Type.List, .args = list_a_args } };
+
+        const binders = try alloc.dupe(u64, &.{a_id});
+        try types.schemes.put(alloc, Known.Con.Nil.unique, .{ .binders = binders, .constraints = &.{}, .body = nil_body });
+    }
+
+    var ctx = DesugarCtx{
+        .alloc = alloc,
+        .types = &types,
+        .diags = &diags,
+    };
+
+    // Test empty list: [] desugars to Var(Nil)
+    {
+        const empty_list = renamer_mod.RExpr{ .List = &.{} };
+        const result = try desugarExpr(&ctx, empty_list);
+        try testing.expect(result.* == .Var);
+        try testing.expectEqualStrings("[]", result.Var.name.base);
+        try testing.expectEqual(@as(u64, 207), result.Var.name.unique.value);
+    }
+
+    // Test [1, 2]: desugars to (:) 1 ((:) 2 [])
+    {
+        const elems = try alloc.dupe(renamer_mod.RExpr, &.{
+            .{ .Lit = .{ .Int = .{ .value = 1, .span = syntheticSpan() } } },
+            .{ .Lit = .{ .Int = .{ .value = 2, .span = syntheticSpan() } } },
+        });
+        const list_expr = renamer_mod.RExpr{ .List = elems };
+        const result = try desugarExpr(&ctx, list_expr);
+
+        // Outermost: App(App(Cons, 1), ...)
+        try testing.expect(result.* == .App);
+        const outer_app = result.App;
+
+        // outer_app.fn_expr = App(Cons, 1)
+        try testing.expect(outer_app.fn_expr.* == .App);
+        const cons_app1 = outer_app.fn_expr.App;
+        try testing.expect(cons_app1.fn_expr.* == .Var);
+        try testing.expectEqualStrings("(:)", cons_app1.fn_expr.Var.name.base);
+        try testing.expect(cons_app1.arg.* == .Lit);
+        try testing.expectEqual(@as(i64, 1), cons_app1.arg.Lit.val.Int);
+
+        // outer_app.arg = App(App(Cons, 2), Nil)
+        try testing.expect(outer_app.arg.* == .App);
+        const inner_app = outer_app.arg.App;
+
+        // inner_app.fn_expr = App(Cons, 2)
+        try testing.expect(inner_app.fn_expr.* == .App);
+        const cons_app2 = inner_app.fn_expr.App;
+        try testing.expect(cons_app2.fn_expr.* == .Var);
+        try testing.expectEqualStrings("(:)", cons_app2.fn_expr.Var.name.base);
+        try testing.expect(cons_app2.arg.* == .Lit);
+        try testing.expectEqual(@as(i64, 2), cons_app2.arg.Lit.val.Int);
+
+        // inner_app.arg = Nil
+        try testing.expect(inner_app.arg.* == .Var);
+        try testing.expectEqualStrings("[]", inner_app.arg.Var.name.base);
+    }
+}
+
+test "desugarExpr: Paren unwraps inner expression" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var types = infer_mod.ModuleTypes{
+        .schemes = .{},
+        .local_binders = .{},
+    };
+    defer types.deinit(alloc);
+
+    var diags = DiagnosticCollector.init();
+    defer diags.deinit(alloc);
+
+    // Add a local binder for x
+    const int_h_ty = try alloc.create(htype_mod.HType);
+    int_h_ty.* = .{ .Con = .{ .name = testName("Int", 0), .args = &.{} } };
+    const x_name = testName("x", 42);
+    try types.local_binders.put(alloc, x_name.unique, int_h_ty);
+
+    var ctx = DesugarCtx{
+        .alloc = alloc,
+        .types = &types,
+        .diags = &diags,
+    };
+
+    const inner = try alloc.create(renamer_mod.RExpr);
+    inner.* = .{ .Var = .{ .name = x_name, .span = syntheticSpan() } };
+
+    const paren_expr = renamer_mod.RExpr{ .Paren = inner };
+    const result = try desugarExpr(&ctx, paren_expr);
+
+    try testing.expect(result.* == .Var);
+    try testing.expectEqualStrings("x", result.Var.name.base);
 }

--- a/src/typechecker/infer.zig
+++ b/src/typechecker/infer.zig
@@ -1852,11 +1852,13 @@ pub fn inferModule(ctx: *InferCtx, module: RenamedModule) std.mem.Allocator.Erro
     // Add built-in constructor schemes so the desugarer can find them.
     // These are mono-bound in TyEnv via initBuiltins() but the desugarer
     // only looks in ModuleTypes.schemes.
-    // Unique IDs from src/naming/known.zig: True=200, False=201, Unit=206
+    // Unique IDs from src/naming/known.zig
     const built_in_uniques = [_]naming_mod.Unique{
         .{ .value = 200 }, // True
         .{ .value = 201 }, // False
         .{ .value = 206 }, // Unit
+        .{ .value = 207 }, // Nil  ([] data constructor)
+        .{ .value = 208 }, // Cons ((:) data constructor)
     };
     for (built_in_uniques) |unique| {
         if (ctx.env.lookupScheme(unique)) |scheme| {


### PR DESCRIPTION
Closes #359

## Summary

The desugarer panicked on `.List` expressions (e.g. `['\a', '\b', '\f', ...]`) because
this `RExpr` variant had no handler. This PR adds desugaring for list literals and
parenthesised expressions.

## Changes

### `src/typechecker/infer.zig`
- Export `Nil` (unique 207) and `Cons` (unique 208) constructor type schemes from
  `inferModule` so the desugarer can look them up.

### `src/core/desugar.zig`
- Import `Known` names module.
- **`.List` handler**: Right-folds elements into a `(:) e1 ((:) e2 (... ((:) en []) ...))`
  chain using Core `App` and `Var` nodes with `Known.Con.Cons` / `Known.Con.Nil`.
- **`.Paren` handler**: Unwraps the inner expression (trivial).
- **Replaced `else =>` catch-all** with explicit arms for each unimplemented `RExpr` variant,
  per CLAUDE.md section 9. All unimplemented variants reference tracking issue #361.
- Added unit tests for empty list, two-element list, and parenthesised expression desugaring.

## Follow-up

- #361: Implement remaining `RExpr` variants in the desugarer (Case, Do, InfixApp, Tuple, etc.)

## Deliverables
- [x] `rhc core tests/should_compile/sc017_string_char_literals.hs` no longer panics
- [x] List literals desugar to Cons/Nil chain
- [x] Parenthesised expressions unwrap correctly
- [x] Explicit unhandled cases with tracking issue
- [x] Unit tests (638 total, +2 new)
- [x] All existing tests pass

## Testing

```bash
# The original bug — now works:
zig build run -- core tests/should_compile/sc017_string_char_literals.hs

# All tests pass:
zig build test --summary all   # 638/638 pass
```
