### PR TITLE
#336: Rename graalvm backend to jit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pipeline:
 Haskell Source → Parse → Typecheck/Desugar → Core → GRIN → Backend
                                                       ├─→ C
                                                       ├─→ JavaScript
-                                                      └─→ LLVM (native, Wasm, GraalVM)
+                                                      └─→ LLVM (native, Wasm, JIT/lli)
 ```
 
 Key design choices:
@@ -182,7 +182,7 @@ https://github.com/WebAssembly/component-tools) to integrate with your
 front-end build system. Runtime execution integration is tracked in issue #471;
 module linking is tracked in issue #472.
 
-**GraalVM / lli** — `rhc build --backend graalvm hello.hs`
+**JIT / lli** — `rhc build --backend jit hello.hs`
 
 ```bash
 # Clone and build on Linux
@@ -191,7 +191,7 @@ cd rusholme
 nix develop
 
 # Compile Haskell to LLVM IR for lli
-zig build run -- build --backend graalvm hello.hs
+zig build run -- build --backend jit hello.hs
 
 # The .ll file is now ready
 $ ls -la hello.ll
@@ -202,15 +202,15 @@ $ lli hello.ll
 Hello from Rusholme!
 ```
 
-The GraalVM backend compiles Haskell to LLVM textual IR (`.ll`) via the same
+The JIT backend compiles Haskell to LLVM textual IR (`.ll`) via the same
 GRIN-to-LLVM pipeline as the native backend, but instead of emitting a native
 object file and linking an executable, it merges the program IR with the
 runtime system and compiler-rt bitcode in-process and writes a single
 portable `.ll` file. This file can be executed directly by `lli` (the LLVM
-interpreter/JIT compiler) or GraalVM's Sulong engine.
+interpreter/JIT compiler).
 
 This backend is useful for rapid prototyping (no link step), debugging the
-generated IR, and running Haskell programs on GraalVM's polyglot platform.
+generated IR, and quick iteration without a native link step.
 
 ## Development
 

--- a/build.zig
+++ b/build.zig
@@ -167,58 +167,58 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(wasm_compiler_rt_lib);
 
     // ═══════════════════════════════════════════════════════════════════════
-    // GraalVM RTS LLVM Bitcode
+    // JIT Backend RTS LLVM Bitcode
     // ═══════════════════════════════════════════════════════════════════════
     // The same src/rts/ source is compiled for the native target but emitted
     // as LLVM bitcode (.bc) instead of a static library (.a).  This bitcode
-    // is merged with program bitcode via llvm-link so that lli can execute
+    // is merged with program bitcode in-process so that lli can execute
     // the result without undefined rts_* symbols.
     //
     // We use a baseline CPU model (no host-specific features) so the emitted
     // IR does not contain target-features strings (e.g. +amx-avx512) that
     // the system lli may not recognise, avoiding noisy warnings.
-    const graalvm_target = b.resolveTargetQuery(.{
+    const jit_target = b.resolveTargetQuery(.{
         .cpu_model = .baseline,
     });
-    const graalvm_rts_lib = b.addLibrary(.{
-        .name = "rts_graalvm",
+    const jit_rts_lib = b.addLibrary(.{
+        .name = "rts_jit",
         .linkage = .static,
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/rts/root.zig"),
-            .target = graalvm_target,
+            .target = jit_target,
             .optimize = optimize,
             .pic = true,
         }),
     });
-    const graalvm_rts_bc = graalvm_rts_lib.getEmittedLlvmBc();
-    // Install the bitcode to zig-out/lib/rts_graalvm.bc so the CLI can
+    const jit_rts_bc = jit_rts_lib.getEmittedLlvmBc();
+    // Install the bitcode to zig-out/lib/rts_jit.bc so the CLI can
     // find it at runtime (path baked in via @embedFile, same as librts.a).
-    const install_graalvm_bc = b.addInstallLibFile(graalvm_rts_bc, "rts_graalvm.bc");
-    b.getInstallStep().dependOn(&install_graalvm_bc.step);
+    const install_jit_bc = b.addInstallLibFile(jit_rts_bc, "rts_jit.bc");
+    b.getInstallStep().dependOn(&install_jit_bc.step);
 
-    // compiler-rt as LLVM bitcode for GraalVM.
+    // compiler-rt as LLVM bitcode for the JIT backend.
     //
     // The Zig RTS references compiler-rt builtins (__zig_probe_stack,
     // __divti3, etc.) that are normally linked by the system linker.
     // When running via lli, these symbols must be present in the merged
     // bitcode.  We compile compiler_rt.zig for the native target and
     // emit its bitcode alongside the RTS bitcode.
-    const graalvm_compiler_rt_lib = b.addLibrary(.{
-        .name = "compiler_rt_graalvm",
+    const jit_compiler_rt_lib = b.addLibrary(.{
+        .name = "compiler_rt_jit",
         .linkage = .static,
         .root_module = b.createModule(.{
             .root_source_file = .{ .cwd_relative = compiler_rt_zig_path },
-            .target = graalvm_target,
+            .target = jit_target,
             .optimize = .ReleaseSmall,
             .pic = true,
         }),
     });
-    const graalvm_compiler_rt_bc = graalvm_compiler_rt_lib.getEmittedLlvmBc();
-    const install_graalvm_compiler_rt_bc = b.addInstallLibFile(
-        graalvm_compiler_rt_bc,
-        "compiler_rt_graalvm.bc",
+    const jit_compiler_rt_bc = jit_compiler_rt_lib.getEmittedLlvmBc();
+    const install_jit_compiler_rt_bc = b.addInstallLibFile(
+        jit_compiler_rt_bc,
+        "compiler_rt_jit.bc",
     );
-    b.getInstallStep().dependOn(&install_graalvm_compiler_rt_bc.step);
+    b.getInstallStep().dependOn(&install_jit_compiler_rt_bc.step);
 
     // ═══════════════════════════════════════════════════════════════════════
     // CLI Executable with RTS Library Paths
@@ -256,26 +256,26 @@ pub fn build(b: *std.Build) void {
         wasm_compiler_rt_lib_path_option,
     );
 
-    const graalvm_rts_bc_path_option = b.option(
+    const jit_rts_bc_path_option = b.option(
         []const u8,
-        "graalvm-rts-bc-path",
-        "Path to GraalVM RTS bitcode (.bc)",
-    ) orelse b.getInstallPath(.lib, "rts_graalvm.bc");
-    const graalvm_rts_bc_path_wf = b.addNamedWriteFiles("graalvm_rts_bc_path");
-    const graalvm_rts_bc_path_file = graalvm_rts_bc_path_wf.add(
+        "jit-rts-bc-path",
+        "Path to JIT backend RTS bitcode (.bc)",
+    ) orelse b.getInstallPath(.lib, "rts_jit.bc");
+    const jit_rts_bc_path_wf = b.addNamedWriteFiles("jit_rts_bc_path");
+    const jit_rts_bc_path_file = jit_rts_bc_path_wf.add(
         "path.txt",
-        graalvm_rts_bc_path_option,
+        jit_rts_bc_path_option,
     );
 
-    const graalvm_compiler_rt_bc_path_option = b.option(
+    const jit_compiler_rt_bc_path_option = b.option(
         []const u8,
-        "graalvm-compiler-rt-bc-path",
-        "Path to GraalVM compiler-rt bitcode (.bc)",
-    ) orelse b.getInstallPath(.lib, "compiler_rt_graalvm.bc");
-    const graalvm_compiler_rt_bc_path_wf = b.addNamedWriteFiles("graalvm_compiler_rt_bc_path");
-    const graalvm_compiler_rt_bc_path_file = graalvm_compiler_rt_bc_path_wf.add(
+        "jit-compiler-rt-bc-path",
+        "Path to JIT backend compiler-rt bitcode (.bc)",
+    ) orelse b.getInstallPath(.lib, "compiler_rt_jit.bc");
+    const jit_compiler_rt_bc_path_wf = b.addNamedWriteFiles("jit_compiler_rt_bc_path");
+    const jit_compiler_rt_bc_path_file = jit_compiler_rt_bc_path_wf.add(
         "path.txt",
-        graalvm_compiler_rt_bc_path_option,
+        jit_compiler_rt_bc_path_option,
     );
 
     // Here we define an executable. An executable needs to have a root module
@@ -330,11 +330,11 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addAnonymousImport("wasm_compiler_rt_lib_path", .{
         .root_source_file = wasm_compiler_rt_path_file,
     });
-    exe.root_module.addAnonymousImport("graalvm_rts_bc_path", .{
-        .root_source_file = graalvm_rts_bc_path_file,
+    exe.root_module.addAnonymousImport("jit_rts_bc_path", .{
+        .root_source_file = jit_rts_bc_path_file,
     });
-    exe.root_module.addAnonymousImport("graalvm_compiler_rt_bc_path", .{
-        .root_source_file = graalvm_compiler_rt_bc_path_file,
+    exe.root_module.addAnonymousImport("jit_compiler_rt_bc_path", .{
+        .root_source_file = jit_compiler_rt_bc_path_file,
     });
 
     // This declares intent for the executable to be installed into the

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
               git
               pre-commit
               wasmtime
-              graalvmPackages.graalvm-ce  # GraalVM CE with Sulong for lli JIT
+              graalvmPackages.graalvm-ce  # Provides lli for the JIT backend
             ]) ++ pkgs.lib.optionals (!isDarwin) [
               pkgs.valgrind
             ];
@@ -62,7 +62,7 @@
               echo "   Zig:      $(zig version)"
               echo "   LLVM:     $(llvm-config --version)"
               echo "   Wasmtime: $(wasmtime --version 2>&1 | head -n1 || echo 'not found')"
-              echo "   GraalVM:  $(lli --version 2>&1 | head -n1 || echo 'not found')"
+              echo "   lli:      $(lli --version 2>&1 | head -n1 || echo 'not found')"
               echo ""
             '';
           };

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -13,7 +13,7 @@
 //!   // Multi-backend trait interface (from #335)
 //!   const_backend_mod = rusholme.backend.backend_mod;
 //!   const native = rusholme.backend.native;
-//!   const graalvm = rusholme.backend.graalvm;
+//!   const jit = rusholme.backend.jit;
 
 // ═══════════════════════════════════════════════════════════════════════
 // Core Backend Infrastructure (from PR #57)
@@ -38,15 +38,15 @@ pub const codegen = @import("backend/codegen.zig");
 /// Backend interface for multi-target code generation.
 ///
 /// Defines the abstraction layer for pluggable backends
-/// (native, GraalVM, WebAssembly, C, etc.) using Zig's
+/// (native, JIT, WebAssembly, C, etc.) using Zig's
 /// function-pointer-in-struct pattern.
 pub const backend_mod = @import("backend/backend_interface.zig");
 
 /// Native LLVM backend implementation.
 pub const native = @import("backend/native.zig");
 
-/// GraalVM/Sulong backend implementation.
-pub const graalvm = @import("backend/graalvm.zig");
+/// JIT backend — emits LLVM IR for execution via lli.
+pub const jit = @import("backend/jit.zig");
 
 /// WebAssembly backend stub (issues #77–#79).
 pub const wasm = @import("backend/wasm.zig");
@@ -65,7 +65,7 @@ test {
     @import("std").testing.refAllDecls(linker);
     @import("std").testing.refAllDecls(backend_mod);
     @import("std").testing.refAllDecls(native);
-    @import("std").testing.refAllDecls(graalvm);
+    @import("std").testing.refAllDecls(jit);
     @import("std").testing.refAllDecls(wasm);
     @import("std").testing.refAllDecls(c_backend);
 }

--- a/src/backend/backend_interface.zig
+++ b/src/backend/backend_interface.zig
@@ -1,10 +1,10 @@
 //! Backend trait for multi-target code generation.
 //!
 //! This module defines the abstraction layer for different backends
-//! (native, GraalVM, WebAssembly, C, etc.). Each backend implements
+//! (native, JIT, WebAssembly, C, etc.). Each backend implements
 //! the Backend vtable with emit/link/run operations.
 //!
-//! See `docs/sulong-architecture.md` for full design details.
+//! See DESIGN.md for full design details.
 
 const std = @import("std");
 
@@ -19,8 +19,8 @@ pub const BackendKind = enum {
     /// Native executable via LLVM (default, current implementation).
     native,
 
-    /// GraalVM/Sulong interpreter (LLVM bitcode).
-    graalvm,
+    /// JIT backend — emits LLVM IR for execution via lli.
+    jit,
 
     /// WebAssembly (future, issues #77-#79).
     wasm,
@@ -33,7 +33,7 @@ pub const BackendKind = enum {
 pub fn backendName(kind: BackendKind) []const u8 {
     return switch (kind) {
         .native => "native",
-        .graalvm => "graalvm",
+        .jit => "jit",
         .wasm => "wasm",
         .c => "c",
     };
@@ -42,7 +42,7 @@ pub fn backendName(kind: BackendKind) []const u8 {
 /// Parse backend name string to enum.
 pub fn parseBackendKind(name: []const u8) ?BackendKind {
     if (std.mem.eql(u8, name, "native")) return .native;
-    if (std.mem.eql(u8, name, "graalvm")) return .graalvm;
+    if (std.mem.eql(u8, name, "jit")) return .jit;
     if (std.mem.eql(u8, name, "wasm")) return .wasm;
     if (std.mem.eql(u8, name, "c")) return .c;
     return null;
@@ -191,11 +191,11 @@ pub const VTable = struct {
 /// };
 /// ```
 ///
-/// Each backend struct (NativeBackend, GraalVMBackend, etc.) should:
+/// Each backend struct (NativeBackend, JitBackend, etc.) should:
 /// 1. Embed Backend as its first field (or in a known position)
 /// 2. Implement the vtable functions with @ptrCast to the concrete type
 pub const Backend = struct {
-    /// Kind of backend (native, graalvm, wasm, c).
+    /// Kind of backend (native, jit, wasm, c).
     kind: BackendKind,
 
     /// Human-readable name.
@@ -236,14 +236,14 @@ pub const Error = error{
 
 test "backendName" {
     try std.testing.expectEqualStrings("native", backendName(.native));
-    try std.testing.expectEqualStrings("graalvm", backendName(.graalvm));
+    try std.testing.expectEqualStrings("jit", backendName(.jit));
     try std.testing.expectEqualStrings("wasm", backendName(.wasm));
     try std.testing.expectEqualStrings("c", backendName(.c));
 }
 
 test "parseBackendKind" {
     try std.testing.expect(parseBackendKind("native").? == .native);
-    try std.testing.expect(parseBackendKind("graalvm").? == .graalvm);
+    try std.testing.expect(parseBackendKind("jit").? == .jit);
     try std.testing.expect(parseBackendKind("wasm").? == .wasm);
     try std.testing.expect(parseBackendKind("c").? == .c);
     try std.testing.expect(parseBackendKind("unknown") == null);
@@ -251,7 +251,7 @@ test "parseBackendKind" {
 
 test "BackendKind enum values" {
     try std.testing.expectEqual(@intFromEnum(BackendKind.native), 0);
-    try std.testing.expectEqual(@intFromEnum(BackendKind.graalvm), 1);
+    try std.testing.expectEqual(@intFromEnum(BackendKind.jit), 1);
     try std.testing.expectEqual(@intFromEnum(BackendKind.wasm), 2);
     try std.testing.expectEqual(@intFromEnum(BackendKind.c), 3);
 }

--- a/src/backend/jit.zig
+++ b/src/backend/jit.zig
@@ -1,7 +1,7 @@
-//! GraalVM/Sulong backend - interprets LLVM bitcode via GraalVM.
+//! JIT backend — emits LLVM IR for execution via lli.
 //!
 //! This backend compiles the Zig runtime to LLVM bitcode and links it
-//! with Haskell LLVM IR for execution via GraalVM's lli launcher.
+//! with Haskell LLVM IR for execution via lli (LLVM interpreter/JIT).
 
 const std = @import("std");
 
@@ -17,7 +17,7 @@ const ZIG_BITCODE_FLAGS = &[_][]const u8{
     "-ofmt=bc",
 };
 
-/// Build Zig runtime system as LLVM bitcode for GraalVM.
+/// Build Zig runtime system as LLVM bitcode for the JIT backend.
 ///
 /// This invokes zig build-lib with the appropriate flags to produce
 /// a .bc file instead of a native object.
@@ -75,13 +75,13 @@ pub fn linkBitcode(allocator: std.mem.Allocator, haskell_bc: []const u8, zig_bc:
     }
 }
 
-/// Emit LLVM bitcode for execution via Sulong.
+/// Emit LLVM bitcode for execution via lli.
 const emit = struct {
     fn emit(
         backend: *const anyopaque,
         context: *const backend_mod.EmitContext,
     ) !backend_mod.EmissionResult {
-        const self_graalvm: *const GraalVMBackend = @ptrCast(@alignCast(backend));
+        const self_jit: *const JitBackend = @ptrCast(@alignCast(backend));
 
         // For M1 scope: emit haskell_llvm_to_bc
         // This would call grin_to_llvm.zig translator and then convert to bitcode
@@ -93,7 +93,7 @@ const emit = struct {
         // 3. Build runtime bitcode via zig build-lib
         // 4. Return path to combined bitcode or just the Haskell bitcode
 
-        _ = self_graalvm.allocator;
+        _ = self_jit.allocator;
         _ = context.grin_program;
 
         return .{ .bitcode = context.output_path };
@@ -106,30 +106,30 @@ const link_link = struct {
         backend: *const anyopaque,
         context: *const backend_mod.LinkContext,
     ) !void {
-        const self_graalvm: *const GraalVMBackend = @ptrCast(@alignCast(backend));
+        const self_jit: *const JitBackend = @ptrCast(@alignCast(backend));
 
         // Expected context: 2 files - [haskell_program.bc, runtime.bc]
         if (context.emitted_files.len < 2) {
-            std.log.err("GraalVM link expected at least 2 files, got {d}", .{context.emitted_files.len});
+            std.log.err("JIT link expected at least 2 files, got {d}", .{context.emitted_files.len});
             return error.InvalidInput;
         }
 
         const haskell_bc = context.emitted_files[0];
         const runtime_bc = context.emitted_files[1];
-        const output_name = context.output_name orelse "graalvm_app.bc";
+        const output_name = context.output_name orelse "jit_app.bc";
 
         // Build runtime bitcode if not already built
         // (In real implementation, check if runtime_bc exists)
-        try buildRuntimeBitcode(self_graalvm.allocator, runtime_bc);
+        try buildRuntimeBitcode(self_jit.allocator, runtime_bc);
 
         // Link them together
-        try linkBitcode(self_graalvm.allocator, haskell_bc, runtime_bc, output_name);
+        try linkBitcode(self_jit.allocator, haskell_bc, runtime_bc, output_name);
 
         std.log.info("Linked {s} and {s} into {s}", .{ haskell_bc, runtime_bc, output_name });
     }
 };
 
-/// Run bitcode via GraalVM's lli.
+/// Run LLVM IR via lli.
 const link_run = struct {
     fn run(
         backend: *const anyopaque,
@@ -137,8 +137,7 @@ const link_run = struct {
     ) !void {
         _ = backend;
 
-        // Invoke lli to execute the bitcode
-        // Check GraalVM is available on PATH
+        // Check lli is available on PATH
         var which_result = try std.process.run(std.heap.page_allocator, undefined, .{
             .argv = &.{ "which", "lli" },
         });
@@ -146,7 +145,7 @@ const link_run = struct {
         defer std.heap.page_allocator.free(which_result.stderr);
 
         if (@intFromEnum(which_result.term) != 0) {
-            return error.GraalVMNotFound;
+            return error.LliNotFound;
         }
 
         // For real execution, would run: lli <executable_path> [args...]
@@ -154,14 +153,14 @@ const link_run = struct {
     }
 };
 
-pub const GraalVMBackend = struct {
+pub const JitBackend = struct {
     /// Allocator for runtime allocations.
     allocator: std.mem.Allocator,
 
     /// Backend struct implementing the vtable operations.
     pub const inner = backend_mod.Backend{
-        .kind = .graalvm,
-        .name = "graalvm",
+        .kind = .jit,
+        .name = "jit",
         .vtable = .{
             .emit = emit.emit,
             .link = link_link.link,
@@ -169,20 +168,20 @@ pub const GraalVMBackend = struct {
         },
     };
 
-    /// Create a GraalVMBackend instance.
-    pub fn init(allocator: std.mem.Allocator) GraalVMBackend {
+    /// Create a JitBackend instance.
+    pub fn init(allocator: std.mem.Allocator) JitBackend {
         return .{ .allocator = allocator };
     }
 
     /// Get the Backend trait reference.
-    pub fn asBackend(self: *const GraalVMBackend) *const backend_mod.Backend {
+    pub fn asBackend(self: *const JitBackend) *const backend_mod.Backend {
         return &self.inner;
     }
 };
 
-test "GraalVMBackend: create and get backend reference" {
+test "JitBackend: create and get backend reference" {
     const allocator = std.testing.allocator;
-    const graalvm = GraalVMBackend.init(allocator);
-    _ = graalvm; // Use value
-    try std.testing.expectEqual(backend_mod.BackendKind.graalvm, GraalVMBackend.inner.kind);
+    const jit_backend = JitBackend.init(allocator);
+    _ = jit_backend;
+    try std.testing.expectEqual(backend_mod.BackendKind.jit, JitBackend.inner.kind);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,7 +8,7 @@
 //!   rhc ll <file.hs>       Full pipeline; emit LLVM IR
 //!   rhc build [--backend <kind>] [-o <out>] <file.hs>
 //!                          Full pipeline; compile to native executable
-//!                          Backends: native (default), graalvm, wasm, c
+//!                          Backends: native (default), jit, wasm, c
 //!   rhc repl               Interactive REPL (read-eval-print loop)
 //!   rhc --help             Show this help message
 //!   rhc --version          Show version information
@@ -51,18 +51,18 @@ fn getWasmCompilerRtLibPath() []const u8 {
     return @embedFile("wasm_compiler_rt_lib_path");
 }
 
-/// Get the path to the GraalVM RTS LLVM bitcode baked in at compile time.
-/// Returns the path to rts_graalvm.bc which is merged with program bitcode
-/// via llvm-link so that lli can resolve rts_alloc, rts_putStrLn, etc.
-fn getGraalvmRtsBcPath() []const u8 {
-    return @embedFile("graalvm_rts_bc_path");
+/// Get the path to the JIT backend RTS LLVM bitcode baked in at compile time.
+/// Returns the path to rts_jit.bc which is merged with program bitcode
+/// in-process so that lli can resolve rts_alloc, rts_putStrLn, etc.
+fn getJitRtsBcPath() []const u8 {
+    return @embedFile("jit_rts_bc_path");
 }
 
-/// Get the path to the GraalVM compiler-rt LLVM bitcode baked in at compile time.
+/// Get the path to the JIT backend compiler-rt LLVM bitcode baked in at compile time.
 /// Provides __zig_probe_stack, __divti3, and other builtins that the Zig RTS
 /// references but which are normally resolved by the system linker.
-fn getGraalvmCompilerRtBcPath() []const u8 {
-    return @embedFile("graalvm_compiler_rt_bc_path");
+fn getJitCompilerRtBcPath() []const u8 {
+    return @embedFile("jit_compiler_rt_bc_path");
 }
 
 pub fn main(init: std.process.Init) !void {
@@ -202,7 +202,7 @@ pub fn main(init: std.process.Init) !void {
                     var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
                     const stderr = &stderr_fw.interface;
                     try stderr.print("rhc build: unknown backend '{s}'\n", .{cmd_args[i]});
-                    try stderr.print("Valid backends: native, graalvm, wasm, c\n", .{});
+                    try stderr.print("Valid backends: native, jit, wasm, c\n", .{});
                     try stderr.flush();
                     std.process.exit(1);
                 };
@@ -699,7 +699,7 @@ fn cmdRepl(allocator: std.mem.Allocator, io: Io, server_mode: bool) !void {
 /// Supports the following backends:
 /// - native: compiles to native executable via LLVM
 /// - wasm: compiles to WebAssembly binary (.wasm)
-/// - graalvm, c: not yet implemented
+/// - jit, c: not yet implemented
 fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8, output_name: []const u8, backend_kind: rusholme.backend.backend_mod.BackendKind, is_repl: bool) !void {
     // REPL mode placeholder - for WASM backend compiles stateful REPL
     _ = is_repl;
@@ -767,7 +767,7 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
     // ── Dispatch to backend-specific emission ─────────────────────────────
     switch (backend_kind) {
         .native => try emitNative(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name),
-        .graalvm => try emitGraalVM(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name),
+        .jit => try emitJit(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name),
         .wasm => try emitWasm(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name),
         .c => {
             var stderr_buf: [4096]u8 = undefined;
@@ -906,7 +906,7 @@ fn emitNative(
     Dir.deleteFile(.cwd(), io, obj_path) catch {};
 }
 
-/// Emit LLVM bitcode for execution via GraalVM's lli (or any LLVM interpreter).
+/// Emit LLVM IR for execution via lli (LLVM interpreter/JIT compiler).
 ///
 /// The flow mirrors emitNative / emitWasm:
 ///   1. Translate each module's GRIN to LLVM IR.
@@ -918,7 +918,7 @@ fn emitNative(
 ///
 /// The final output is `{output_name}.bc` which can be run with:
 ///   lli {output_name}.bc
-fn emitGraalVM(
+fn emitJit(
     allocator: std.mem.Allocator,
     io: Io,
     session: *const rusholme.modules.compile_env.CompileEnv,
@@ -952,7 +952,7 @@ fn emitGraalVM(
             var stderr_buf: [4096]u8 = undefined;
             var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
             const stderr = &stderr_fw.interface;
-            try stderr.print("rhc: LLVM codegen failed for GraalVM module '{s}': {}\n", .{ mod_name, err });
+            try stderr.print("rhc: LLVM codegen failed for JIT module '{s}': {}\n", .{ mod_name, err });
             try stderr.flush();
             std.process.exit(1);
         };
@@ -978,7 +978,7 @@ fn emitGraalVM(
     };
 
     // ── Set native target layout ────────────────────────────────────────
-    // GraalVM's Sulong accepts bitcode compiled for the host architecture.
+    // lli accepts bitcode/IR compiled for the host architecture.
     const machine = llvm.createNativeTargetMachine() catch |err| {
         var stderr_buf: [4096]u8 = undefined;
         var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
@@ -997,12 +997,12 @@ fn emitGraalVM(
     // them into the program module using LLVM's in-process linker.  This
     // avoids shelling out to llvm-link (which can fail on bitcode produced
     // by a different LLVM build — e.g. Zig's embedded LLVM vs Nix LLVM).
-    const graalvm_rts_bc_path = getGraalvmRtsBcPath();
-    const rts_mod = llvm.parseBitcodeFile(graalvm_rts_bc_path) catch |err| {
+    const jit_rts_bc_path = getJitRtsBcPath();
+    const rts_mod = llvm.parseBitcodeFile(jit_rts_bc_path) catch |err| {
         var stderr_buf: [4096]u8 = undefined;
         var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
         const stderr = &stderr_fw.interface;
-        try stderr.print("rhc: failed to load RTS bitcode '{s}': {}\n", .{ graalvm_rts_bc_path, err });
+        try stderr.print("rhc: failed to load RTS bitcode '{s}': {}\n", .{ jit_rts_bc_path, err });
         try stderr.flush();
         std.process.exit(1);
     };
@@ -1016,12 +1016,12 @@ fn emitGraalVM(
         std.process.exit(1);
     };
 
-    const graalvm_compiler_rt_bc_path = getGraalvmCompilerRtBcPath();
-    const compiler_rt_mod = llvm.parseBitcodeFile(graalvm_compiler_rt_bc_path) catch |err| {
+    const jit_compiler_rt_bc_path = getJitCompilerRtBcPath();
+    const compiler_rt_mod = llvm.parseBitcodeFile(jit_compiler_rt_bc_path) catch |err| {
         var stderr_buf: [4096]u8 = undefined;
         var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
         const stderr = &stderr_fw.interface;
-        try stderr.print("rhc: failed to load compiler-rt bitcode '{s}': {}\n", .{ graalvm_compiler_rt_bc_path, err });
+        try stderr.print("rhc: failed to load compiler-rt bitcode '{s}': {}\n", .{ jit_compiler_rt_bc_path, err });
         try stderr.flush();
         std.process.exit(1);
     };
@@ -1320,7 +1320,7 @@ fn printUsage(io: Io) !void {
         \\  rhc ll <file.hs>       Full pipeline; emit LLVM IR
         \\  rhc build [--backend <kind>] [-o <out>] <file.hs>
         \\                         Full pipeline; compile to an executable
-        \\                         Backends: native (default), graalvm, wasm, c
+        \\                         Backends: native (default), jit, wasm, c
         \\  rhc repl [--server]   Interactive REPL (read-eval-print loop)
         \\                         Use --server for JSON-RPC protocol mode
         \\  rhc --help             Show this help message

--- a/website/template.html
+++ b/website/template.html
@@ -407,7 +407,7 @@
                 </div>
                 <div class="flex items-center gap-2 px-4 py-2 bg-gray-800/50 rounded-full border border-gray-700/50">
                     <span class="w-2 h-2 rounded-full bg-red-500"></span>
-                    <span class="text-sm text-gray-400">GraalVM</span>
+                    <span class="text-sm text-gray-400">JIT/lli</span>
                 </div>
             </div>
         </div>
@@ -487,7 +487,7 @@
                     <div class="card-hover p-6 bg-gray-900 rounded-2xl border border-gray-800">
                         <div class="text-4xl mb-4">🌐</div>
                         <h3 class="text-lg font-bold text-white mb-2">Multi-Backend</h3>
-                        <p class="text-sm text-gray-500">LLVM native, WebAssembly, GraalVM/lli, C, and JavaScript targets</p>
+                        <p class="text-sm text-gray-500">LLVM native, WebAssembly, JIT/lli, C, and JavaScript targets</p>
                     </div>
 
                     <div class="card-hover p-6 bg-gray-900 rounded-2xl border border-gray-800">
@@ -613,7 +613,7 @@
                             <rect x="650" y="195" width="80" height="50" rx="8" fill="#1f2937" stroke="#22c55e"
                                 stroke-width="2" />
                             <text x="690" y="225" text-anchor="middle" fill="#f1f5f9" font-size="11"
-                                font-weight="600">GraalVM</text>
+                                font-weight="600">JIT/lli</text>
                         </g>
 
                         <!-- Dashed lines to backends -->
@@ -632,7 +632,7 @@
                         <text x="395" y="185" text-anchor="middle" fill="#6b7280" font-size="9">System F_C</text>
                         <text x="550" y="185" text-anchor="middle" fill="#6b7280" font-size="9">Explicit Heap</text>
                         <text x="790" y="130" text-anchor="middle" fill="#6b7280" font-size="9">Native / Web /</text>
-                        <text x="790" y="142" text-anchor="middle" fill="#6b7280" font-size="9">Polyglot</text>
+                        <text x="790" y="142" text-anchor="middle" fill="#6b7280" font-size="9">JIT</text>
                     </svg>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

Rename the "graalvm" backend to "jit" across the entire codebase. The previous name overpromised -- the backend emits LLVM IR (.ll) for execution via lli, with no actual JVM involvement. The name "jit" accurately describes what it does: emit IR for a JIT engine.

## Changes

Systematic rename across 8 files:

- **src/backend/graalvm.zig -> src/backend/jit.zig**: GraalVMBackend -> JitBackend, all internal references
- **src/backend/backend_interface.zig**: .graalvm -> .jit enum variant, parser, name mapping
- **src/backend.zig**: Import path and doc comment
- **build.zig**: All variable/artifact names (rts_jit, compiler_rt_jit, path options)
- **src/main.zig**: emitGraalVM() -> emitJit(), path helpers, help text (--backend jit)
- **flake.nix**: Comments and shell hook label
- **README.md**: Section title, examples, descriptions
- **website/template.html**: Badges, feature cards, SVG pipeline diagram

## What stays unchanged

- The Nix package graalvmPackages.graalvm-ce (that is the actual Nix package name)
- ROADMAP.md issue titles (they reference GitHub issue titles which are external)
- All backend functionality -- this is a pure rename, no behavioral changes

## Testing

- 847/847 tests pass
- Build artifacts correctly named rts_jit.bc and compiler_rt_jit.bc
