### PR TITLE
feat: Tier 1 Pattern Match Desugaring (#376)

### DIFF
--- a/tests/golden/ghc_016_tier1_patterns.core.golden
+++ b/tests/golden/ghc_016_tier1_patterns.core.golden
@@ -1,0 +1,15 @@
+=== Core Program (1 data, 2 bindings) ===
+data Color_1005 = (Red_1000 :: Color_1005) | (Green_1001 :: Color_1005) | (Blue_1002 :: Color_1005)
+
+(isRed_1003 :: Color_1005 -> Bool_104) = \(arg_0 :: Color_1005) -> case arg_0 of (arg_0 :: Color_1005) {
+  Red_1000 -> True_200
+  _ -> False_201
+}
+
+(describeNumber_1004 :: Int_100 -> []_110 Char_105) = \(arg_0 :: Int_100) -> case arg_0 of (arg_0 :: Int_100) {
+  0 -> "zero"
+  _ -> case arg_0 of (arg_0 :: Int_100) {
+    1 -> "one"
+    _ -> "many"
+  }
+}

--- a/tests/golden/ghc_016_tier1_patterns.hs
+++ b/tests/golden/ghc_016_tier1_patterns.hs
@@ -1,0 +1,12 @@
+module Tier1Patterns where
+
+data Color = Red | Green | Blue
+
+isRed :: Color -> Bool
+isRed Red = True
+isRed _   = False
+
+describeNumber :: Int -> String
+describeNumber 0 = "zero"
+describeNumber 1 = "one"
+describeNumber _ = "many"


### PR DESCRIPTION
Resolves #376.

## 🚀 Tier 1 Pattern Match Desugaring

This PR implements the initial (Tier 1) phase of pattern matching desugaring into Core IR. Previously, `desugarModule` relied on a naive placeholder that panicked the compiler when encountering non-`Var` patterns or multiple equations in function bindings.

### ✨ Features
- **[NEW] Match Compiler**: Added the `desugarMatch` function inside `src/core/desugar.zig`.
  - It incrementally synthesizes nested `Case` and `Lam` nodes to cover all arguments of a multi-equation function.
  - Successfully translates simple disjoint patterns (`Lit`, `Wild`, `Con`, and `Var`) for function parameters.
  - Emits a stubbed explicit fallback (`"Non-exhaustive patterns in function"`) rather than crashing compilation when patterns fail.

### 🧪 Verification
- A new golden end-to-end test `ghc_016_tier1_patterns.hs` was added, which visually validates the precise nested `.Case` logic translation.
- A direct AST-based Core validation unit test was embedded into `src/core/desugar.zig`.
- Validated that `651/651` tests pass flawlessly across backend translations.

### 🛑 Out of Scope
This PR does **not** include nested pattern matching, guards, or exhaustiveness checking decision trees. Those are tracked in follow-up issues (#377 and #378).
