### PR TITLE
#569: Fix dictionary constructor unique duplication

### DIFF
--- a/src/core/desugar.zig
+++ b/src/core/desugar.zig
@@ -17,7 +17,7 @@ const DiagnosticCollector = diag_mod.DiagnosticCollector;
 
 pub const DesugarCtx = struct {
     alloc: std.mem.Allocator,
-    types: *const infer_mod.ModuleTypes,
+    types: *infer_mod.ModuleTypes,
     diags: *DiagnosticCollector,
     /// Used to generate fresh unique values for synthetic binders (lambda
     /// parameters created by the pattern-match compiler, constructor field
@@ -132,7 +132,7 @@ pub const DesugarResult = struct {
 pub fn desugarModule(
     alloc: std.mem.Allocator,
     module: renamer_mod.RenamedModule,
-    module_types: *const infer_mod.ModuleTypes,
+    module_types: *infer_mod.ModuleTypes,
     diags: *DiagnosticCollector,
     u_supply: *naming_mod.UniqueSupply,
     external_dict_names: ?*const DesugarCtx.DictNameMap,
@@ -692,6 +692,10 @@ fn desugarClassDecl(
             .rhs = lam_default,
         } });
     }
+
+    // Store the dictionary constructor name in ClassEnv so that instance
+    // declarations can reuse it (issue #569).
+    ctx.types.class_env.setDictConName(cd.name.unique.value, dict_con_name);
 }
 
 /// Desugar an instance declaration into a dictionary value binding.
@@ -706,11 +710,9 @@ fn desugarInstanceDecl(
     // Look up the class to know method order.
     const class_info = class_env.lookupClass(id_decl.class_name.unique.value) orelse return;
 
-    // Find the dictionary constructor name.  Convention: MkDict$<ClassName>.
-    const dict_con_name = Name{
-        .base = try std.fmt.allocPrint(alloc, "MkDict${s}", .{id_decl.class_name.base}),
-        .unique = ctx.u_supply.fresh(),
-    };
+    // Reuse the dictionary constructor name from the class declaration.
+    // This ensures all instances use the same constructor unique (issue #569).
+    const dict_con_name = class_info.dict_con_name;
 
     // Build an instance dictionary name.  Convention: dict$<ClassName>$<HeadType>.
     const head_name = try instanceHeadName(alloc, id_decl.instance_type);

--- a/src/typechecker/class_env.zig
+++ b/src/typechecker/class_env.zig
@@ -68,6 +68,10 @@ pub const ClassInfo = struct {
     superclasses: []const Name,
     /// Method signatures declared in the class body.
     methods: []const MethodInfo,
+    /// Dictionary constructor name (e.g. `MkDict$Eq`).
+    /// Stored during desugaring so that instance declarations can reuse
+    /// the same constructor unique instead of creating fresh ones (issue #569).
+    dict_con_name: Name,
 };
 
 /// A single method in a class declaration.
@@ -135,6 +139,16 @@ pub const ClassEnv = struct {
     /// Register a class declaration.
     pub fn addClass(self: *ClassEnv, info: ClassInfo) !void {
         try self.classes.put(self.alloc, info.name.unique.value, info);
+    }
+
+    /// Update the dictionary constructor name for an existing class.
+    /// Called by the desugarer after creating the dictionary data type.
+    /// Asserts that the class exists (should have been registered during type inference).
+    pub fn setDictConName(self: *ClassEnv, class_unique: u64, dict_con_name: Name) void {
+        const entry = self.classes.getPtr(class_unique) orelse {
+            std.debug.panic("setDictConName: class {d} not found in ClassEnv", .{class_unique});
+        };
+        entry.dict_con_name = dict_con_name;
     }
 
     /// Register an instance declaration.
@@ -235,6 +249,7 @@ test "ClassEnv: add and lookup class" {
     };
 
     try env.addClass(.{
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
         .name = Known.Class.Eq,
         .tyvar = 5000,
         .superclasses = &.{},
@@ -278,6 +293,7 @@ test "ClassEnv: superclass chain" {
 
     // class Eq a
     try env.addClass(.{
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
         .name = Known.Class.Eq,
         .tyvar = 5000,
         .superclasses = &.{},
@@ -286,6 +302,7 @@ test "ClassEnv: superclass chain" {
 
     // class Eq a => Ord a
     try env.addClass(.{
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
         .name = Known.Class.Ord,
         .tyvar = 5001,
         .superclasses = &.{Known.Class.Eq},
@@ -312,6 +329,7 @@ test "ClassEnv: lookupClassByBaseName finds registered class" {
     defer env.deinit();
 
     try env.addClass(.{
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
         .name = Known.Class.Eq,
         .tyvar = 5000,
         .superclasses = &.{},

--- a/src/typechecker/infer.zig
+++ b/src/typechecker/infer.zig
@@ -1963,6 +1963,8 @@ pub fn inferModule(
                     .tyvar = tyvar_id,
                     .superclasses = superclass_names,
                     .methods = method_infos,
+                    // Placeholder - will be set by desugarer when creating dictionary data type
+                    .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
                 });
             },
             .InstanceDecl => |id_decl| {
@@ -2953,6 +2955,7 @@ test "skolemiseSignature: forall with Eq constraint produces ClassConstraint" {
         .tyvar = 5000,
         .superclasses = &.{},
         .methods = &.{eq_method},
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
     });
 
     const AstType = @import("../frontend/ast.zig").Type;

--- a/src/typechecker/solver.zig
+++ b/src/typechecker/solver.zig
@@ -920,6 +920,7 @@ test "solve: class constraint with matching instance resolves to evidence" {
     defer class_env.deinit();
 
     try class_env.addClass(.{
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
         .name = Known.Class.Eq,
         .tyvar = 5000,
         .superclasses = &.{},
@@ -959,6 +960,7 @@ test "solve: class constraint with no matching instance emits missing_instance" 
     defer class_env.deinit();
 
     try class_env.addClass(.{
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
         .name = Known.Class.Eq,
         .tyvar = 5000,
         .superclasses = &.{},
@@ -991,6 +993,7 @@ test "solve: class constraint with rigid type defers (no error)" {
     defer class_env.deinit();
 
     try class_env.addClass(.{
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
         .name = Known.Class.Eq,
         .tyvar = 5000,
         .superclasses = &.{},
@@ -1024,6 +1027,7 @@ test "solve: mixed Eq and Class constraints both resolved" {
     defer class_env.deinit();
 
     try class_env.addClass(.{
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
         .name = Known.Class.Eq,
         .tyvar = 5000,
         .superclasses = &.{},
@@ -1080,6 +1084,7 @@ test "solve: parametric instance with context resolves recursively" {
     defer class_env.deinit();
 
     try class_env.addClass(.{
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
         .name = Known.Class.Eq,
         .tyvar = 5000,
         .superclasses = &.{},
@@ -1151,6 +1156,7 @@ test "solve: parametric instance with missing context emits diagnostic" {
     defer class_env.deinit();
 
     try class_env.addClass(.{
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
         .name = Known.Class.Eq,
         .tyvar = 5000,
         .superclasses = &.{},
@@ -1203,6 +1209,7 @@ test "solve: nested parametric resolution (Eq [[Int]])" {
     defer class_env.deinit();
 
     try class_env.addClass(.{
+        .dict_con_name = .{ .base = "", .unique = .{ .value = 0 } },
         .name = Known.Class.Eq,
         .tyvar = 5000,
         .superclasses = &.{},


### PR DESCRIPTION
Fixes the root cause identified in issue #569 by ensuring dictionary constructors use consistent unique IDs across class and instance declarations.

## Summary

PR #596 attempted to fix #569 by adding field type tracking, but it didn't address the underlying issue: the desugarer was creating **fresh uniques** for dictionary constructors in each instance declaration instead of reusing the constructor from the class declaration.

This PR fixes the actual root cause.

## Problem

Before this fix:
```
data Dict$Eq_1007 a = (MkDict$Eq_1008 :: ...)
(dict$Eq$Int_1014 :: MkDict$Eq_1013) = MkDict$Eq_1013 eqInt_1000
```

The constructor `MkDict$Eq` appeared with **two different uniques** (1008 from the data declaration, 1013 in the instance). This caused:
1. The GRIN translator to not recognize unique 1013 as a constructor (not in `con_map`)
2. GRIN to emit a **function call** instead of a constructor allocation
3. Linker errors: `undefined reference to MkDict$Eq_1013`

## Solution

- Add `dict_con_name: Name` field to `ClassInfo` to store the constructor name
- Update `desugarClassDecl` to save the constructor name in `ClassEnv` after creating it
- Update `desugarInstanceDecl` to **reuse** the stored constructor instead of creating a fresh one
- Make `DesugarCtx.types` mutable (change from `*const` to `*`) so `ClassEnv` can be updated

After this fix:
```
data Dict$Eq_1007 a = (MkDict$Eq_1008 :: ...)
(dict$Eq$Int_1013 :: MkDict$Eq_1008) = MkDict$Eq_1008 eqInt_1000
```

Both the type annotation and the value now use **the same unique (1008)**.

## GRIN Output

Before:
```grin
dict$Eq$Int_1014 =
  MkDict$Eq_1013 eqInt_1000  # Function call - wrong!
```

After:
```grin
dict$Eq$Int_1013 =
  store (CMkDict$Eq_1008 eqInt_1000) ;  # Constructor allocation - correct!
  \node ->
    pure node
```

## Test Results

✅ All 899 existing tests pass

## Remaining Issues

This fix resolves the constructor unique duplication, but **does not** fully close #569 because:

1. **Dictionary argument insertion is incomplete**: The test case `1 == 2` should desugar to `==_1002 dict$Eq$Int 1 2`, but the dictionary argument is missing. This causes the GRIN partial application to be wrong.

2. **LLVM OutOfMemory error**: The native compilation still fails with `error.OutOfMemory`, which is likely a catch-all error masking an underlying LLVM codegen issue.

These are **separate issues** from the constructor unique duplication and should be tracked independently. This PR fixes the most critical issue blocking dictionary-passing translation.

## Files Modified

- `src/typechecker/class_env.zig` - Add `dict_con_name` field and `setDictConName` method
- `src/typechecker/infer.zig` - Initialize `dict_con_name` when creating `ClassInfo`
- `src/core/desugar.zig` - Store and reuse dictionary constructor names
- `src/typechecker/solver.zig` - Initialize `dict_con_name` in test code
