### PR TITLE
#609: Implement string-as-[Char] and Prelude loading for native JIT REPL

### DIFF
--- a/lib/Prelude.hs
+++ b/lib/Prelude.hs
@@ -9,7 +9,7 @@ module Prelude
     , map, filter, (++), head, tail, null, length
     , foldr, foldl, concat, take, drop
     , maybe, fromMaybe, either
-    , putStrLn, putStr
+    , putChar, putStr, putStrLn
     , error
     ) where
 
@@ -30,6 +30,7 @@ foreign import prim "lt_Int"    primLtInt    :: Int -> Int -> Bool
 foreign import prim "le_Int"    primLeInt    :: Int -> Int -> Bool
 foreign import prim "gt_Int"    primGtInt    :: Int -> Int -> Bool
 foreign import prim "ge_Int"    primGeInt    :: Int -> Int -> Bool
+foreign import prim "putChar"   primPutChar  :: Char -> IO ()
 foreign import prim "putStrLn"  primPutStrLn :: String -> IO ()
 foreign import prim "putStr"    primPutStr   :: String -> IO ()
 foreign import prim "error"     primError    :: String -> a
@@ -78,6 +79,9 @@ error = primError
 -- ========================================================================
 -- IO wrappers
 -- ========================================================================
+
+putChar :: Char -> IO ()
+putChar = primPutChar
 
 putStrLn :: String -> IO ()
 putStrLn = primPutStrLn

--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -48,6 +48,18 @@ const rts_node = @import("../rts/node.zig");
 const llvm = @import("llvm.zig");
 const c = llvm.c;
 
+/// Well-known constructor discriminants captured from the tag table.
+/// Used by the JIT engine to format results correctly.
+pub const KnownTags = struct {
+    true_disc: ?i64 = null,
+    false_disc: ?i64 = null,
+    nil_disc: ?i64 = null,
+    cons_disc: ?i64 = null,
+    nothing_disc: ?i64 = null,
+    just_disc: ?i64 = null,
+    unit_disc: ?i64 = null,
+};
+
 // Known Prelude constants with stable unique IDs
 // These are used when variables reference Prelude literals like True, False, etc.
 const known = struct {
@@ -107,6 +119,16 @@ const PrimOpMapping = struct {
                     .return_kind = .i32,
                     .param_kinds = &.{.ptr},
                     .arg_strategy = .string_to_global_ptr,
+                },
+            };
+        }
+        if (std.mem.eql(u8, name.base, "putChar")) {
+            return .{
+                .libcall = .{
+                    .name = "rts_putChar",
+                    .return_kind = .i32,
+                    .param_kinds = &.{.i64},
+                    .arg_strategy = .value_passthrough,
                 },
             };
         }
@@ -263,6 +285,11 @@ const TagTable = struct {
     partial_tags: std.AutoHashMapUnmanaged(u64, void),
     /// Maps P-tag composite keys to their tag info (name + missing count + field count).
     partial_tag_info: std.AutoHashMapUnmanaged(u64, PartialTagInfo),
+    /// Maps constructor base name strings to their discriminants.
+    /// Populated during register() for Con tags. Used by findByName()
+    /// to look up well-known constructors (True, False, [], (:), etc.)
+    /// regardless of which unique ID the renamer assigned.
+    con_name_to_disc: std.StringHashMapUnmanaged(i64),
     /// Next discriminant to assign.
     next: i64,
 
@@ -271,6 +298,11 @@ const TagTable = struct {
         missing: u32,
         n_fields: u32,
     };
+
+    // Start discriminants at 0x1000 to avoid colliding with RTS special
+    // tags (Unit=0, Int=1, Char=2, String=3, Thunk=0x100, Ind=0x101,
+    // Closure=0x200). This matches rts/node.zig Tag.Data = 0x1000.
+    const first_discriminant: i64 = 0x1000;
 
     fn init() TagTable {
         return .{
@@ -281,7 +313,8 @@ const TagTable = struct {
             .fun_tag_names = .{},
             .partial_tags = .{},
             .partial_tag_info = .{},
-            .next = 0,
+            .con_name_to_disc = .{},
+            .next = first_discriminant,
         };
     }
 
@@ -298,6 +331,7 @@ const TagTable = struct {
         self.fun_tag_names.deinit(alloc);
         self.partial_tags.deinit(alloc);
         self.partial_tag_info.deinit(alloc);
+        self.con_name_to_disc.deinit(alloc);
     }
 
     /// Compute a composite key that distinguishes tag types sharing
@@ -330,6 +364,10 @@ const TagTable = struct {
         const types = try alloc.alloc(FieldType, n_fields);
         for (types) |*t| t.* = .ptr;
         try self.field_types.put(alloc, key, types);
+        // Track Con-tags by base name for reverse lookup (findByName).
+        if (tag.tag_type == .Con) {
+            try self.con_name_to_disc.put(alloc, tag.name.base, self.next);
+        }
         // Track F-tags for the inline eval loop in translateCase.
         if (tag.tag_type == .Fun) {
             try self.fun_tags.put(alloc, key, {});
@@ -378,6 +416,38 @@ const TagTable = struct {
         const con_key = name.unique.value *% 4; // Con key encoding
         return self.discriminants.get(con_key);
     }
+    
+    /// Find a constructor discriminant by base name string.
+    /// Returns the discriminant if a constructor with this name exists in the table.
+    /// Used for well-known constructors (True, False, [], (:), etc.) whose
+    /// unique IDs vary between compilation contexts (the renamer assigns fresh
+    /// uniques to data declaration constructors).
+    fn findByName(self: *const TagTable, name_base: []const u8) ?i64 {
+        return self.con_name_to_disc.get(name_base);
+    }
+
+    /// Ensure list constructors ([] and (:)) are registered in the tag table.
+    /// These are needed whenever string literals appear in the program, because
+    /// strings are converted to [Char] lists at runtime via rts_cstring_to_charlist.
+    /// If a program doesn't explicitly use list constructors in GRIN patterns,
+    /// they won't be found by the tag scanner — this method fills that gap
+    /// using the well-known unique IDs from naming/known.zig.
+    fn ensureListConstructors(self: *TagTable, alloc: std.mem.Allocator) !void {
+        if (self.con_name_to_disc.get("[]") == null) {
+            const nil_tag = grin.Tag{
+                .tag_type = .Con,
+                .name = .{ .base = "[]", .unique = .{ .value = known.nil_val } },
+            };
+            try self.register(alloc, nil_tag, 0);
+        }
+        if (self.con_name_to_disc.get("(:)") == null) {
+            const cons_tag = grin.Tag{
+                .tag_type = .Con,
+                .name = .{ .base = "(:)", .unique = .{ .value = known.cons_val } },
+            };
+            try self.register(alloc, cons_tag, 2);
+        }
+    }
 
     /// Ensure that intermediate partial tags exist for the apply function.
     /// If the program contains `P(n)func` with `n > 1`, the apply function
@@ -411,6 +481,8 @@ fn buildTagTable(alloc: std.mem.Allocator, program: grin.Program) !TagTable {
     for (program.defs) |def| {
         try scanExprForTags(alloc, def.body, &table);
     }
+    // Ensure list constructors are available for string↔[Char] conversion.
+    try table.ensureListConstructors(alloc);
 
     // Merge constructor field types from the GRIN program's field_types map.
     // This allows dictionary constructors with function-typed fields to be
@@ -675,6 +747,23 @@ pub const GrinTranslator = struct {
         llvm.disposeContext(self.ctx);
     }
 
+    /// Extract the tag discriminants for well-known constructors
+    /// (True, False, [], (:), etc.) from the current tag table.
+    /// Used by the JIT engine to format results correctly.
+    pub fn getKnownTagDiscriminants(self: *const GrinTranslator) KnownTags {
+        // Look up by name base instead of unique ID, since different compilation
+        // contexts may assign different uniques to the same constructor.
+        return .{
+            .true_disc = self.tag_table.findByName("True"),
+            .false_disc = self.tag_table.findByName("False"),
+            .nil_disc = self.tag_table.findByName("[]"),
+            .cons_disc = self.tag_table.findByName("(:)"),
+            .nothing_disc = self.tag_table.findByName("Nothing"),
+            .just_disc = self.tag_table.findByName("Just"),
+            .unit_disc = self.tag_table.findByName("()"),
+        };
+    }
+
     /// Returns true if `base` is an entry-point name — either the standard
     /// "main" or the REPL-specific entry point set via `repl_entry_point`.
     fn isEntryPoint(self: *const GrinTranslator, base: []const u8) bool {
@@ -702,7 +791,7 @@ pub const GrinTranslator = struct {
             unit_disc,
             c.LLVMConstInt(llvm.i32Type(), 0, 0), // n_fields = 0
         };
-        const node_ptr = c.LLVMBuildCall2(
+        return c.LLVMBuildCall2(
             self.builder,
             llvm.getFunctionType(rts_alloc_fn),
             rts_alloc_fn,
@@ -710,7 +799,6 @@ pub const GrinTranslator = struct {
             2,
             "unit",
         );
-        return c.LLVMBuildPtrToInt(self.builder, node_ptr, llvm.i64Type(), "unit_i64");
     }
 
     /// Translate the entire GRIN program into the LLVM module.
@@ -718,15 +806,41 @@ pub const GrinTranslator = struct {
     /// The module is owned by this translator's context — do not dispose it
     /// separately; it is freed when the translator is deinited.
     pub fn translateProgramToModule(self: *GrinTranslator, program: grin.Program) TranslationError!llvm.Module {
-        // Build the tag table once before any translation.
-        self.tag_table = buildTagTable(self.allocator, program) catch return error.OutOfMemory;
-        // Also scan extra defs (from prior REPL sessions) for tag
-        // registration. These defs are NOT translated — they were
-        // already compiled in a previous JIT session — but their tags
-        // must be known so that forceValueToWhnf can handle thunks
-        // created by those functions.
+        // Build the tag table by scanning extra defs FIRST (from prior
+        // REPL sessions like the Prelude), then the current program.
+        // Order matters: scanning extra defs first ensures that
+        // constructors from prior sessions receive the same discriminants
+        // they had when they were originally compiled. If we scanned the
+        // current program first, its constructors would claim discriminants
+        // 0, 1, 2... and prior session constructors would get different
+        // values, causing tag mismatches at runtime (e.g. [] gets
+        // discriminant 5 in the Prelude but 0 in the expression).
+        self.tag_table = TagTable.init();
         for (self.extra_tag_defs) |def| {
             scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
+        }
+        // Now scan the current program's defs. Tags already registered
+        // by extra_tag_defs are skipped (register is idempotent), so
+        // shared constructors keep their prior discriminants.
+        for (program.defs) |def| {
+            scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
+        }
+        // Ensure list constructors are available for string↔[Char] conversion.
+        self.tag_table.ensureListConstructors(self.allocator) catch return error.OutOfMemory;
+        // Merge constructor field types from the GRIN program's field_types map.
+        {
+            var iter = program.field_types.iterator();
+            while (iter.next()) |entry| {
+                const unique = entry.key_ptr.*;
+                const field_types = entry.value_ptr.*;
+                const key = unique *% 4;
+                if (self.tag_table.field_types.get(key)) |existing| {
+                    self.allocator.free(existing);
+                }
+                const types = self.allocator.alloc(FieldType, field_types.len) catch return error.OutOfMemory;
+                @memcpy(types, field_types);
+                self.tag_table.field_types.put(self.allocator, key, types) catch return error.OutOfMemory;
+            }
         }
         // Link TypeEnv to the tag table for field type lookups.
         self.type_env.setTagTable(&self.tag_table);
@@ -787,7 +901,21 @@ pub const GrinTranslator = struct {
     /// Any previously held tag table is released.
     pub fn prepareGlobalTagTable(self: *GrinTranslator, all_prog: grin.Program) TranslationError!void {
         self.tag_table.deinit(self.allocator);
-        self.tag_table = buildTagTable(self.allocator, all_prog) catch return error.OutOfMemory;
+        // Scan extra_tag_defs FIRST (from prior REPL sessions like the
+        // Prelude), then the current program's defs. Order matters:
+        // scanning extra defs first ensures discriminant assignments are
+        // consistent with expression compilations that also use
+        // extra_tag_defs. Tags already registered are idempotent, so
+        // shared tags keep their prior discriminants.
+        self.tag_table = TagTable.init();
+        for (self.extra_tag_defs) |def| {
+            scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
+        }
+        for (all_prog.defs) |def| {
+            scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
+        }
+        // Ensure list constructors are available for string↔[Char] conversion.
+        self.tag_table.ensureListConstructors(self.allocator) catch return error.OutOfMemory;
         // TypeEnv pointer is refreshed inside translateModuleGrin before each
         // module translation (needed because the tag_table field was reassigned).
     }
@@ -908,7 +1036,8 @@ pub const GrinTranslator = struct {
                             // IO primops return a null pointer placeholder
                             // (see translateAppToValue). Treat as Unit.
                             if (c.LLVMIsAConstantPointerNull(val) != null) {
-                                _ = llvm.buildRet(self.builder, self.buildUnitNode());
+                                const unit_ptr = self.buildUnitNode();
+                                _ = llvm.buildRet(self.builder, c.LLVMBuildPtrToInt(self.builder, unit_ptr, llvm.i64Type(), "unit_i64"));
                             } else {
                                 // Force any F-tagged thunks to WHNF before
                                 // returning. The user expects REPL results
@@ -924,20 +1053,25 @@ pub const GrinTranslator = struct {
                             _ = llvm.buildRet(self.builder, val);
                         }
                     } else {
-                        // Non-REPL function: force thunks before returning.
+                        // Non-REPL function: ensure return value matches function signature.
+                        // Primop instructions return i64, but user functions return ptr.
+                        // Cast i64→ptr to match the declared return type.
                         const val_kind2 = c.LLVMGetTypeKind(c.LLVMTypeOf(val));
-                        const forced = if (val_kind2 == c.LLVMPointerTypeKind)
+                        const coerced = if (val_kind2 == c.LLVMPointerTypeKind)
                             self.callForceIfNeeded(val)
+                        else if (val_kind2 == c.LLVMIntegerTypeKind)
+                            c.LLVMBuildIntToPtr(self.builder, val, ptrType(), "ret_as_ptr")
                         else
                             val;
-                        _ = llvm.buildRet(self.builder, forced);
+                        _ = llvm.buildRet(self.builder, coerced);
                     }
                 } else {
                     if (is_repl_entry) {
                         // Body returned no value (e.g. IO action) —
                         // return a Unit heap node so the REPL displays
                         // nothing rather than a random integer.
-                        _ = llvm.buildRet(self.builder, self.buildUnitNode());
+                        const unit_ptr2 = self.buildUnitNode();
+                        _ = llvm.buildRet(self.builder, c.LLVMBuildPtrToInt(self.builder, unit_ptr2, llvm.i64Type(), "unit_i64"));
                     } else {
                         _ = llvm.buildRet(self.builder, c.LLVMConstPointerNull(value_type));
                     }
@@ -952,7 +1086,8 @@ pub const GrinTranslator = struct {
                 if (is_repl_entry) {
                     // REPL entry point: return a Unit heap node so
                     // formatJitResult can distinguish unit from boolean False.
-                    _ = llvm.buildRet(self.builder, self.buildUnitNode());
+                    const unit_ptr3 = self.buildUnitNode();
+                    _ = llvm.buildRet(self.builder, c.LLVMBuildPtrToInt(self.builder, unit_ptr3, llvm.i64Type(), "unit_i64"));
                 } else if (is_entry) {
                     // Native main: return 0 (success exit code, C ABI).
                     _ = llvm.buildRet(self.builder, c.LLVMConstInt(llvm.i32Type(), 0, 0));
@@ -1335,7 +1470,20 @@ pub const GrinTranslator = struct {
 
         var llvm_args: [8]llvm.Value = undefined;
         for (args[0..@min(args.len, 8)], 0..) |val, i| {
-            llvm_args[i] = try self.translateValToLlvm(val);
+            llvm_args[i] = switch (libc_fn.arg_strategy) {
+                // For primops that expect C strings: string literals are passed
+                // directly as global string pointers (avoiding a round-trip through
+                // [Char] lists). Variables are assumed to be [Char] lists (the
+                // Haskell representation of String) and are converted via the RTS.
+                .string_to_global_ptr => switch (val) {
+                    .Lit => |lit| switch (lit) {
+                        .String => |s| try self.translateStringLitToPtr(s),
+                        else => try self.translateValToLlvm(val),
+                    },
+                    else => self.emitCharlistToCstring(try self.translateValToLlvm(val)),
+                },
+                .value_passthrough => try self.translateValToLlvm(val),
+            };
         }
 
         const actual_args = llvm_args[0..args.len];
@@ -1346,6 +1494,78 @@ pub const GrinTranslator = struct {
             @ptrCast(actual_args.ptr),
             @intCast(args.len),
             "",
+        );
+    }
+
+    /// Emit a call to rts_charlist_to_cstring to convert a [Char] heap list
+    /// to a null-terminated C string pointer.
+    fn emitCharlistToCstring(self: *GrinTranslator, list_val: llvm.Value) llvm.Value {
+        // Declare rts_charlist_to_cstring if not already declared
+        const conv_fn = blk: {
+            const existing = c.LLVMGetNamedFunction(self.module, "rts_charlist_to_cstring");
+            if (existing) |f| break :blk f;
+            // Signature: ptr rts_charlist_to_cstring(ptr list, i64 cons_disc, i64 nil_disc)
+            var param_types = [_]llvm.Type{ ptrType(), llvm.i64Type(), llvm.i64Type() };
+            const ft = c.LLVMFunctionType(ptrType(), &param_types, 3, 0);
+            break :blk llvm.addFunction(self.module, "rts_charlist_to_cstring", ft);
+        };
+
+        // Look up the (:) and [] discriminants from the tag table
+        const cons_disc: i64 = self.tag_table.findByName("(:)") orelse 0;
+        const nil_disc: i64 = self.tag_table.findByName("[]") orelse 0;
+
+        // Ensure list_val is a pointer (it may be an i64 if from PtrToInt)
+        const list_ptr = if (c.LLVMGetTypeKind(c.LLVMTypeOf(list_val)) == c.LLVMIntegerTypeKind)
+            c.LLVMBuildIntToPtr(self.builder, list_val, ptrType(), "list_ptr")
+        else
+            list_val;
+
+        var call_args = [_]llvm.Value{
+            list_ptr,
+            c.LLVMConstInt(llvm.i64Type(), @bitCast(cons_disc), 0),
+            c.LLVMConstInt(llvm.i64Type(), @bitCast(nil_disc), 0),
+        };
+        return c.LLVMBuildCall2(
+            self.builder,
+            c.LLVMGlobalGetValueType(conv_fn),
+            conv_fn,
+            &call_args,
+            3,
+            "cstr",
+        );
+    }
+
+    /// Emit a call to rts_cstring_to_charlist to convert a C string pointer
+    /// to a [Char] heap list (Cons/Nil linked list).
+    ///
+    /// Called when a string literal value needs to be represented as a [Char]
+    /// list at runtime (e.g., when passed to a user-defined function that
+    /// pattern-matches on list constructors).
+    fn emitCstringToCharlist(self: *GrinTranslator, str_val: llvm.Value) llvm.Value {
+        const conv_fn = blk: {
+            const existing = c.LLVMGetNamedFunction(self.module, "rts_cstring_to_charlist");
+            if (existing) |f| break :blk f;
+            // Signature: ptr rts_cstring_to_charlist(ptr str, i64 cons_disc, i64 nil_disc)
+            var param_types = [_]llvm.Type{ ptrType(), llvm.i64Type(), llvm.i64Type() };
+            const ft = c.LLVMFunctionType(ptrType(), &param_types, 3, 0);
+            break :blk llvm.addFunction(self.module, "rts_cstring_to_charlist", ft);
+        };
+
+        const cons_disc: i64 = self.tag_table.findByName("(:)") orelse 0;
+        const nil_disc: i64 = self.tag_table.findByName("[]") orelse 0;
+
+        var call_args = [_]llvm.Value{
+            str_val,
+            c.LLVMConstInt(llvm.i64Type(), @bitCast(cons_disc), 0),
+            c.LLVMConstInt(llvm.i64Type(), @bitCast(nil_disc), 0),
+        };
+        return c.LLVMBuildCall2(
+            self.builder,
+            c.LLVMGlobalGetValueType(conv_fn),
+            conv_fn,
+            &call_args,
+            3,
+            "charlist",
         );
     }
 
@@ -1362,7 +1582,12 @@ pub const GrinTranslator = struct {
         // Unary instructions (neg_Int, abs_Int)
         if (instr == .neg or instr == .abs) {
             if (args.len < 1) return error.UnsupportedGrinVal;
-            const operand = try self.translateValToLlvm(args[0]);
+            const operand_raw = try self.translateValToLlvm(args[0]);
+            // Coerce operand to i64 if it's a pointer
+            const operand = if (c.LLVMGetTypeKind(c.LLVMTypeOf(operand_raw)) == c.LLVMPointerTypeKind)
+                c.LLVMBuildPtrToInt(self.builder, operand_raw, llvm.i64Type(), "operand_i64")
+            else
+                operand_raw;
             return switch (instr) {
                 .neg => c.LLVMBuildNeg(self.builder, operand, "neg"),
                 .abs => blk: {
@@ -1452,14 +1677,25 @@ pub const GrinTranslator = struct {
         );
     }
 
+    /// Translate a GRIN string literal to an LLVM global string pointer.
+    /// Used by emitLibcCall for primops that expect C strings.
+    fn translateStringLitToPtr(self: *GrinTranslator, s: []const u8) TranslationError!llvm.Value {
+        const s_z = self.allocator.dupeZ(u8, s) catch return error.OutOfMemory;
+        defer self.allocator.free(s_z);
+        return c.LLVMBuildGlobalStringPtr(self.builder, s_z.ptr, ".str") orelse
+            return error.OutOfMemory;
+    }
+
     fn translateValToLlvm(self: *GrinTranslator, val: grin.Val) TranslationError!llvm.Value {
         return switch (val) {
             .Lit => |lit| switch (lit) {
                 .String => |s| blk: {
-                    const s_z = self.allocator.dupeZ(u8, s) catch return error.OutOfMemory;
-                    defer self.allocator.free(s_z);
-                    break :blk c.LLVMBuildGlobalStringPtr(self.builder, s_z.ptr, ".str") orelse
-                        return error.OutOfMemory;
+                    // Convert string literal to [Char] heap list at runtime.
+                    // This ensures strings are always represented as proper Haskell
+                    // lists, making pattern matching (e.g., in ++) work correctly.
+                    // Primop boundaries use translateStringLitToPtr for C string access.
+                    const str_ptr = try self.translateStringLitToPtr(s);
+                    break :blk self.emitCstringToCharlist(str_ptr);
                 },
                 .Int => |i| c.LLVMConstInt(llvm.i64Type(), @bitCast(@as(i64, i)), 1),
                 .Float => |f| c.LLVMConstReal(c.LLVMDoubleType(), f),
@@ -1473,18 +1709,31 @@ pub const GrinTranslator = struct {
                 if (self.params.get(name.unique.value)) |v| break :blk v;
                 // 2. Nullary constructor: emit its tag discriminant as an i64.
                 //    Tracked in: https://github.com/adinapoli/rusholme/issues/410
-                // 2. Check if variable is a known Prelude constant (True, False, None, etc.)
-                //    These have stable unique IDs and should be emitted as literals.
-                switch (name.unique.value) {
-                    known.true_val, known.false_val => break :blk c.LLVMConstInt(llvm.i64Type(), @bitCast(@as(i64, if (name.unique.value == known.true_val) 1 else 0)), 1),
-                    known.unit_val => break :blk self.buildUnitNode(),
-                    else => {},
+                // 2. Check if variable is a known Prelude constant.
+                //    Unit is special: always returns a heap node so the REPL can
+                //    distinguish "no value" from integer 0.
+                if (name.unique.value == known.unit_val) {
+                    break :blk self.buildUnitNode();
                 }
 
                 // 2b. If not a known literal, check tag discriminant for nullary constructors.
+                //    Allocate a heap node so that the REPL and case analysis can
+                //    distinguish constructors from integer literals by type (ptr vs i64).
                 //    Tracked in: https://github.com/adinapoli/rusholme/issues/410
                 if (self.tag_table.discriminantByName(name)) |disc| {
-                    break :blk c.LLVMConstInt(llvm.i64Type(), @bitCast(disc), 0);
+                    const alloc_fn = declareRtsAlloc(self.module);
+                    var alloc_args2 = [_]llvm.Value{
+                        c.LLVMConstInt(llvm.i64Type(), @bitCast(disc), 0),
+                        c.LLVMConstInt(llvm.i32Type(), 0, 0),
+                    };
+                    break :blk c.LLVMBuildCall2(
+                        self.builder,
+                        llvm.getFunctionType(alloc_fn),
+                        alloc_fn,
+                        &alloc_args2,
+                        2,
+                        "nullary_node",
+                    );
                 }
                 // 3. Top-level function reference: look up the LLVM function by
                 //    full name (base + unique suffix) and return its pointer (for
@@ -1519,12 +1768,27 @@ pub const GrinTranslator = struct {
                 return error.UnsupportedGrinVal;
             },
             .ValTag => |t| blk: {
-                // Bare tag value — emit its discriminant as i64.
+                // Bare tag value — allocate a heap node with 0 fields.
+                // Using a heap node (pointer) rather than a bare i64 discriminant
+                // lets the REPL and case analysis distinguish constructors from
+                // integer literals by LLVM type (ptr vs i64).
                 const disc = self.tag_table.discriminant(t) orelse {
                     std.debug.print("UnsupportedGrinVal: ValTag {s} not in tag table\n", .{t.name.base});
                     return error.UnsupportedGrinVal;
                 };
-                break :blk c.LLVMConstInt(llvm.i64Type(), @bitCast(disc), 0);
+                const alloc_fn = declareRtsAlloc(self.module);
+                var alloc_args2 = [_]llvm.Value{
+                    c.LLVMConstInt(llvm.i64Type(), @bitCast(disc), 0),
+                    c.LLVMConstInt(llvm.i32Type(), 0, 0),
+                };
+                break :blk c.LLVMBuildCall2(
+                    self.builder,
+                    llvm.getFunctionType(alloc_fn),
+                    alloc_fn,
+                    &alloc_args2,
+                    2,
+                    "valtag_node",
+                );
             },
         };
     }
@@ -1558,30 +1822,11 @@ pub const GrinTranslator = struct {
                 // already i64.  No boxing via alloca is needed — the RTS field
                 // slots are plain u64.
                 //
-                // For nullary constructors (ValTag), we need to box them first
-                // since fields must be pointers to heap nodes.
-                // See: https://github.com/adinapuli/rusholme/issues/449
+                // Nullary constructors (ValTag) are already heap-allocated nodes
+                // from translateValToLlvm, so they flow through the pointer path.
                 const rts_store_fn = declareRtsStoreField(self.module);
                 for (ctn.fields, 0..) |field, fi| {
-                    // Check if field is a nullary constructor that needs boxing
-                    const raw_val: llvm.Value = if (field == .ValTag) blk: {
-                        // Box the nullary constructor: allocate a node with tag but 0 fields
-                        const field_tag = field.ValTag;
-                        const field_disc = self.tag_table.discriminant(field_tag) orelse return error.UnsupportedGrinVal;
-                        const field_alloc_fn = declareRtsAlloc(self.module);
-                        var field_alloc_args = [_]llvm.Value{
-                            c.LLVMConstInt(llvm.i64Type(), @bitCast(field_disc), 0),
-                            c.LLVMConstInt(llvm.i32Type(), 0, 0), // n_fields = 0
-                        };
-                        break :blk c.LLVMBuildCall2(
-                            self.builder,
-                            llvm.getFunctionType(field_alloc_fn),
-                            field_alloc_fn,
-                            &field_alloc_args,
-                            2,
-                            "boxed_field",
-                        );
-                    } else try self.translateValToLlvm(field);
+                    const raw_val: llvm.Value = try self.translateValToLlvm(field);
 
                     const field_ty = c.LLVMTypeOf(raw_val);
                     const kind = c.LLVMGetTypeKind(field_ty);
@@ -2427,29 +2672,11 @@ pub const GrinTranslator = struct {
                     // Main returns i32 so no conversion needed — it falls
                     // through to the default buildRet below.
                     if (is_int) {
-                        if (val == .ValTag) {
-                            // Allocate a node with tag but 0 fields
-                            const rts_alloc_fn = declareRtsAlloc(self.module);
-                            var alloc_args = [_]llvm.Value{
-                                llvm_val, // tag discriminant as i64
-                                c.LLVMConstInt(llvm.i32Type(), 0, 0), // n_fields = 0
-                            };
-                            const node_ptr = c.LLVMBuildCall2(
-                                self.builder,
-                                llvm.getFunctionType(rts_alloc_fn),
-                                rts_alloc_fn,
-                                &alloc_args,
-                                2,
-                                "boxed_tag",
-                            );
-                            _ = llvm.buildRet(self.builder, node_ptr);
-                            return;
-                        } else {
-                            // For other i64 values, use inttoptr
-                            const converted = c.LLVMBuildIntToPtr(self.builder, llvm_val, ptrType(), "ret_as_ptr");
-                            _ = llvm.buildRet(self.builder, converted);
-                            return;
-                        }
+                        // Integer values (e.g. primop results) need inttoptr
+                        // to match the ptr return type of non-entry functions.
+                        const converted = c.LLVMBuildIntToPtr(self.builder, llvm_val, ptrType(), "ret_as_ptr");
+                        _ = llvm.buildRet(self.builder, converted);
+                        return;
                     }
                 }
                 // Native main: fall through to default buildRet (returns i32 as-is).
@@ -3096,8 +3323,8 @@ test "TagTable: register and discriminant" {
     try table.register(alloc, nil_tag, 0);
     try table.register(alloc, cons_tag, 2);
 
-    try std.testing.expectEqual(@as(?i64, 0), table.discriminant(nil_tag));
-    try std.testing.expectEqual(@as(?i64, 1), table.discriminant(cons_tag));
+    try std.testing.expectEqual(@as(?i64, 0x1000), table.discriminant(nil_tag));
+    try std.testing.expectEqual(@as(?i64, 0x1001), table.discriminant(cons_tag));
     try std.testing.expectEqual(@as(?u32, 0), table.fieldCount(nil_tag));
     try std.testing.expectEqual(@as(?u32, 2), table.fieldCount(cons_tag));
 }
@@ -3128,7 +3355,7 @@ test "TagTable: idempotent re-registration" {
     try table.register(alloc, tag, 1);
     try table.register(alloc, tag, 1); // second call must not change discriminant
 
-    try std.testing.expectEqual(@as(?i64, 0), table.discriminant(tag));
+    try std.testing.expectEqual(@as(?i64, 0x1000), table.discriminant(tag));
 }
 
 test "Store emits rts_alloc and rts_store_field instead of malloc" {

--- a/src/core/desugar.zig
+++ b/src/core/desugar.zig
@@ -1391,7 +1391,6 @@ pub fn desugarExpr(ctx: *DesugarCtx, expr: renamer_mod.RExpr) std.mem.Allocator.
             }
         },
         .Lit => |l| {
-            // In a complete compiler, we'd lookup Enum types based on Literal variant.
             node.* = .{ .Lit = .{ .val = desugarLiteral(l), .span = l.getSpan() } };
         },
         .App => |a| {

--- a/src/grin/primop.zig
+++ b/src/grin/primop.zig
@@ -57,6 +57,10 @@ pub const PrimOp = enum(u16) {
     /// Type: String -> IO ()
     putStrLn_ = 3,
 
+    /// Write a single character to stdout.
+    /// Type: Char -> IO ()
+    putChar_ = 4,
+
     // ═══════════════════════════════════════════════════════════════════════
     // Integer Arithmetic (100-149)
     // ═══════════════════════════════════════════════════════════════════════
@@ -257,6 +261,7 @@ pub const PrimOp = enum(u16) {
             .write_stderr => "write_stderr",
             .read_stdin => "read_stdin",
             .putStrLn_ => "putStrLn_",
+            .putChar_ => "putChar_",
             .add_Int => "add_Int",
             .sub_Int => "sub_Int",
             .mul_Int => "mul_Int",
@@ -340,6 +345,7 @@ pub const PrimOp = enum(u16) {
     pub fn fromPreludeName(str: []const u8) ?PrimOp {
         if (std.mem.eql(u8, str, "putStrLn")) return .putStrLn_;
         if (std.mem.eql(u8, str, "putStr")) return .write_stdout;
+        if (std.mem.eql(u8, str, "putChar")) return .putChar_;
         if (std.mem.eql(u8, str, "print")) return .write_stdout;
         // Add more Prelude function mappings here as needed
         return null;
@@ -426,7 +432,7 @@ test "PrimOpRegistry: stable names" {
 test "PrimOp: all ops have name mappings" {
     // Verify that all defined PrimOps have a name() implementation
     const ops = [_]PrimOp{
-        .write_stdout, .write_stderr, .read_stdin, .putStrLn_,
+        .write_stdout, .write_stderr, .read_stdin, .putStrLn_, .putChar_,
         .add_Int,      .sub_Int,      .mul_Int,    .neg_Int,
         .abs_Int,      .quot_Int,     .rem_Int,    .add_Double,
         .sub_Double,   .mul_Double,   .div_Double, .neg_Double,

--- a/src/grin/translate.zig
+++ b/src/grin/translate.zig
@@ -292,6 +292,8 @@ fn primopArity(name_str: []const u8) u32 {
     return switch (op) {
         // IO: write_stdout, write_stderr, putStrLn_ take 1 arg (String -> IO ())
         .write_stdout, .write_stderr, .putStrLn_ => 1,
+        // IO: putChar_ takes 1 arg (Char -> IO ())
+        .putChar_ => 1,
         // IO: read_stdin takes 0 args (IO String)
         .read_stdin => 0,
         // Unary arithmetic: neg_Int, abs_Int, neg_Double

--- a/src/repl/jit_engine.zig
+++ b/src/repl/jit_engine.zig
@@ -60,6 +60,8 @@ pub const JitError = error{
 /// Manages JIT compilation and execution for the REPL. Declarations are
 /// added permanently to the main JITDylib; expressions use unique entry
 /// point names and resource trackers for per-evaluation cleanup.
+const KnownTags = grin_to_llvm.KnownTags;
+
 pub const JitEngine = struct {
     allocator: Allocator,
     jit: llvm.OrcLLJITRef,
@@ -73,6 +75,8 @@ pub const JitEngine = struct {
     /// that expression compilation can scan them for F-tag registration,
     /// enabling `forceValueToWhnf` to handle thunks from any session.
     accumulated_grin_defs: std.ArrayListUnmanaged(grin_ast.Def) = .{},
+    /// Constructor discriminants from Prelude compilation for result formatting.
+    known_tags: KnownTags = .{},
 
     /// Create a new JIT engine backed by LLVM ORC LLJIT.
     pub fn init(allocator: Allocator) JitError!JitEngine {
@@ -117,27 +121,61 @@ pub const JitEngine = struct {
                 return JitError.OutOfMemory;
         }
 
+        // Use a single translator with a global tag table so that
+        // discriminant assignments are consistent across all defs.
+        // Then translate each def individually into its own LLVM module.
+        //
+        // Compiling all defs into a single large module triggers an ORC
+        // JIT "Duplicate definition" error: the inline eval loop in each
+        // translated function forward-declares thunk functions from other
+        // defs, and ORC's materializer treats the combination of forward
+        // declaration + definition as a duplicate symbol within the same
+        // materialization unit. Per-def modules avoid this by keeping
+        // each module small — intra-program function references become
+        // cross-module external declarations that ORC resolves at link time.
         var translator = GrinTranslator.init(self.allocator);
         defer translator.deinit();
-        // Enable REPL mode so that zero-arity functions (e.g. dictionary
-        // bindings like dict$ShowIt$A) return ptr instead of void. The
-        // ORC linker needs matching signatures between declaration and
-        // expression modules. The sentinel value "__decl__" is never
-        // matched as an actual entry point.
         translator.repl_entry_point = "__decl__";
+        // Seed with accumulated defs from prior sessions (e.g. Prelude)
+        // so that discriminant assignments are consistent with future
+        // expression compilations that also scan these defs.
+        translator.extra_tag_defs = self.accumulated_grin_defs.items;
 
-        const ir_text = translator.translateProgram(program.*) catch {
+        // Build a global tag table from all defs.
+        translator.prepareGlobalTagTable(program.*) catch
             return JitError.TranslationFailed;
-        };
-        defer self.allocator.free(ir_text);
 
-        const ts_mod = try self.parseIrToThreadSafeModule(ir_text);
+        // Capture constructor discriminants for result formatting.
+        self.known_tags = translator.getKnownTagDiscriminants();
 
-        const main_dylib = c.LLVMOrcLLJITGetMainJITDylib(self.jit);
-        const add_err = c.LLVMOrcLLJITAddLLVMIRModule(self.jit, main_dylib, ts_mod);
-        if (add_err != null) {
-            c.LLVMConsumeError(add_err);
-            return JitError.ModuleAddFailed;
+        for (program.defs) |def| {
+            const single_defs = self.allocator.alloc(grin_ast.Def, 1) catch
+                return JitError.OutOfMemory;
+            defer self.allocator.free(single_defs);
+            single_defs[0] = def;
+
+            const single_prog = grin_ast.Program{
+                .defs = single_defs,
+                .field_types = program.field_types,
+                .arities = program.arities,
+            };
+
+            const mod = translator.translateModuleGrin("decl", single_prog) catch
+                return JitError.TranslationFailed;
+
+            const ir_text = llvm.printModuleToString(mod, self.allocator) catch
+                return JitError.OutOfMemory;
+            defer self.allocator.free(ir_text);
+
+            const ts_mod = self.parseIrToThreadSafeModule(ir_text) catch
+                return JitError.TranslationFailed;
+
+            const main_dylib = c.LLVMOrcLLJITGetMainJITDylib(self.jit);
+            const add_err = c.LLVMOrcLLJITAddLLVMIRModule(self.jit, main_dylib, ts_mod);
+            if (add_err != null) {
+                c.LLVMConsumeError(add_err);
+                return JitError.ModuleAddFailed;
+            }
         }
     }
 
@@ -181,6 +219,11 @@ pub const JitEngine = struct {
         };
         defer self.allocator.free(ir_text);
 
+        // Update known_tags from the expression's translator, which has
+        // the complete tag table (seeded from all accumulated defs).
+        // This ensures formatJitResult uses correct discriminants.
+        self.known_tags = translator.getKnownTagDiscriminants();
+
         // 4. Parse IR and add to JIT with a resource tracker.
         const ts_mod = try self.parseIrToThreadSafeModule(ir_text);
 
@@ -213,7 +256,7 @@ pub const JitEngine = struct {
         const raw_result = entry_fn();
 
         // 7. Format the result before cleaning up.
-        const formatted = formatJitResult(self.allocator, raw_result) catch {
+        const formatted = formatJitResult(self.allocator, raw_result, self.known_tags) catch {
             const rm_err = c.LLVMOrcResourceTrackerRemove(tracker);
             if (rm_err != null) c.LLVMConsumeError(rm_err);
             c.LLVMOrcReleaseResourceTracker(tracker);
@@ -286,6 +329,9 @@ pub const JitEngine = struct {
         const io_symbols = [_]Symbol{
             .{ .name = "rts_putStrLn", .addr = @intFromPtr(&rts_io.rts_putStrLn) },
             .{ .name = "rts_putStr", .addr = @intFromPtr(&rts_io.rts_putStr) },
+            .{ .name = "rts_putChar", .addr = @intFromPtr(&rts_io.rts_putChar) },
+            .{ .name = "rts_charlist_to_cstring", .addr = @intFromPtr(&rts_io.rts_charlist_to_cstring) },
+            .{ .name = "rts_cstring_to_charlist", .addr = @intFromPtr(&rts_io.rts_cstring_to_charlist) },
             .{ .name = "rts_error", .addr = @intFromPtr(&rts_io.rts_error) },
         };
 
@@ -359,136 +405,97 @@ fn patchEntryPointName(allocator: Allocator, program: *const grin_ast.Program, t
 /// We check if the value looks like a valid heap pointer (non-zero,
 /// aligned) and try to interpret it as a node. If that fails, we
 /// treat it as a plain integer.
-fn formatJitResult(allocator: Allocator, raw: i64) Allocator.Error![]const u8 {
-    // Check if this is a boolean literal (encoded as 0 or 1 directly, not a heap node)
-    // Booleans in GRIN are unboxed i64 values where 1 = True and 0 = False
-    // (from grin_to_llvm.zig where true_val maps to 1 and false_val maps to 0)
-    if (raw == 1) return allocator.dupe(u8, "True");
-    if (raw == 0) return allocator.dupe(u8, "False");
-
-    // Check if the result is a valid-looking pointer to a heap node.
-    // Heap nodes are allocated by rts_alloc and have a specific layout
-    // with a tag in the first 8 bytes.
+fn formatJitResult(allocator: Allocator, raw: i64, tags: KnownTags) Allocator.Error![]const u8 {
     const as_usize: usize = @bitCast(raw);
 
-    if (as_usize != 0 and as_usize % @alignOf(*anyopaque) == 0) {
-        // Try to interpret as a heap node pointer.
+    // Check if the result is a valid-looking pointer to a heap node.
+    // Must be above the first page (4096) to exclude small integers
+    // that happen to be aligned (e.g. ASCII characters like 'h' = 104).
+    const MIN_HEAP_PTR: usize = 0x10000;
+    if (as_usize >= MIN_HEAP_PTR and as_usize % @alignOf(*anyopaque) == 0) {
         const node_ptr: *const rts_node.Node = @ptrFromInt(as_usize);
-
-        // Quick validation: check if tag in reasonable range before formatting
         const tag_int: u64 = @intFromEnum(node_ptr.tag);
         if (tag_int <= 0x10000 and node_ptr.n_fields <= 1024) {
-            // Looks like a valid heap node format it
-            return formatNode(allocator, node_ptr);
+            return formatNode(allocator, node_ptr, tags);
         }
     }
 
-    // If not a heap node, check if it looks like a C string (NUL-terminated)
-    // Global string literals from LLVM GlobalStringPtr return as raw pointers
-    // Only attempt to read if the address is in a reasonable range (not too small like an integer)
-    const MIN_VALID_PTR: usize = 0x1000; // Typical page boundary, integers 0-4095 are likely literal values
+    // Check if it looks like a C string pointer (for raw string results).
+    const MIN_VALID_PTR: usize = 0x1000;
     if (as_usize >= MIN_VALID_PTR) {
         const str_ptr: [*]const u8 = @ptrFromInt(as_usize);
-        
-        // Check first byte for printable ASCII
         if (str_ptr[0] >= 32 and str_ptr[0] <= 126) {
             var len: usize = 0;
-            const max_len: usize = 256; // Reasonable safety limit
-            
-            // Read until NUL or we hit non-printable bytes
+            const max_len: usize = 256;
             while (len < max_len) {
                 const byte = str_ptr[len];
-                if (byte == 0) break; // NUL terminator found
-                if (byte < 32 or byte > 126) break; // Non-printable
+                if (byte == 0) break;
+                if (byte < 32 or byte > 126) break;
                 len += 1;
             }
-            
-            // If we found a reasonable-looking string
             if (len > 0 and len < max_len and str_ptr[len] == 0) {
-                const str_slice = str_ptr[0..len];
-                return std.fmt.allocPrint(allocator, "\"{s}\"", .{str_slice});
+                return std.fmt.allocPrint(allocator, "\"{s}\"", .{str_ptr[0..len]});
             }
         }
     }
 
-    // Not a valid heap node - treat as plain integer literal.
+    // Plain integer literal.
     return std.fmt.allocPrint(allocator, "{d}", .{raw});
 }
 
-// Known Prelude constant tags for boolean/unit formatting
-// These match the unique IDs from grin_to_llvm.zig's `known` struct
-const KNOWN_TRUE_ID: u64 = 200;
-const KNOWN_FALSE_ID: u64 = 201;
-const KNOWN_UNIT_ID: u64 = 206;
-
-/// Format a heap node as a human-readable string.
-/// Assumes the caller has already validated that this is a valid heap node
-/// (tag in reasonable range, n_fields reasonable).
-fn formatNode(allocator: Allocator, node: *const rts_node.Node) ![]const u8 {
+/// Format a heap node as a human-readable string using dynamic tag
+/// discriminants from the compilation's tag table.
+fn formatNode(allocator: Allocator, node: *const rts_node.Node, tags: KnownTags) Allocator.Error![]const u8 {
     const tag_int: u64 = @intFromEnum(node.tag);
+    const disc: i64 = @bitCast(tag_int);
 
-    // Caller should have validated, but if we somehow got here with invalid data,
-    // conservatively return a generic representation
-    if (tag_int > 0x10000 or node.n_fields > 1024) {
-        return std.fmt.allocPrint(allocator, "<invalid node tag={d}>", .{tag_int});
-    }
-
-    // Handle unit (RtsTag.Unit = 0) - display as empty string
-    // Direct tag value comparison since node.tag was set by LLVM code
+    // Unit (RTS-level tag 0)
     if (tag_int == @intFromEnum(rts_node.Tag.Unit)) {
         return allocator.dupe(u8, "");
     }
 
-    // Check if the RtsTag is the user-defined Data type
-    // For these, the actual constructor discriminant is stored in the first field
-    // (tracked in GRIN tag table as unique IDs like 200=True, 201=False, etc.)
-    if (node.tag == .Data) {
-        // Try to read the actual discriminant from the first field
-        if (node.n_fields >= 1) {
-            const disc = rts_node.rts_load_field(node, 0);
-            // Handle boolean values by their GRIN-level discriminant
-            if (disc == KNOWN_TRUE_ID) return allocator.dupe(u8, "True");
-            if (disc == KNOWN_FALSE_ID) return allocator.dupe(u8, "False");
-            if (disc == KNOWN_UNIT_ID) return allocator.dupe(u8, "");
+    // Boolean constructors (nullary, 0 fields)
+    if (tags.true_disc) |td| {
+        if (disc == td and node.n_fields == 0) return allocator.dupe(u8, "True");
+    }
+    if (tags.false_disc) |fd| {
+        if (disc == fd and node.n_fields == 0) return allocator.dupe(u8, "False");
+    }
+
+    // Nothing (nullary, 0 fields)
+    if (tags.nothing_disc) |nd| {
+        if (disc == nd and node.n_fields == 0) return allocator.dupe(u8, "Nothing");
+    }
+
+    // Just x (1 field)
+    if (tags.just_disc) |jd| {
+        if (disc == jd and node.n_fields == 1) {
+            const inner_raw: i64 = @bitCast(rts_node.fieldsConst(node)[0]);
+            const inner = try formatJitResult(allocator, inner_raw, tags);
+            defer allocator.free(inner);
+            return std.fmt.allocPrint(allocator, "Just {s}", .{inner});
         }
     }
 
-    // Handle String nodes - read the string content from the stored pointer
-    if (node.tag == .String and node.n_fields >= 1) {
-        const str_ptr = rts_node.stringValue(node);
-        // Get C string length
-        var len: usize = 0;
-        while (str_ptr[len] != 0) : (len += 1) {}
-        // Format with quotes and escape
-        const str_slice = str_ptr[0..len];
-        var result = try std.ArrayList(u8).initCapacity(allocator, len + 10);
-        try result.append(allocator, '"');
-        try result.appendSlice(allocator, str_slice);
-        try result.append(allocator, '"');
-        return result.toOwnedSlice(allocator);
+    // List: [] (Nil) or x : xs (Cons)
+    if (tags.nil_disc) |nd| {
+        if (disc == nd and node.n_fields == 0) return allocator.dupe(u8, "[]");
+    }
+    if (tags.cons_disc) |cd| {
+        if (disc == cd and node.n_fields == 2) {
+            return formatList(allocator, node, tags);
+        }
     }
 
-    // Handle boolean values using discriminant from tag table
-    // True has stable ID 200, False has ID 201
-    if (tag_int == KNOWN_TRUE_ID) {
-        return allocator.dupe(u8, "True");
-    }
-    if (tag_int == KNOWN_FALSE_ID) {
-        return allocator.dupe(u8, "False");
-    }
-
-    // For nullary constructors, just print the tag number for now.
-    // A full implementation would map tag IDs back to constructor names,
-    // but that requires threading the tag table from compilation.
+    // Generic constructor display
     if (node.n_fields == 0) {
         return std.fmt.allocPrint(allocator, "<constructor tag={d}>", .{tag_int});
     }
 
     var result = try std.fmt.allocPrint(allocator, "<constructor tag={d}", .{tag_int});
-    const field_slots = rts_node.fieldsConst(node);
     var i: u32 = 0;
     while (i < node.n_fields) : (i += 1) {
-        const field_val: i64 = @bitCast(field_slots[i]);
+        const field_val: i64 = @bitCast(rts_node.fieldsConst(node)[i]);
         const new = try std.fmt.allocPrint(allocator, "{s} {d}", .{ result, field_val });
         allocator.free(result);
         result = new;
@@ -496,6 +503,119 @@ fn formatNode(allocator: Allocator, node: *const rts_node.Node) ![]const u8 {
     const final = try std.fmt.allocPrint(allocator, "{s}>", .{result});
     allocator.free(result);
     return final;
+}
+
+/// Format a Cons-headed list as "[e1,e2,e3]".
+/// Traverses the spine, collecting elements until Nil or a non-list node.
+fn formatList(allocator: Allocator, head_node: *const rts_node.Node, tags: KnownTags) Allocator.Error![]const u8 {
+    const nil_disc = tags.nil_disc orelse return allocator.dupe(u8, "[...]");
+    const cons_disc = tags.cons_disc orelse return allocator.dupe(u8, "[...]");
+
+    // First pass: check if this is a [Char] list (String).
+    // If every element is a printable character, format as "string".
+    if (isCharList(head_node, cons_disc, nil_disc)) {
+        return formatCharList(allocator, head_node, cons_disc, nil_disc);
+    }
+
+    var buf = std.ArrayListUnmanaged(u8){};
+    try buf.append(allocator, '[');
+
+    var current: *const rts_node.Node = head_node;
+    var first = true;
+    var depth: usize = 0;
+    const max_depth: usize = 100; // Safety limit
+
+    while (depth < max_depth) : (depth += 1) {
+        const cur_disc: i64 = @bitCast(@as(u64, @intFromEnum(current.tag)));
+
+        if (cur_disc == nil_disc and current.n_fields == 0) {
+            // End of list
+            break;
+        }
+
+        if (cur_disc != cons_disc or current.n_fields != 2) {
+            // Not a proper list tail — show as improper
+            try buf.appendSlice(allocator, "|...");
+            break;
+        }
+
+        if (!first) try buf.append(allocator, ',');
+        first = false;
+
+        // Format the head element
+        const head_raw: i64 = @bitCast(rts_node.fieldsConst(current)[0]);
+        const elem = try formatJitResult(allocator, head_raw, tags);
+        defer allocator.free(elem);
+        try buf.appendSlice(allocator, elem);
+
+        // Advance to the tail
+        const tail_raw: usize = rts_node.fieldsConst(current)[1];
+        if (tail_raw == 0 or tail_raw % @alignOf(*anyopaque) != 0) break;
+        current = @ptrFromInt(tail_raw);
+    }
+
+    try buf.append(allocator, ']');
+    return buf.toOwnedSlice(allocator);
+}
+
+/// Check if a list is a [Char] — every element is a valid Unicode codepoint
+/// stored as a raw integer (not a heap pointer).
+fn isCharList(head_node: *const rts_node.Node, cons_disc: i64, nil_disc: i64) bool {
+    var current: *const rts_node.Node = head_node;
+    var depth: usize = 0;
+    const max_depth: usize = 1000;
+
+    while (depth < max_depth) : (depth += 1) {
+        const cur_disc: i64 = @bitCast(@as(u64, @intFromEnum(current.tag)));
+
+        if (cur_disc == nil_disc and current.n_fields == 0) return depth > 0;
+        if (cur_disc != cons_disc or current.n_fields != 2) return false;
+
+        const head_val: u64 = rts_node.fieldsConst(current)[0];
+        // Characters are Unicode codepoints: 0 to 0x10FFFF.
+        if (head_val > 0x10FFFF) return false;
+
+        const tail_raw: usize = rts_node.fieldsConst(current)[1];
+        if (tail_raw == 0 or tail_raw % @alignOf(*anyopaque) != 0) return false;
+        current = @ptrFromInt(tail_raw);
+    }
+    return false;
+}
+
+/// Format a [Char] list as a quoted string: "hello".
+fn formatCharList(allocator: Allocator, head_node: *const rts_node.Node, cons_disc: i64, nil_disc: i64) Allocator.Error![]const u8 {
+    var buf = std.ArrayListUnmanaged(u8){};
+    try buf.append(allocator, '"');
+
+    var current: *const rts_node.Node = head_node;
+    var depth: usize = 0;
+    const max_depth: usize = 1000;
+
+    while (depth < max_depth) : (depth += 1) {
+        const cur_disc: i64 = @bitCast(@as(u64, @intFromEnum(current.tag)));
+        if (cur_disc == nil_disc and current.n_fields == 0) break;
+        if (cur_disc != cons_disc or current.n_fields != 2) break;
+
+        const ch: u64 = rts_node.fieldsConst(current)[0];
+        if (ch < 128) {
+            try buf.append(allocator, @intCast(ch));
+        } else {
+            // Encode as Unicode escape for non-ASCII
+            var code_buf: [4]u8 = undefined;
+            const cp: u21 = @intCast(ch);
+            const len = std.unicode.utf8Encode(cp, &code_buf) catch 0;
+            if (len > 0) {
+                try buf.appendSlice(allocator, code_buf[0..len]);
+            }
+        }
+
+        const tail_raw: usize = rts_node.fieldsConst(current)[1];
+        if (tail_raw == 0 or tail_raw % @alignOf(*anyopaque) != 0) break;
+        current = @ptrFromInt(tail_raw);
+    }
+
+    try buf.append(allocator, '"');
+    return buf.toOwnedSlice(allocator);
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────

--- a/src/repl/session.zig
+++ b/src/repl/session.zig
@@ -214,16 +214,7 @@ pub const Session = struct {
 
         // Load the Prelude so its functions are available immediately.
         // Non-fatal: on failure the session continues with built-in names only.
-        //
-        // Currently WASM-only: the native JIT backend cannot yet compile
-        // the Prelude's GRIN output (GRIN→LLVM translation fails — tracked
-        // in #589). Additionally, loading Prelude `data Bool` reassigns
-        // constructor uniques, breaking the JIT's hardcoded True/False
-        // discriminant check in formatJitResult. Once #589 is resolved,
-        // this guard can be removed.
-        if (is_wasi) {
-            self.loadPrelude();
-        }
+        self.loadPrelude();
 
         return self;
     }
@@ -320,9 +311,16 @@ pub const Session = struct {
         self.accumulated_dict_names.deinit(self.allocator);
         self.accumulated_dict_names = result.dict_names;
 
-        // Note: no addDeclarations call needed here. This function is
-        // only called on the WASM path (guarded in init), where the
-        // tree-walking evaluator uses accumulated_defs directly.
+        // On native JIT, add Prelude declarations to the JIT engine so
+        // symbols are available for linking.
+        if (!is_wasi) {
+            self.engine.addDeclarations(&result.grin_prog) catch |err| {
+                // Non-fatal: continue with Prelude symbols in renamer/typechecker
+                // but unavailable in JIT (expressions using them will fail at link time).
+                std.debug.print("Warning: addDeclarations failed for Prelude: {}\n", .{err});
+                return;
+            };
+        }
     }
 
     // ── Input processing ──────────────────────────────────────────────
@@ -698,10 +696,9 @@ test "session: processInput returns diagnostics on error" {
 
 // ── Prelude loading tests ─────────────────────────────────────────────
 //
-// loadPrelude is only called automatically on WASM (is_wasi). These
-// tests call it explicitly to verify the pipeline on native, where
-// the GRIN tree-walker is not available but the frontend pipeline
-// (parse → rename → typecheck → desugar → GRIN translate) still works.
+// loadPrelude is called automatically by init() for all targets.
+// These tests verify that Prelude names resolve correctly in
+// subsequent REPL inputs.
 
 test "session: loadPrelude populates accumulated state" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -710,9 +707,6 @@ test "session: loadPrelude populates accumulated state" {
 
     var session = try Session.init(alloc, testing.io);
     defer session.deinit();
-
-    // On native, loadPrelude is not called by init. Call explicitly.
-    if (!is_wasi) session.loadPrelude();
 
     // Prelude should have loaded — accumulated_defs should be non-empty.
     try testing.expect(session.accumulated_defs.items.len > 0);
@@ -728,8 +722,6 @@ test "session: Prelude names resolve after loadPrelude" {
     var session = try Session.init(alloc, testing.io);
     defer session.deinit();
 
-    if (!is_wasi) session.loadPrelude();
-
     // `id` is defined in the Prelude — should compile as expression.
     const result = try session.processInput("id 42");
     try testing.expect(result.compile.kind == .expression);
@@ -743,8 +735,6 @@ test "session: Prelude operators resolve after loadPrelude" {
     var session = try Session.init(alloc, testing.io);
     defer session.deinit();
 
-    if (!is_wasi) session.loadPrelude();
-
     // `(+)` is defined in the Prelude — should compile as expression.
     const result = try session.processInput("1 + 2");
     try testing.expect(result.compile.kind == .expression);
@@ -757,8 +747,6 @@ test "session: Prelude data constructors resolve after loadPrelude" {
 
     var session = try Session.init(alloc, testing.io);
     defer session.deinit();
-
-    if (!is_wasi) session.loadPrelude();
 
     // `Just` is defined in the Prelude — should compile as expression.
     const result = try session.processInput("Just 42");

--- a/src/rts/io.zig
+++ b/src/rts/io.zig
@@ -10,6 +10,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const node_mod = @import("node.zig");
 
 // ═══════════════════════════════════════════════════════════════════════
 // Internal helpers
@@ -66,6 +67,110 @@ pub export fn rts_putStr(str: [*:0]const u8) i32 {
     return 0;
 }
 
+/// Print a single character to stdout.
+///
+/// Called `rts_putChar` from LLVM-generated code (PrimOp for `putChar`).
+/// The character is passed as an i64 (the Char's codepoint, zero-extended).
+/// Returns 0 on success.
+pub export fn rts_putChar(ch: i64) i32 {
+    const byte: u8 = @intCast(ch & 0xFF);
+    writeBytes(&[1]u8{byte});
+    return 0;
+}
+
+/// Convert a [Char] heap list (Cons/Nil linked list of character nodes) to a
+/// null-terminated C string allocated on the RTS heap.
+///
+/// Called `rts_charlist_to_cstring` from LLVM-generated code when a [Char]
+/// value is passed to a primop that expects a C string (e.g., putStrLn).
+///
+/// Parameters:
+///   - list_ptr: pointer to the head node of the [Char] list
+///   - cons_disc: the tag discriminant for the (:) constructor
+///   - nil_disc: the tag discriminant for the [] constructor
+///
+/// Returns a pointer to a null-terminated C string. The string is allocated
+/// from the RTS heap and need not be freed (arena-managed).
+pub export fn rts_charlist_to_cstring(list_ptr: *const node_mod.Node, cons_disc: u64, nil_disc: u64) [*:0]const u8 {
+    // First pass: count the length
+    var len: usize = 0;
+    var cur: *const node_mod.Node = list_ptr;
+    while (true) {
+        const tag_int: u64 = @intFromEnum(cur.tag);
+        if (tag_int == nil_disc) break;
+        if (tag_int != cons_disc) break; // unexpected tag, stop
+        if (cur.n_fields < 2) break;
+        len += 1;
+        // field[1] is the tail pointer — may be stored as PtrToInt (i64)
+        const tail_raw = node_mod.fieldsConst(cur)[1];
+        if (tail_raw == 0) break;
+        // The tail is a pointer to the next node stored as u64
+        cur = @ptrFromInt(@as(usize, @intCast(tail_raw)));
+    }
+
+    // Allocate buffer (len + 1 for null terminator)
+    const heap_alloc = @import("heap.zig").allocator();
+    const buf = heap_alloc.alloc(u8, len + 1) catch @panic("OOM in rts_charlist_to_cstring");
+
+    // Second pass: extract characters
+    cur = list_ptr;
+    for (0..len) |i| {
+        const tag_int: u64 = @intFromEnum(cur.tag);
+        if (tag_int != cons_disc or cur.n_fields < 2) break;
+        // field[0] is the character value (either raw i64 or pointer to Char node)
+        const char_field = node_mod.fieldsConst(cur)[0];
+        // Check if the field is a pointer to a Char node
+        const align_val: u64 = @alignOf(*anyopaque);
+        if (char_field > 0x1000 and char_field % align_val == 0) {
+            const char_node: *const node_mod.Node = @ptrFromInt(@as(usize, @intCast(char_field)));
+            if (char_node.tag == .Char and char_node.n_fields >= 1) {
+                buf[i] = @intCast(node_mod.fieldsConst(char_node)[0] & 0xFF);
+            } else {
+                buf[i] = @intCast(char_field & 0xFF);
+            }
+        } else {
+            buf[i] = @intCast(char_field & 0xFF);
+        }
+        const tail_uptr: usize = @intCast(node_mod.fieldsConst(cur)[1]);
+        cur = @ptrFromInt(tail_uptr);
+    }
+    buf[len] = 0;
+
+    return @ptrCast(buf.ptr);
+}
+
+/// Convert a null-terminated C string to a [Char] heap list (Cons/Nil linked
+/// list of character values).
+///
+/// Called `rts_cstring_to_charlist` from LLVM-generated code when a string
+/// literal needs to be treated as a [Char] list (e.g., for pattern matching
+/// by `++`, `head`, `tail`, etc.).
+///
+/// Parameters:
+///   - str: pointer to a null-terminated C string
+///   - cons_disc: the tag discriminant for the (:) constructor
+///   - nil_disc: the tag discriminant for the [] constructor
+///
+/// Returns a pointer to the head node of the [Char] list. Each Cons node
+/// has 2 fields: field[0] = character value (as u64), field[1] = tail pointer.
+pub export fn rts_cstring_to_charlist(str: [*:0]const u8, cons_disc: u64, nil_disc: u64) *node_mod.Node {
+    // Build the list from right to left: start with Nil, then prepend each character.
+    var tail: *node_mod.Node = node_mod.rts_alloc(nil_disc, 0);
+    const span = std.mem.span(str);
+
+    var i = span.len;
+    while (i > 0) {
+        i -= 1;
+        const cons = node_mod.rts_alloc(cons_disc, 2);
+        // field[0] = character value (raw i64)
+        node_mod.rts_store_field(cons, 0, @as(u64, span[i]));
+        // field[1] = tail pointer (as u64)
+        node_mod.rts_store_field(cons, 1, @intFromPtr(tail));
+        tail = cons;
+    }
+    return tail;
+}
+
 /// Print an error message to stderr and terminate the program with exit code 1.
 ///
 /// Implements the `error :: String -> a` Haskell primitive.  Called
@@ -90,6 +195,14 @@ test "rts_putStrLn is callable" {
 
 test "rts_putStr is callable" {
     _ = &rts_putStr;
+}
+
+test "rts_putChar is callable" {
+    _ = &rts_putChar;
+}
+
+test "rts_cstring_to_charlist is callable" {
+    _ = &rts_cstring_to_charlist;
 }
 
 test "rts_error is callable" {

--- a/src/rts/root.zig
+++ b/src/rts/root.zig
@@ -26,6 +26,9 @@ comptime {
     _ = &node.rts_store;
     _ = &io_module.rts_putStrLn;
     _ = &io_module.rts_putStr;
+    _ = &io_module.rts_putChar;
+    _ = &io_module.rts_charlist_to_cstring;
+    _ = &io_module.rts_cstring_to_charlist;
     _ = &io_module.rts_error;
     _ = &heap.init;
     _ = &heap.deinit;

--- a/src/runtime/eval.zig
+++ b/src/runtime/eval.zig
@@ -106,6 +106,7 @@ fn evalIOPrim(ctx: EvalContext, op: PrimOp, args: []const Value) EvalError!Value
         .write_stderr => io_mod.writeStderr(ctx.io, args),
         .read_stdin => io_mod.readStdin(ctx.io, ctx.allocator, args),
         .putStrLn_ => io_mod.putStrLn(ctx.io, args),
+        .putChar_ => io_mod.putChar(ctx.io, args),
         else => EvalError.NotImplemented,
     };
 }

--- a/src/runtime/io.zig
+++ b/src/runtime/io.zig
@@ -73,6 +73,21 @@ pub fn putStrLn(io: std.Io, args: []const Value) EvalError!Value {
     return Value.unit;
 }
 
+/// Write a single character to stdout.
+pub fn putChar(io: std.Io, args: []const Value) EvalError!Value {
+    if (args.len != 1) return EvalError.ArityMismatch;
+
+    const ch = args[0].asChar() orelse return EvalError.TypeError;
+
+    var buf: [4096]u8 = undefined;
+    var fw: File.Writer = .init(.stdout(), io, &buf);
+    const w = &fw.interface;
+    w.writeByte(@intCast(ch)) catch return EvalError.IOError;
+    w.flush() catch return EvalError.IOError;
+
+    return Value.unit;
+}
+
 /// Read a line from stdin using the provided Io interface.
 ///
 /// Args: []

--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -106,6 +106,14 @@ pub const Value = union(enum) {
         };
     }
 
+    /// Get the value as a character, if it is one.
+    pub fn asChar(self: Value) ?u21 {
+        return switch (self) {
+            .Char => |c| c,
+            else => null,
+        };
+    }
+
     /// Get the value as an integer, if it is one.
     pub fn asInt(self: Value) ?i64 {
         return switch (self) {


### PR DESCRIPTION
Closes #609

## Summary

Implements the infrastructure for string-as-`[Char]` representation in the native JIT REPL, enabling Prelude loading and laying the groundwork for string concatenation support.

## Changes

### String representation (`[Char]` support)
- Add `rts_putChar` primitive for single character output
- Add `rts_cstring_to_charlist` and `rts_charlist_to_cstring` RTS functions for converting between C strings and Haskell `[Char]` linked lists
- Convert `Lit.String` to `[Char]` in the LLVM backend (`translateValToLlvm`) — string literals are now desugared to Cons/Nil linked lists at code generation time
- Add charlist-to-cstring conversion at primop boundaries (`putStr`, `putStrLn`) so I/O operations receive C strings
- Add `putChar_` primop through the GRIN pipeline and Prelude

### Tag table consistency
- Set `first_discriminant = 0x1000` to avoid collision with RTS special tags (`Unit=0`, `Int=1`, `Char=2`, `String=3`)
- Add `con_name_to_disc` map and `findByName` using base names for reverse lookup
- `prepareGlobalTagTable` now scans `extra_tag_defs` first, ensuring discriminant assignments are consistent between declaration compilation and expression compilation across REPL sessions

### JIT engine improvements
- Per-def module compilation: each GRIN def is translated into its own LLVM module, fixing ORC JIT "Duplicate definition" errors that occurred with large single-module compilation
- Re-enable `loadPrelude()` for native JIT — Prelude functions (`++`, `putStrLn`, etc.) are now available from the first REPL input
- Register new RTS functions (`rts_putChar`, `rts_charlist_to_cstring`, `rts_cstring_to_charlist`) as JIT absolute symbols
- Add `isCharList`/`formatCharList` for displaying `[Char]` values as quoted strings
- Add `MIN_HEAP_PTR` threshold (0x10000) to prevent segfault when small aligned integers (e.g. ASCII characters) are misinterpreted as heap pointers
- Add `n_fields == 0` check for nullary constructor matching (`True`, `False`) to prevent false matches against nodes with the same discriminant but different arity

## Known limitation

Lazy list spines produced by `++` are not deeply forced — `"hello" ++ " world"` currently displays as `[104|...]` instead of `"hello world"`. The REPL forces the outermost value to WHNF but does not recursively force list tails, which may be unevaluated thunks. A follow-up issue will track implementing principled deep spine forcing.

## Testing

- 902/902 unit tests pass
- 42/42 build steps succeed
- All 30 REPL tests pass (including 3 previously failing tests: boolean literal, chained declarations, typeclass method call)
- 27/27 e2e tests pass
