### PR TITLE
#63: Add Core output golden test infrastructure

### DIFF
--- a/tests/golden_test_runner.zig
+++ b/tests/golden_test_runner.zig
@@ -1,11 +1,26 @@
 //! Golden test runner for GHC test programs.
 //!
-//! Each golden test file has its own test declaration so that Zig's test runner
-//! reports per-file pass/fail/skip in the build summary. Tests with a
-//! `.properties` sidecar containing `skip:` are silently skipped.
+//! Two kinds of golden tests are supported:
 //!
-//! When adding a new golden test file, add a corresponding test declaration
-//! at the bottom of this file.
+//! 1. **Parse tests** (`testParseGolden`): parse the `.hs` file and verify
+//!    that it succeeds without errors.
+//!
+//! 2. **Core output tests** (`testCoreGolden`): run the full pipeline
+//!    (parse → rename → typecheck → desugar) and compare the Core IR output
+//!    against a `.core.golden` sidecar file.
+//!
+//! ## Updating golden files
+//!
+//! Set the environment variable `RUSHOLME_GOLDEN_UPDATE=1` before running
+//! tests to regenerate all `.core.golden` files in place.
+//!
+//! ## Adding a new golden test
+//!
+//! 1. Create `tests/golden/<name>.hs`.
+//! 2. Optionally create `tests/golden/<name>.core.golden` with expected Core
+//!    output; if the file is absent and `RUSHOLME_GOLDEN_UPDATE=1` is set,
+//!    it will be written automatically on first run.
+//! 3. Add a test declaration at the bottom of this file.
 
 const std = @import("std");
 const Dir = std.Io.Dir;
@@ -15,8 +30,14 @@ const Parser = rusholme.frontend.parser.Parser;
 const Lexer = rusholme.frontend.lexer.Lexer;
 const LayoutProcessor = rusholme.frontend.layout.LayoutProcessor;
 const DiagnosticCollector = rusholme.diagnostics.diagnostic.DiagnosticCollector;
+const renamer_mod = rusholme.renamer.renamer;
+const htype_mod = rusholme.tc.htype;
+const infer_mod = rusholme.tc.infer;
+const FileId = rusholme.FileId;
 
 const golden_test_dir = "tests/golden";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
 /// Check whether a .properties file marks the test as skipped.
 fn isSkipped(allocator: std.mem.Allocator, comptime basename: []const u8) !bool {
@@ -42,6 +63,14 @@ fn isSkipped(allocator: std.mem.Allocator, comptime basename: []const u8) !bool 
     }
     return false;
 }
+
+/// Return true when `RUSHOLME_GOLDEN_UPDATE=1` is set in the environment.
+fn goldenUpdateMode() bool {
+    const val: [*:0]const u8 = std.c.getenv("RUSHOLME_GOLDEN_UPDATE") orelse return false;
+    return std.mem.eql(u8, std.mem.span(val), "1");
+}
+
+// ── Parse-only test ───────────────────────────────────────────────────────────
 
 /// Read a Haskell source file and verify it parses successfully.
 fn testParseGolden(allocator: std.mem.Allocator, comptime basename: []const u8) !void {
@@ -81,9 +110,142 @@ fn testParseGolden(allocator: std.mem.Allocator, comptime basename: []const u8) 
     };
 }
 
+// ── Core output test ──────────────────────────────────────────────────────────
+
+/// Run the full pipeline (parse → rename → typecheck → desugar) on `source`
+/// and return the Core IR pretty-printed as an owned string.
+///
+/// The returned string must be freed with `allocator.free`.
+fn pipelineToCore(allocator: std.mem.Allocator, source: []const u8) ![]const u8 {
+    const file_id: FileId = 1;
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    // ── Parse ────────────────────────────────────────────────────────────
+    var lexer = Lexer.init(arena_alloc, source, file_id);
+    var layout = LayoutProcessor.init(arena_alloc, &lexer);
+    var diags = DiagnosticCollector.init();
+    defer diags.deinit(arena_alloc);
+    layout.setDiagnostics(&diags);
+
+    var parser = try Parser.init(arena_alloc, &layout, &diags);
+    const module = try parser.parseModule();
+    if (diags.hasErrors()) return error.ParseError;
+
+    // ── Rename ───────────────────────────────────────────────────────────
+    var u_supply = rusholme.naming.unique.UniqueSupply{};
+    var rename_env = try renamer_mod.RenameEnv.init(arena_alloc, &u_supply, &diags);
+    defer rename_env.deinit();
+    const renamed = try renamer_mod.rename(module, &rename_env);
+    if (diags.hasErrors()) return error.RenameError;
+
+    // ── Typecheck ────────────────────────────────────────────────────────
+    var mv_supply = htype_mod.MetaVarSupply{};
+    var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
+    try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply);
+    var infer_ctx = infer_mod.InferCtx.init(arena_alloc, &ty_env, &mv_supply, &u_supply, &diags);
+    var module_types = try infer_mod.inferModule(&infer_ctx, renamed);
+    defer module_types.deinit(arena_alloc);
+    if (diags.hasErrors()) return error.TypecheckError;
+
+    // ── Desugar ──────────────────────────────────────────────────────────
+    const core_prog = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags);
+    if (diags.hasErrors()) return error.DesugarError;
+
+    // ── Pretty-print Core to a heap string ───────────────────────────────
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+
+    try out.writer.print("=== Core Program ({} data, {} bindings) ===\n", .{
+        core_prog.data_decls.len,
+        core_prog.binds.len,
+    });
+    var pp = rusholme.core.pretty.CorePrinter(*std.Io.Writer).init(&out.writer);
+    try pp.printProgram(core_prog);
+    try out.writer.writeByte('\n');
+
+    return try out.toOwnedSlice();
+}
+
+/// Run the full pipeline on a Haskell source file and compare the Core IR
+/// output against the corresponding `.core.golden` sidecar file.
+///
+/// When `RUSHOLME_GOLDEN_UPDATE=1` is set, the sidecar file is written/
+/// overwritten with the actual output instead of compared.
+fn testCoreGolden(allocator: std.mem.Allocator, comptime basename: []const u8) !void {
+    const io = std.testing.io;
+
+    if (try isSkipped(allocator, basename)) return;
+
+    const haskell_path = golden_test_dir ++ "/" ++ basename ++ ".hs";
+    const golden_path = golden_test_dir ++ "/" ++ basename ++ ".core.golden";
+
+    // Read the Haskell source.
+    const hs_file = try Dir.openFile(.cwd(), io, haskell_path, .{});
+    defer hs_file.close(io);
+
+    var read_buf: [8192]u8 = undefined;
+    var rdr = hs_file.reader(io, &read_buf);
+    const source = try rdr.interface.allocRemaining(allocator, .limited(1024 * 1024));
+    defer allocator.free(source);
+
+    // Run the pipeline.
+    const actual = pipelineToCore(allocator, source) catch |err| {
+        std.debug.print("Pipeline failed for {s}: {}\n", .{ basename, err });
+        return err;
+    };
+    defer allocator.free(actual);
+
+    if (goldenUpdateMode()) {
+        // Write / overwrite the golden file.
+        const gf = try Dir.createFile(.cwd(), io, golden_path, .{});
+        defer gf.close(io);
+        var wbuf: [4096]u8 = undefined;
+        var fw: std.Io.File.Writer = .init(gf, io, &wbuf);
+        try fw.interface.writeAll(actual);
+        try fw.interface.flush();
+        return;
+    }
+
+    // Read the expected golden file.
+    const golden_file = Dir.openFile(.cwd(), io, golden_path, .{}) catch |err| {
+        if (err == error.FileNotFound) {
+            std.debug.print(
+                "Golden file missing: {s}\n" ++
+                    "  Run with RUSHOLME_GOLDEN_UPDATE=1 to create it.\n",
+                .{golden_path},
+            );
+        }
+        return err;
+    };
+    defer golden_file.close(io);
+
+    var gbuf: [8192]u8 = undefined;
+    var grdr = golden_file.reader(io, &gbuf);
+    const expected = try grdr.interface.allocRemaining(allocator, .limited(1024 * 1024));
+    defer allocator.free(expected);
+
+    // Trim trailing whitespace/newlines from both sides to avoid spurious
+    // failures caused by editor-added trailing newlines.
+    const actual_trimmed = std.mem.trimEnd(u8, actual, " \t\r\n");
+    const expected_trimmed = std.mem.trimEnd(u8, expected, " \t\r\n");
+
+    if (!std.mem.eql(u8, actual_trimmed, expected_trimmed)) {
+        std.debug.print(
+            "Core output mismatch for {s}:\n--- expected ---\n{s}\n--- actual ---\n{s}\n",
+            .{ basename, expected_trimmed, actual_trimmed },
+        );
+        return error.GoldenMismatch;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // One test declaration per golden test file.
 // ---------------------------------------------------------------------------
+
+// ── Parse-only tests ─────────────────────────────────────────────────────────
 
 test "golden: ghc_001_qualified_import" { try testParseGolden(std.testing.allocator, "ghc_001_qualified_import"); }
 test "golden: ghc_002_fixity" { try testParseGolden(std.testing.allocator, "ghc_002_fixity"); }
@@ -100,3 +262,7 @@ test "golden: ghc_012_type_operator" { try testParseGolden(std.testing.allocator
 test "golden: ghc_013_newtype" { try testParseGolden(std.testing.allocator, "ghc_013_newtype"); }
 test "golden: ghc_014_type_synonym" { try testParseGolden(std.testing.allocator, "ghc_014_type_synonym"); }
 test "golden: ghc_015_tuples" { try testParseGolden(std.testing.allocator, "ghc_015_tuples"); }
+
+// ── Core output tests ─────────────────────────────────────────────────────────
+
+test "golden: ghc_016_tier1_patterns core" { try testCoreGolden(std.testing.allocator, "ghc_016_tier1_patterns"); }


### PR DESCRIPTION
Closes #63

## Summary

- **Root situation**: The golden test runner only parsed `.hs` files to check they compile, but did not compare output against expected files. The issue asked for snapshot-based comparison.
- **Implementation**: Added `pipelineToCore` (runs the full parse → rename → typecheck → desugar pipeline and returns Core IR as a string) and `testCoreGolden` (reads a `.core.golden` sidecar file and diffs it against the actual output).
- **Update mode**: Running with `RUSHOLME_GOLDEN_UPDATE=1` regenerates the golden files in place, making it easy to accept new baselines.
- **First golden test**: `ghc_016_tier1_patterns` exercises the Tier 1 pattern match pipeline end-to-end (Color ADT + simple pattern match) using the pre-existing `.core.golden` sidecar.

## Deliverables

- [x] Reads `.hs` files from `tests/golden/`
- [x] Runs them through the Rusholme pipeline (parse → rename → typecheck → desugar → Core)
- [x] Compares output against a `.core.golden` sidecar file
- [x] Support for updating golden files via `RUSHOLME_GOLDEN_UPDATE=1`
- [x] One Core golden test added (`ghc_016_tier1_patterns`)
- [x] All 675 tests pass

## Follow-up

Filed #415 to add parse and GRIN output golden variants in a follow-up issue.

## Testing

```
zig build test --summary all   # 675/675 pass
```

To update golden files after a pipeline change:
```
RUSHOLME_GOLDEN_UPDATE=1 zig build test -- --test-filter "golden:"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
