### PR TITLE
#504: Fix terminal corruption after :type command

### DIFF
--- a/website/template.html
+++ b/website/template.html
@@ -1706,6 +1706,7 @@
                                 if (!expr) {
                                     term.writeln('\x1b[31mError: No expression provided\x1b[0m');
                                     term.write('\x1b[32m> \x1b[0m');
+                                    currentLine = '';
                                     return;
                                 }
                                 try {
@@ -1724,6 +1725,7 @@
                                     term.writeln('\x1b[31mError: ' + error.message + '\x1b[0m');
                                 }
                                 term.write('\x1b[32m> \x1b[0m');
+                                currentLine = '';
                                 return;
                             } else if (cmd.startsWith('load ') || cmd.startsWith('l ') || cmd === 'load' || cmd === 'l') {
                                 fileInput.click();


### PR DESCRIPTION
Closes #504

## Summary
Fixed terminal corruption issue in the browser REPL after executing any :type command. The bug was caused by early return statements in the :type handler that did not clear the currentLine input buffer, causing subsequent keystrokes to be appended to the old input line.

## Testing
The fix can be verified by:
1. Opening the Rusholme browser REPL
2. Executing a type query: :type const
3. Then executing another command: putStrLn "Hello"
4. The second command should execute cleanly without showing corrupted output
