### PR TITLE
#425: Fix GRIN→LLVM codegen for ADTs and higher-order functions

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -379,7 +379,7 @@ fn cmdCore(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     }
 
     // ── Desugar ────────────────────────────────────────────────────────
-    const core_prog = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags);
+    const core_prog = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags, &u_supply);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
@@ -464,7 +464,7 @@ fn cmdGrin(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     }
 
     // ── Desugar ────────────────────────────────────────────────────────
-    const core_prog = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags);
+    const core_prog = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags, &u_supply);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
@@ -563,7 +563,7 @@ fn cmdLl(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     }
 
     // ── Desugar ────────────────────────────────────────────────────────
-    const core_prog = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags);
+    const core_prog = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags, &u_supply);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
@@ -675,7 +675,7 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_path: []const u8, output_
     }
 
     // ── Desugar ────────────────────────────────────────────────────────
-    const core_prog = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags);
+    const core_prog = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags, &u_supply);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);

--- a/tests/golden/ghc_016_tier1_patterns.core.golden
+++ b/tests/golden/ghc_016_tier1_patterns.core.golden
@@ -1,14 +1,14 @@
 === Core Program (1 data, 2 bindings) ===
 data Color_1005 = (Red_1000 :: Color_1005) | (Green_1001 :: Color_1005) | (Blue_1002 :: Color_1005)
 
-(isRed_1003 :: Color_1005 -> Bool_104) = \(arg_0 :: Color_1005) -> case arg_0 of (arg_0 :: Color_1005) {
+(isRed_1003 :: Color_1005 -> Bool_104) = \(arg_0_1006 :: Color_1005) -> case arg_0_1006 of (arg_0_1006 :: Color_1005) {
   Red_1000 -> True_200
   _ -> False_201
 }
 
-(describeNumber_1004 :: Int_100 -> []_110 Char_105) = \(arg_0 :: Int_100) -> case arg_0 of (arg_0 :: Int_100) {
+(describeNumber_1004 :: Int_100 -> []_110 Char_105) = \(arg_0_1007 :: Int_100) -> case arg_0_1007 of (arg_0_1007 :: Int_100) {
   0 -> "zero"
-  _ -> case arg_0 of (arg_0 :: Int_100) {
+  _ -> case arg_0_1007 of (arg_0_1007 :: Int_100) {
     1 -> "one"
     _ -> "many"
   }

--- a/tests/golden/ghc_017_tier2_patterns.core.golden
+++ b/tests/golden/ghc_017_tier2_patterns.core.golden
@@ -3,29 +3,29 @@ data Tree_1007 a = (Leaf_1000 :: forall a_1013. Tree_1007 a_1013) | (Node_1001 :
 
 data Wrapper_1008 a = (Wrap_1002 :: forall a_1014. a_1014 -> Wrapper_1008 a_1014)
 
-(unwrapNode_1003 :: (Tree_1007 Int_100) -> Int_100) = \(arg_0 :: Tree_1007 Int_100) -> case arg_0 of (arg_0 :: Tree_1007 Int_100) {
-  Node_1001 (_field_0_0_0 :: _t) (x_1009 :: Int_100) (_field_0_0_2 :: _t) -> x_1009
-  _ -> case arg_0 of (arg_0 :: Tree_1007 Int_100) {
+(unwrapNode_1003 :: (Tree_1007 Int_100) -> Int_100) = \(arg_0_1015 :: Tree_1007 Int_100) -> case arg_0_1015 of (arg_0_1015 :: Tree_1007 Int_100) {
+  Node_1001 (_field_0_0_0_1018 :: _t) (x_1009 :: Int_100) (_field_0_0_2_1016 :: _t) -> x_1009
+  _ -> case arg_0_1015 of (arg_0_1015 :: Tree_1007 Int_100) {
     Leaf_1000 -> 0
     _ -> "Non-exhaustive patterns in function"
   }
 }
 
-(leftValue_1004 :: (Tree_1007 Int_100) -> Int_100) = \(arg_0 :: Tree_1007 Int_100) -> case arg_0 of (arg_0 :: Tree_1007 Int_100) {
-  Node_1001 (_field_0_0_0 :: _t) (_field_0_0_1 :: _t) (_field_0_0_2 :: _t) -> case _field_0_0_0 of (_field_0_0_0 :: _t) {
-    Node_1001 (_field_0_1_0 :: _t) (x_1010 :: Int_100) (_field_0_1_2 :: _t) -> x_1010
+(leftValue_1004 :: (Tree_1007 Int_100) -> Int_100) = \(arg_0_1019 :: Tree_1007 Int_100) -> case arg_0_1019 of (arg_0_1019 :: Tree_1007 Int_100) {
+  Node_1001 (_field_0_0_0_1022 :: _t) (_field_0_0_1_1021 :: _t) (_field_0_0_2_1020 :: _t) -> case _field_0_0_0_1022 of (_field_0_0_0_1022 :: _t) {
+    Node_1001 (_field_0_1_0_1025 :: _t) (x_1010 :: Int_100) (_field_0_1_2_1023 :: _t) -> x_1010
     _ -> 0
   }
   _ -> 0
 }
 
-(wrapOrDefault_1005 :: (Wrapper_1008 Int_100) -> Wrapper_1008 Int_100) = \(arg_0 :: Wrapper_1008 Int_100) -> let (w_1011 :: Wrapper_1008 Int_100) = arg_0
-in case arg_0 of (arg_0 :: Wrapper_1008 Int_100) {
-  Wrap_1002 (_field_0_0_0 :: _t) -> w_1011
+(wrapOrDefault_1005 :: (Wrapper_1008 Int_100) -> Wrapper_1008 Int_100) = \(arg_0_1026 :: Wrapper_1008 Int_100) -> let (w_1011 :: Wrapper_1008 Int_100) = arg_0_1026
+in case arg_0_1026 of (arg_0_1026 :: Wrapper_1008 Int_100) {
+  Wrap_1002 (_field_0_0_0_1027 :: _t) -> w_1011
   _ -> Wrap_1002 0
 }
 
-(sumPair_1006 :: ((,)_209 Int_100 Int_100) -> Int_100) = \(arg_0 :: (,)_209 Int_100 Int_100) -> case arg_0 of (arg_0 :: (,)_209 Int_100 Int_100) {
-  (,) (a_1012 :: Int_100) (_field_0_0_1 :: _t) -> a_1012
+(sumPair_1006 :: ((,)_209 Int_100 Int_100) -> Int_100) = \(arg_0_1028 :: (,)_209 Int_100 Int_100) -> case arg_0_1028 of (arg_0_1028 :: (,)_209 Int_100 Int_100) {
+  (,) (a_1012 :: Int_100) (_field_0_0_1_1029 :: _t) -> a_1012
   _ -> "Non-exhaustive patterns in function"
 }

--- a/tests/golden_test_runner.zig
+++ b/tests/golden_test_runner.zig
@@ -151,7 +151,7 @@ fn pipelineToCore(allocator: std.mem.Allocator, source: []const u8) ![]const u8 
     if (diags.hasErrors()) return error.TypecheckError;
 
     // ── Desugar ──────────────────────────────────────────────────────────
-    const core_prog = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags);
+    const core_prog = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags, &u_supply);
     if (diags.hasErrors()) return error.DesugarError;
 
     // ── Pretty-print Core to a heap string ───────────────────────────────


### PR DESCRIPTION
Closes #425

## Summary

Five bugs in the GRIN→LLVM compilation pipeline prevented programs with user-defined ADTs and higher-order functions from compiling. This PR fixes all of them, enabling the following test program to compile and run:

```haskell
data List a = Nil | Cons a (List a)
map_it f Nil = Nil
map_it f (Cons x xs) = f x `Cons` map_it f xs
main = putStrLn $ head_it $ map_it identity (Cons "Hello from Rusholme!" Nil)
```

## Deliverables
- [x] Bug 1: `desugar.zig` — synthetic lambda binders used `unique=0`, causing GRIN parameter name collisions. Added `UniqueSupply` to `DesugarCtx`.
- [x] Bug 2: `grin/translate.zig` — `translateLet` NonRec used `freshName("p")` instead of `mapBinder`, disconnecting let-bound variables from body references.
- [x] Bug 3: `grin_to_llvm.zig` — `params` map keyed by `name.base` caused collisions for variables sharing a base name. Changed to `AutoHashMap(u64, Value)` keyed by `unique.value`.
- [x] Bug 4: `grin_to_llvm.zig` — `translateExprToValue` didn't handle `Bind` expressions, losing values from left-associative ANF chains. Added `.Bind` arm.
- [x] Bug 5: `grin_to_llvm.zig` — higher-order calls (callee in `params` as a function pointer) emitted calls to undefined functions. Fixed with indirect call via `params` lookup.
- [x] 692/692 tests pass
- [x] Golden files updated for `ghc_016`/`ghc_017` (synthetic binders now have proper unique IDs)

## Testing

```bash
nix develop --command zig build test --summary all
nix develop --command zig build run -- build /tmp/hello.hs -o /tmp/hello_out && /tmp/hello_out
# Expected: Hello from Rusholme!
```
