### PR TITLE
sync: Reconcile ROADMAP with GitHub state (#55, #321 done) + file follow-up issues #390–#392

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -334,6 +334,9 @@
 | [#384](https://github.com/adinapoli/rusholme/issues/384) | Implement actual thunk evaluation in runtime | [#56](https://github.com/adinapoli/rusholme/issues/56) | :white_circle: |
 | [#385](https://github.com/adinapoli/rusholme/issues/385) | Implement proper heap node field storage for GRIN values | [#56](https://github.com/adinapoli/rusholme/issues/56) | :white_circle: |
 | [#386](https://github.com/adinapoli/rusholme/issues/386) | Implement runtime closure support | [#56](https://github.com/adinapoli/rusholme/issues/56) | :white_circle: |
+| [#390](https://github.com/adinapoli/rusholme/issues/390) | LLVM codegen: translate remaining GRIN expression types (Bind, Case, Store, Fetch, Update, Return) | [#55](https://github.com/adinapoli/rusholme/issues/55) | :white_circle: |
+| [#391](https://github.com/adinapoli/rusholme/issues/391) | LLVM codegen: expand PrimOpMapping and support multi-arg calls | [#55](https://github.com/adinapoli/rusholme/issues/55) | :white_circle: |
+| [#392](https://github.com/adinapoli/rusholme/issues/392) | LLVM codegen: translate function parameters in GRIN defs | [#55](https://github.com/adinapoli/rusholme/issues/55) | :white_circle: |
 
 ---
 


### PR DESCRIPTION
## Summary

Syncs ROADMAP.md with actual GitHub issue state after merging PR #389.

### ROADMAP fixes
- **#55** (LLVM codegen for GRIN) → ✅ Done
- **#321** (end-to-end Hello World integration test) → ✅ Done
- Added 2026-02-25 Recent Progress entry

### Follow-up issues filed
Three shortcomings from the M1 LLVM translator, now tracked and added to Epic #9:

| Issue | Title |
|-------|-------|
| [#390](https://github.com/adinapoli/rusholme/issues/390) | Translate remaining GRIN expression types (Bind, Case, Store, Fetch, Update, Return) |
| [#391](https://github.com/adinapoli/rusholme/issues/391) | Expand PrimOpMapping and support multi-arg calls |
| [#392](https://github.com/adinapoli/rusholme/issues/392) | Translate function parameters in GRIN defs |
