### PR TITLE
roadmap: Sync status + add Module System epic (#365-#371)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -334,6 +334,17 @@
 
 > **Goal:** ADTs, pattern matching, type classes, modules, minimal Prelude.
 
+### Epic [#365](https://github.com/adinapoli/rusholme/issues/365): Module System & Multi-Module Compilation
+
+| # | Issue | Deps | Status |
+|---|-------|------|--------|
+| [#366](https://github.com/adinapoli/rusholme/issues/366) | Define module interface representation (ModIface) with `.rhi` serialisation | [#38](https://github.com/adinapoli/rusholme/issues/38) | :white_circle: |
+| [#367](https://github.com/adinapoli/rusholme/issues/367) | Implement module graph and topological compilation order | [#29](https://github.com/adinapoli/rusholme/issues/29) | :white_circle: |
+| [#368](https://github.com/adinapoli/rusholme/issues/368) | Implement compilation session (CompileEnv) | [#366](https://github.com/adinapoli/rusholme/issues/366), [#367](https://github.com/adinapoli/rusholme/issues/367) | :white_circle: |
+| [#369](https://github.com/adinapoli/rusholme/issues/369) | Implement implicit Prelude import | [#368](https://github.com/adinapoli/rusholme/issues/368) | :white_circle: |
+| [#371](https://github.com/adinapoli/rusholme/issues/371) | Implement recompilation avoidance via `.rhi` fingerprinting | [#366](https://github.com/adinapoli/rusholme/issues/366), [#368](https://github.com/adinapoli/rusholme/issues/368) | :white_circle: |
+| [#370](https://github.com/adinapoli/rusholme/issues/370) | Bootstrap Prelude from Haskell source | [#368](https://github.com/adinapoli/rusholme/issues/368), [#58](https://github.com/adinapoli/rusholme/issues/58), [#59](https://github.com/adinapoli/rusholme/issues/59) | :white_circle: |
+
 ### Epic [#10](https://github.com/adinapoli/rusholme/issues/10): Minimal Prelude
 
 | # | Issue | Deps | Status |


### PR DESCRIPTION
## Summary

Update ROADMAP.md with the latest GitHub state and add the new Module System epic under M2.

## Changes

### Status sync
- #347: `:white_circle:` → `:green_circle:` (merged via PR #363)
- #349: Added as `:green_circle:` (merged via PR #352)
- #350: Added as `:green_circle:` (merged via PR #352)
- #351: Added as `:green_circle:` (merged via PR #352)
- #359: `:yellow_circle:` → `:green_circle:` (merged via PR #362)
- #361: `:white_circle:` → `:green_circle:` (merged via PR #364)

### New: Module System epic (M2)
Added Epic [#365](https://github.com/adinapoli/rusholme/issues/365) with 6 child issues:
- #366 — ModIface + `.rhi` serialisation
- #367 — Module graph + topological compilation order
- #368 — Compilation session (CompileEnv)
- #369 — Implicit Prelude import
- #370 — Prelude bootstrap from Haskell source
- #371 — Recompilation avoidance via `.rhi` fingerprinting
