### PR TITLE
#371: Implement recompilation avoidance via .rhi fingerprinting

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -688,7 +688,7 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
     }
 
     // ── Compile all modules via CompileEnv ─────────────────────────────
-    var session_result = try compile_env_mod.compileProgram(arena_alloc, source_modules.items);
+    var session_result = try compile_env_mod.compileProgram(arena_alloc, io, source_modules.items);
     var session = &session_result.env;
     defer session.deinit();
 


### PR DESCRIPTION
Closes #371

## Summary

Implements recompilation avoidance in `compileProgram` via Wyhash fingerprinting of source bytes and dependency fingerprints.

## Deliverables

- [x] Fingerprint computation: `computeFingerprint(source, dep_fps)` using `std.hash.Wyhash` — includes source bytes and per-import dep fingerprints in import-declaration order
- [x] Cache check: before calling `compileSingle`, if `source_path` is set, derive the `.rhi` path and call `tryLoadCachedIface`; on hit, register the cached `ModIface` + empty `CoreProgram` and skip compilation
- [x] Cache write: on a cache miss after successful `compileSingle`, stamp `iface.fingerprint` and call `writeRhiToDisk`
- [x] `SourceModule.source_path` opt-in: `cmdBuild` leaves it `null` until per-module `.bc` backend caching lands (#436), avoiding broken output binaries from empty Core
- [x] Tests: cache hit (empty Core on second run), changed source (new fingerprint), changed dependency (downstream fingerprint changes)
- [x] All 760 tests pass

## Known limitation

On a cache hit, an empty `CoreProgram` is registered. This means the merged Core for a cached module has zero binds — correct for frontend caching, but the backend cannot produce a binary without per-module `.bc` artifacts. Full end-to-end caching requires #436 (tracked in comment on `SourceModule.source_path`).
