### PR TITLE
#463: Fix LLVM function name mismatch by reusing forward declarations

### DIFF
--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -599,7 +599,10 @@ pub const GrinTranslator = struct {
 
         const fn_type = llvm.functionType(ret_type, param_types[0..def.params.len], false);
         const fn_name_z = self.formatName(def.name);
-        const func = llvm.addFunction(self.module, fn_name_z, fn_type);
+        // Check if function was already forward-declared; if so, reuse it.
+        // This prevents LLVM from adding .1 suffix due to name collision.
+        const func = c.LLVMGetNamedFunction(self.module, fn_name_z) orelse
+            llvm.addFunction(self.module, fn_name_z, fn_type);
         self.current_func = func;
         const entry_bb = llvm.appendBasicBlock(func, "entry");
         llvm.positionBuilderAtEnd(self.builder, entry_bb);

--- a/tests/e2e/e2e_002_bool.properties
+++ b/tests/e2e/e2e_002_bool.properties
@@ -1,1 +1,4 @@
-skip: GRIN→LLVM function name mismatch causes linker errors - tracked in #463
+# Test 002: Inductive data types with multiple constructors
+# Uses standard Bool type (True/False) to test that user-defined types
+# can shadow Prelude built-in constructors without duplicate errors
+exit_code: 0

--- a/tests/e2e/e2e_005_nested_datatypes.properties
+++ b/tests/e2e/e2e_005_nested_datatypes.properties
@@ -1,1 +1,3 @@
-skip: GRIN→LLVM function name mismatch causes linker errors - tracked in #463
+# Test 005: Nested data types (Maybe and List)
+# Tests nested data constructor handling
+exit_code: 0


### PR DESCRIPTION
Closes #463

## Summary
Fixed LLVM function name mismatch where forward declarations were being recreated instead of reused, causing LLVM to add `.1` suffixes to function names (e.g., `showOuter_1005.1` instead of `showOuter_1005`).

The fix modifies `translateDef` in `grin_to_llvm.zig` to check if a function already exists via `LLVMGetNamedFunction` before calling `addFunction`. This reuses the forward declaration created during earlier translation steps.

## Deliverables
- [x] Fix LLVM function name collision by reusing forward declarations
- [x] Enable e2e_002_bool test (previously skipped due to #463)
- [x] Enable e2e_005_nested_datatypes test (previously skipped due to #463)

## Testing
All 773 tests pass. The following e2e tests now work:
- `e2e_002_bool` - Tests user-defined Bool type shadowing Prelude
- `e2e_005_nested_datatypes` - Tests nested Maybe and List constructors
