### PR TITLE
#588: Preserve type constructor names across REPL inputs

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -366,7 +366,7 @@ fn cmdCheck(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply);
 
     var infer_ctx = infer_mod.InferCtx.init(arena_alloc, &ty_env, &mv_supply, &u_supply, &diags);
-    var module_types = try infer_mod.inferModule(&infer_ctx, renamed);
+    var module_types = try infer_mod.inferModule(&infer_ctx, renamed, null);
     defer module_types.deinit(arena_alloc);
 
     if (diags.hasErrors()) {
@@ -449,7 +449,7 @@ fn cmdCore(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
     try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply);
     var infer_ctx = infer_mod.InferCtx.init(arena_alloc, &ty_env, &mv_supply, &u_supply, &diags);
-    var module_types = try infer_mod.inferModule(&infer_ctx, renamed);
+    var module_types = try infer_mod.inferModule(&infer_ctx, renamed, null);
     defer module_types.deinit(arena_alloc);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
@@ -535,7 +535,7 @@ fn cmdGrin(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
     try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply);
     var infer_ctx = infer_mod.InferCtx.init(arena_alloc, &ty_env, &mv_supply, &u_supply, &diags);
-    var module_types = try infer_mod.inferModule(&infer_ctx, renamed);
+    var module_types = try infer_mod.inferModule(&infer_ctx, renamed, null);
     defer module_types.deinit(arena_alloc);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
@@ -635,7 +635,7 @@ fn cmdLl(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
     try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply);
     var infer_ctx = infer_mod.InferCtx.init(arena_alloc, &ty_env, &mv_supply, &u_supply, &diags);
-    var module_types = try infer_mod.inferModule(&infer_ctx, renamed);
+    var module_types = try infer_mod.inferModule(&infer_ctx, renamed, null);
     defer module_types.deinit(arena_alloc);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -386,7 +386,7 @@ pub const CompileEnv = struct {
             &self.u_supply,
             &self.diags,
         );
-        var module_types = try infer_mod.inferModule(&infer_ctx, renamed);
+        var module_types = try infer_mod.inferModule(&infer_ctx, renamed, null);
         defer module_types.deinit(self.alloc);
         if (self.diags.hasErrors()) return null;
 

--- a/src/renamer/renamer.zig
+++ b/src/renamer/renamer.zig
@@ -934,13 +934,9 @@ fn decomposeInstanceHead(ty: ast.Type) ?struct { class_name: []const u8, instanc
                 .instance_type = .{ .App = parts[1..] },
             };
         },
-        // Bare constructor: `instance Eq` (no instance type — malformed but handle gracefully)
-        .Con => |con| {
-            return .{
-                .class_name = con.name,
-                .instance_type = ty,
-            };
-        },
+        // Bare constructor with no type argument is invalid.
+        // Catches malformed instances like `instance ShowIt where ...`.
+        .Con => return null,
         else => return null,
     }
 }

--- a/src/repl/pipeline.zig
+++ b/src/repl/pipeline.zig
@@ -36,6 +36,7 @@ const FileId = span_mod.FileId;
 
 const unique_mod = @import("../naming/unique.zig");
 const UniqueSupply = unique_mod.UniqueSupply;
+const Name = unique_mod.Name;
 
 const infer_mod = @import("../typechecker/infer.zig");
 const htype_mod = @import("../typechecker/htype.zig");
@@ -55,6 +56,7 @@ const DictNameMap = desugar_mod.DesugarCtx.DictNameMap;
 
 const ArityMap = std.AutoHashMapUnmanaged(u64, u32);
 const ConMap = std.AutoHashMapUnmanaged(u64, u32);
+const TypeConNames = std.StringHashMapUnmanaged(Name);
 
 // ── Result types ──────────────────────────────────────────────────────
 
@@ -292,6 +294,7 @@ pub const Pipeline = struct {
         external_con_map: ?*const ConMap,
         external_class_env: ?*const ClassEnv,
         external_dict_names: ?*const DictNameMap,
+        external_type_con_names: ?*const TypeConNames,
     ) CompileError!ModuleResult {
         const alloc = self.allocator;
 
@@ -335,7 +338,7 @@ pub const Pipeline = struct {
             };
         }
 
-        var module_types = infer_mod.inferModule(&infer_ctx, renamed) catch {
+        var module_types = infer_mod.inferModule(&infer_ctx, renamed, external_type_con_names) catch {
             return CompileError.OutOfMemory;
         };
         if (diags.hasErrors()) {
@@ -403,6 +406,7 @@ pub const Pipeline = struct {
         external_con_map: ?*const ConMap,
         external_class_env: ?*const ClassEnv,
         external_dict_names: ?*const DictNameMap,
+        external_type_con_names: ?*const TypeConNames,
     ) CompileError!CompileResult {
         const alloc = self.allocator;
         const file_id: FileId = 0;
@@ -431,7 +435,7 @@ pub const Pipeline = struct {
             var decl_diags = DiagnosticCollector.init();
             defer decl_diags.deinit(alloc);
 
-            if (self.compileModule(decl_source, file_id, u_supply, rename_env, ty_env, mv_supply, &decl_diags, external_arities, external_con_map, external_class_env, external_dict_names)) |result| {
+            if (self.compileModule(decl_source, file_id, u_supply, rename_env, ty_env, mv_supply, &decl_diags, external_arities, external_con_map, external_class_env, external_dict_names, external_type_con_names)) |result| {
                 // Copy any diagnostics from the attempt
                 try copyDiagnostics(alloc, &decl_diags, diags);
                 return .{ .program = result.grin_prog, .kind = decl_kind, .core_data_decls = result.core_data_decls, .class_env = result.class_env, .dict_names = result.dict_names };
@@ -456,7 +460,7 @@ pub const Pipeline = struct {
             self.last_source = expr_source;
             self.last_input_kind = .expression;
 
-            if (self.compileModule(expr_source, file_id, u_supply, rename_env, ty_env, mv_supply, diags, external_arities, external_con_map, external_class_env, external_dict_names)) |result| {
+            if (self.compileModule(expr_source, file_id, u_supply, rename_env, ty_env, mv_supply, diags, external_arities, external_con_map, external_class_env, external_dict_names, external_type_con_names)) |result| {
                 // Expression succeeded — clear declaration diagnostics.
                 clearLeadingDiags(alloc, diags, decl_diag_count);
                 return .{ .program = result.grin_prog, .kind = .expression, .core_data_decls = result.core_data_decls, .class_env = result.class_env, .dict_names = result.dict_names };
@@ -520,6 +524,7 @@ test "pipeline: compile simple literal expression" {
         null,
         null,
         null,
+        null,
     );
 
     try testing.expect(result.program.defs.len > 0);
@@ -551,6 +556,7 @@ test "pipeline: compile data declaration" {
         &ty_env,
         &mv_supply,
         &diags,
+        null,
         null,
         null,
         null,
@@ -587,6 +593,7 @@ test "pipeline: compile function declaration" {
         &ty_env,
         &mv_supply,
         &diags,
+        null,
         null,
         null,
         null,
@@ -708,6 +715,7 @@ test "pipeline: handle let prefix in declarations" {
         &ty_env,
         &mv_supply,
         &diags,
+        null,
         null,
         null,
         null,

--- a/src/repl/session.zig
+++ b/src/repl/session.zig
@@ -33,6 +33,7 @@ const FileId = span_mod.FileId;
 
 const unique_mod = @import("../naming/unique.zig");
 const UniqueSupply = unique_mod.UniqueSupply;
+const Name = unique_mod.Name;
 
 const htype_mod = @import("../typechecker/htype.zig");
 const env_mod = @import("../typechecker/env.zig");
@@ -163,6 +164,12 @@ pub const Session = struct {
     // REPL inputs can find dictionaries declared in prior inputs (#578).
     accumulated_dict_names: DictNameMap,
 
+    // Accumulated type constructor names from data declarations in prior inputs.
+    // Maps base name (e.g. "A") → Name (with correct unique).
+    // Passed to the typechecker so that instance heads can reference types
+    // from prior REPL inputs (#588).
+    accumulated_type_con_names: std.StringHashMapUnmanaged(Name),
+
     /// Create a new REPL session with initialised compiler state.
     pub fn init(allocator: Allocator, io: std.Io) SessionError!Session {
         var u_supply = UniqueSupply{};
@@ -202,6 +209,7 @@ pub const Session = struct {
             .accumulated_con_map = .{},
             .accumulated_class_env = ClassEnv.init(allocator),
             .accumulated_dict_names = .empty,
+            .accumulated_type_con_names = .empty,
         };
 
         // Load the Prelude so its functions are available immediately.
@@ -223,6 +231,7 @@ pub const Session = struct {
     /// Release all session resources.
     pub fn deinit(self: *Session) void {
         // GrinEngine has no deinit; only JitEngine does.
+        self.accumulated_type_con_names.deinit(self.allocator);
         self.accumulated_dict_names.deinit(self.allocator);
         self.accumulated_class_env.deinit();
         self.accumulated_con_map.deinit(self.allocator);
@@ -268,6 +277,7 @@ pub const Session = struct {
             null, // no external con_map yet
             null, // no external class_env yet
             null, // no external dict_names yet
+            null, // no external type_con_names yet
         ) catch {
             // Prelude failed to compile — roll back and continue without it.
             self.ty_env.pop();
@@ -294,6 +304,13 @@ pub const Session = struct {
                     translate_mod.countConFields(con.ty),
                 ) catch return;
             }
+        }
+
+        // Accumulate type constructor names from Prelude data declarations.
+        // This allows instance heads to reference types from the Prelude
+        // (#588).
+        for (result.core_data_decls) |decl| {
+            self.accumulated_type_con_names.put(self.allocator, decl.name.base, decl.name) catch return;
         }
 
         // Take ownership of class_env and dict_names.
@@ -356,6 +373,7 @@ pub const Session = struct {
             &self.accumulated_con_map,
             &self.accumulated_class_env,
             &self.accumulated_dict_names,
+            &self.accumulated_type_con_names,
         ) catch |err| {
             // Capture compilation context for diagnostic rendering.
             self.last_source = self.pipeline.last_source;
@@ -423,6 +441,13 @@ pub const Session = struct {
                         translate_mod.countConFields(con.ty),
                     );
                 }
+            }
+
+            // Accumulate type constructor names from data declarations.
+            // This allows instance heads to reference types from prior REPL
+            // inputs by their correct unique IDs (#588).
+            for (result.core_data_decls) |decl| {
+                try self.accumulated_type_con_names.put(self.allocator, decl.name.base, decl.name);
             }
 
             // Replace the accumulated class env with the result's env.

--- a/src/repl/typequery.zig
+++ b/src/repl/typequery.zig
@@ -76,6 +76,7 @@ pub fn typeOf(
         &session.accumulated_con_map,
         &session.accumulated_class_env,
         &session.accumulated_dict_names,
+        &session.accumulated_type_con_names,
     ) catch |err| {
         // Capture compilation context for diagnostic rendering.
         session.last_source = session.pipeline.last_source;

--- a/src/typechecker/infer.zig
+++ b/src/typechecker/infer.zig
@@ -99,6 +99,8 @@ pub const ClassConstraint = class_env_mod.ClassConstraint;
 pub const DiagnosticCollector = diag_mod.DiagnosticCollector;
 pub const DiagnosticCode = diag_mod.DiagnosticCode;
 pub const Severity = diag_mod.Severity;
+pub const Name = naming_mod.Name;
+pub const TypeConNames = std.StringHashMapUnmanaged(Name);
 pub const SourceSpan = span_mod.SourceSpan;
 pub const SourcePos = span_mod.SourcePos;
 pub const RExpr = renamer_mod.RExpr;
@@ -109,7 +111,6 @@ pub const RStmt = renamer_mod.RStmt;
 pub const RRhs = renamer_mod.RRhs;
 pub const RMatch = renamer_mod.RMatch;
 pub const RenamedModule = renamer_mod.RenamedModule;
-pub const Name = naming_mod.Name;
 pub const UniqueSupply = naming_mod.UniqueSupply;
 const Known = known_mod;
 
@@ -1825,7 +1826,11 @@ fn inferMatch(ctx: *InferCtx, match: RMatch) std.mem.Allocator.Error!*HType {
 ///
 /// Returns a `ModuleTypes` mapping each top-level name's unique to its
 /// `TyScheme`.  Errors are collected in `ctx.diags`.
-pub fn inferModule(ctx: *InferCtx, module: RenamedModule) std.mem.Allocator.Error!ModuleTypes {
+pub fn inferModule(
+    ctx: *InferCtx,
+    module: RenamedModule,
+    external_type_con_names: ?*const TypeConNames,
+) std.mem.Allocator.Error!ModuleTypes {
     // Pass 0: Build type constructor lookup map from data declarations.
     // This map is used during type signature conversion to resolve custom ADT
     // type constructors to their proper unique IDs.
@@ -1839,6 +1844,20 @@ pub fn inferModule(ctx: *InferCtx, module: RenamedModule) std.mem.Allocator.Erro
             else => {},
         }
     }
+
+    // Merge in type constructor names from prior REPL inputs (#588).
+    // This allows instance heads to reference types declared in previous
+    // inputs with their correct unique IDs. Don't overwrite — current
+    // module's declarations take precedence.
+    if (external_type_con_names) |ext_names| {
+        var it = ext_names.iterator();
+        while (it.next()) |entry| {
+            if (!type_con_names.contains(entry.key_ptr.*)) {
+                try type_con_names.put(ctx.alloc, entry.key_ptr.*, entry.value_ptr.*);
+            }
+        }
+    }
+
     ctx.type_con_names = &type_con_names;
 
     // Pass 0a: Collect type signatures and convert them to HType.
@@ -3627,7 +3646,7 @@ test "inferModule: main = putStrLn \"Hello\"" {
         .span = testSpan(),
     };
 
-    var module_types = try inferModule(&ctx, module);
+    var module_types = try inferModule(&ctx, module, null);
     defer module_types.deinit(alloc);
 
     try testing.expect(!diags.hasErrors());
@@ -3680,7 +3699,7 @@ test "inferModule: two independent definitions" {
         .span = testSpan(),
     };
 
-    var module_types = try inferModule(&ctx, module);
+    var module_types = try inferModule(&ctx, module, null);
     defer module_types.deinit(alloc);
 
     try testing.expect(!diags.hasErrors());
@@ -3751,7 +3770,7 @@ test "inferModule: signature matches inferred type" {
         .span = testSpan(),
     };
 
-    var module_types = try inferModule(&ctx, module);
+    var module_types = try inferModule(&ctx, module, null);
     defer module_types.deinit(alloc);
 
     // Should have no errors (signature matches)
@@ -3810,7 +3829,7 @@ test "inferModule: signature mismatch produces error" {
         .span = testSpan(),
     };
 
-    var module_types = try inferModule(&ctx, module);
+    var module_types = try inferModule(&ctx, module, null);
     defer module_types.deinit(alloc);
 
     try testing.expect(diags.hasErrors());
@@ -3875,7 +3894,7 @@ test "inferModule: type variables in signature are scoped correctly" {
         .span = testSpan(),
     };
 
-    var module_types = try inferModule(&ctx, module);
+    var module_types = try inferModule(&ctx, module, null);
     defer module_types.deinit(alloc);
 
     try testing.expect(!diags.hasErrors());
@@ -3967,7 +3986,7 @@ test "inferModule: #304 bad x y = x with sig a -> b -> b produces RigidMismatch"
         .span = testSpan(),
     };
 
-    var module_types = try inferModule(&ctx, module);
+    var module_types = try inferModule(&ctx, module, null);
     defer module_types.deinit(alloc);
 
     // The body returns `x :: a` but the signature declares the result as `b`.
@@ -4025,7 +4044,7 @@ test "inferModule: #304 good x y = y with sig a -> b -> b succeeds" {
         .span = testSpan(),
     };
 
-    var module_types = try inferModule(&ctx, module);
+    var module_types = try inferModule(&ctx, module, null);
     defer module_types.deinit(alloc);
 
     try testing.expect(!diags.hasErrors());
@@ -4392,7 +4411,7 @@ test "inferModule with type application in signature" {
         .span = testSpan(),
     };
 
-    var module_types = try inferModule(&ctx, module);
+    var module_types = try inferModule(&ctx, module, null);
     defer module_types.deinit(alloc);
 
     // The signature gets parsed and converted correctly; the type error

--- a/tests/golden_test_runner.zig
+++ b/tests/golden_test_runner.zig
@@ -146,7 +146,7 @@ fn pipelineToCore(allocator: std.mem.Allocator, source: []const u8) ![]const u8 
     var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
     try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply);
     var infer_ctx = infer_mod.InferCtx.init(arena_alloc, &ty_env, &mv_supply, &u_supply, &diags);
-    var module_types = try infer_mod.inferModule(&infer_ctx, renamed);
+    var module_types = try infer_mod.inferModule(&infer_ctx, renamed, null);
     defer module_types.deinit(arena_alloc);
     if (diags.hasErrors()) return error.TypecheckError;
 

--- a/tests/repl/cli_e2e_tests.zig
+++ b/tests/repl/cli_e2e_tests.zig
@@ -15,6 +15,11 @@
 //! arrives in bulk via a pipe. This is tracked as a known issue and
 //! will be testable once the fix lands.
 //! tracked in: https://github.com/adinapoli/rusholme/issues/487
+//!
+//! NOTE: Issue #588 e2e tests (bare instance rejection, instance finding across REPL inputs)
+//! are blocked on multi-line REPL support. The bare instance case requires multi-line body,
+//! and the cross-REPL-inputs case requires class → data → instance → use workflow.
+//! Unit tests in repl_tests.zig cover these compilation checks.
 
 const std = @import("std");
 const testing = std.testing;

--- a/tests/repl/repl_tests.zig
+++ b/tests/repl/repl_tests.zig
@@ -757,6 +757,62 @@ test "repl: typeclass method call across inputs compiles (#578)" {
     try testing.expect(r4.compile.kind == .expression);
 }
 
+test "repl: bare instance without type should be rejected (#588)" {
+    // Bug 1 from issue #588: `instance ShowIt where ...` (bare class, no type arg)
+    // should be rejected by the compiler, not silently accepted.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var session = Session.init(alloc, testing_io) catch |err| {
+        std.debug.panic("Failed to init session: {}", .{err});
+    };
+    defer session.deinit();
+
+    _ = try session.processInput("class ShowIt a where\n  showIt :: a -> String");
+
+    // This should fail — `instance ShowIt where ...` has no type argument
+    if (session.processInput("instance ShowIt where\n  showIt _ = \"bug\"")) |_| {
+        std.debug.print("\n[#588-bug1] bare instance was ACCEPTED (bug still exists)\n", .{});
+        // This is the bug — bare instance should be rejected
+        try testing.expect(false);
+    } else |_| {
+        // Good — the bare instance was rejected
+    }
+}
+
+test "repl: showIt MkA reproduces issue #588" {
+    // Verify whether calling a typeclass method with a concrete argument
+    // still fails with "no instance for ShowIt A" (issue #588).
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var session = Session.init(alloc, testing_io) catch |err| {
+        std.debug.panic("Failed to init session: {}", .{err});
+    };
+    defer session.deinit();
+
+    _ = try session.processInput("class ShowIt a where\n  showIt :: a -> String");
+    _ = try session.processInput("data A = MkA");
+    _ = try session.processInput("instance ShowIt A where\n  showIt MkA = \"MkA\"");
+
+    // This is the exact scenario from issue #588.
+    // If it compiles, the "no instance" bug is fixed (even if dict-passing crashes at runtime).
+    // If it returns CompileError, the bug still exists.
+    if (session.processInput("showIt MkA")) |r| {
+        std.debug.print("\n[#588] showIt MkA compiled OK, kind={}\n", .{r.compile.kind});
+    } else |err| {
+        std.debug.print("\n[#588] showIt MkA FAILED: {}\n", .{err});
+        // Print diagnostics
+        for (session.last_diagnostics.items) |diag| {
+            std.debug.print("[#588] diag: {s}\n", .{diag.message});
+        }
+        // Fail the test to show the bug still exists
+        try testing.expect(false);
+    }
+}
+
 test "repl: bare class method does not segfault (#582)" {
     // Evaluating a bare class method (e.g. `showIt` without arguments)
     // must not cause a stack overflow / segfault. The dictionary-passing


### PR DESCRIPTION
Closes #588

## Summary

Fixed two bugs related to typeclass constraints in the REPL:

1. **Reject bare instance heads**: `instance ShowIt where ...` (without type argument) is now correctly rejected by the renamer.

2. **Preserve type constructor names across REPL inputs**: When a user defines a type in one REPL input and creates an instance in another, the instance's head type now uses the correct unique ID from the prior input, allowing the constraint solver to find the instance.

## Deliberables

- [x] Reject bare instance declarations (`instance ShowIt where ...`)
- [x] Enable instance finding across REPL inputs (e.g., class declared in input 1, data in input 2, instance in input 3)
- [x] Accumulate type constructor names with their correct unique IDs in `Session.accumulated_type_con_names`

## Implementation

**Bug 1 Fix**: Changed `decomposeInstanceHead()` in `src/renamer/renamer.zig` to return `null` for bare `.Con` cases, causing the renamer to emit "invalid instance head: expected 'Class Type'" error.

**Bug 2 Fix**: Added `accumulated_type_con_names` field to `Session` that maps base type names → `Name` values with correct unique IDs. This map is populated from data declarations (both from user inputs and Prelude) and passed through the pipeline as `external_type_con_names` to the typechecker where it's merged into the local `type_con_names` map.

## Known Limitations

- **Runtime execution fails**: While compilation now succeeds, executing `showIt MkA` will fail at runtime with "JIT session error: Symbols not found" because dictionary passing (#569) is not yet implemented. This is expected behavior per the issue description.

- **E2E tests blocked**: Full end-to-end tests for these bugs require multi-line REPL input (class → data → instance → use workflow), which is currently blocked by issue #487 (stdin pipe drops bytes). Unit tests in `repl_tests.zig` cover compilation checks.

## Testing

All 899 tests pass. Unit tests in `repl_tests.zig` verify:
- Bare instances compile-time rejection
- Instance finding across REPL inputs compiles successfully
