### PR TITLE
#627: Infrastructure for constrained instance dictionary-passing

### DIFF
--- a/lib/Prelude.hs
+++ b/lib/Prelude.hs
@@ -318,15 +318,15 @@ instance Show Ordering where
 instance Show Char where
   show c = '\'' : c : '\'' : []
 
--- Polymorphic Show instances require dictionary-passing codegen that
--- crashes the LLVM backend (#618).  Tracked as a follow-up.
+-- Polymorphic Show instances require evidence plumbing in instance
+-- method bodies (tracked as a follow-up to #627).
 -- instance Show a => Show [a] where
 --   show xs = showListWith xs
 
 -- instance Show a => Show (Maybe a) where
 --   show Nothing  = "Nothing"
 --   show (Just x) = "Just " ++ show x
---
+
 -- instance (Show a, Show b) => Show (Either a b) where
 --   show (Left x)  = "Left " ++ show x
 --   show (Right y) = "Right " ++ show y

--- a/src/core/desugar.zig
+++ b/src/core/desugar.zig
@@ -784,6 +784,23 @@ fn desugarInstanceDecl(
         .head_name = head_name,
     }, dict_name);
 
+    // If the instance has context constraints (e.g. `Show a => Show [a]`),
+    // pre-populate dict_param_names so that evidence resolution inside method
+    // bodies can reference the enclosing dictionary parameters.  These names
+    // are reused when wrapping the dictionary expression with lambdas below.
+    var context_param_names = try alloc.alloc(Name, id_decl.context.len);
+    if (id_decl.context.len > 0) {
+        ctx.dict_param_names.clearRetainingCapacity();
+        for (id_decl.context, 0..) |assertion, ci| {
+            const dpn = Name{
+                .base = try std.fmt.allocPrint(alloc, "dict${s}", .{assertion.class_name.base}),
+                .unique = ctx.u_supply.fresh(),
+            };
+            context_param_names[ci] = dpn;
+            try ctx.dict_param_names.put(alloc, assertion.class_name.unique.value, dpn);
+        }
+    }
+
     // Build the dictionary value: MkDict$Class method1_impl method2_impl ...
     // For each method in class declaration order, find the binding in the instance.
     // If not found and the class has a default, use a placeholder.
@@ -799,7 +816,7 @@ fn desugarInstanceDecl(
         }
 
         if (found_binding) |binding| {
-            // Desugar the instance method body
+            // Desugar the instance method body.
             if (binding.equations.len == 1 and binding.equations[0].patterns.len == 0) {
                 // Simple case: no patterns, just an RHS
                 const body = try alloc.create(ast_mod.Expr);
@@ -896,6 +913,35 @@ fn desugarInstanceDecl(
             },
         };
         dict_expr = app;
+    }
+
+    // If the instance has context constraints, wrap the dictionary expression
+    // with lambdas for each constraint.  E.g. for `instance Show a => Show [a]`:
+    //   dict$Show$List = \dict$Show -> MkDict$Show (\xs -> showListWith dict$Show xs)
+    // This makes the dictionary a function that accepts the sub-dictionaries.
+    if (id_decl.context.len > 0) {
+        var i = id_decl.context.len;
+        while (i > 0) {
+            i -= 1;
+            const dict_param_ty = ast_mod.CoreType{ .TyCon = .{
+                .name = Name{
+                    .base = try std.fmt.allocPrint(alloc, "Dict${s}", .{id_decl.context[i].class_name.base}),
+                    .unique = .{ .value = 0 },
+                },
+                .args = &.{},
+            } };
+            const wrapped = try alloc.create(ast_mod.Expr);
+            wrapped.* = .{ .Lam = .{
+                .binder = .{
+                    .name = context_param_names[i],
+                    .ty = dict_param_ty,
+                    .span = id_decl.span,
+                },
+                .body = dict_expr,
+                .span = id_decl.span,
+            } };
+            dict_expr = wrapped;
+        }
     }
 
     // The dictionary binding type (placeholder — not critical for GRIN translation).
@@ -1021,13 +1067,10 @@ fn buildDictExpr(
         .instance => |inst| {
             // Look up the dictionary name by (class, head_type_name).
             const head_name = htypeHeadName(inst.head_ty);
-            const dict_name = ctx.dict_names.get(.{
-                .class_unique = inst.class_name.unique.value,
-                .head_name = head_name,
-            });
+            const dict_name = lookupDictName(&ctx.dict_names, inst.class_name.unique.value, head_name);
 
             if (dict_name) |dn| {
-                const node = try alloc.create(ast_mod.Expr);
+                var node = try alloc.create(ast_mod.Expr);
                 const dict_ty = ast_mod.CoreType{ .TyCon = .{
                     .name = Name{
                         .base = try std.fmt.allocPrint(alloc, "Dict${s}", .{inst.class_name.base}),
@@ -1036,6 +1079,22 @@ fn buildDictExpr(
                     .args = &.{},
                 } };
                 node.* = .{ .Var = .{ .name = dn, .ty = dict_ty, .span = span } };
+
+                // Apply context evidence as arguments for constrained instances.
+                // E.g. for `Show [Int]` resolved via `instance Show a => Show [a]`,
+                // the context_evidence contains [Show Int], so we generate:
+                //   dict$Show$List dict$Show$Int
+                for (inst.context_evidence) |ctx_ev| {
+                    const sub_dict = try buildDictExpr(ctx, &ctx_ev, span);
+                    const app = try alloc.create(ast_mod.Expr);
+                    app.* = .{ .App = .{
+                        .fn_expr = node,
+                        .arg = sub_dict,
+                        .span = span,
+                    } };
+                    node = app;
+                }
+
                 return node;
             } else {
                 // Dictionary not found — emit a placeholder.
@@ -1099,12 +1158,26 @@ fn buildDictExpr(
     }
 }
 
+/// Linear scan lookup for dictionary names.
+///
+/// Works around an issue where `ArrayHashMap.get()` fails to find
+/// entries that were seeded from an external map (likely a hash
+/// function inconsistency when keys are copied between maps).
+fn lookupDictName(map: *const DesugarCtx.DictNameMap, class_unique: u64, head_name: []const u8) ?Name {
+    for (map.keys(), map.values()) |k, v| {
+        if (k.class_unique == class_unique and std.mem.eql(u8, k.head_name, head_name)) {
+            return v;
+        }
+    }
+    return null;
+}
+
 /// Extract a base name from an HType for dictionary name lookup.
 /// Maps concrete types to their base name string (e.g. `Con(Int)` → "Int").
 fn htypeHeadName(ty: htype_mod.HType) []const u8 {
     const chased = ty.chase();
     return switch (chased) {
-        .Con => |c| c.name.base,
+        .Con => |c| if (std.mem.eql(u8, c.name.base, "[]")) "List" else c.name.base,
         .Rigid => |r| r.base,
         .AppTy => |a| htypeHeadName(a.head.*),
         .Meta => "Meta",

--- a/src/grin/evaluator.zig
+++ b/src/grin/evaluator.zig
@@ -837,8 +837,15 @@ pub const GrinEvaluator = struct {
 
                 // Check if this is a prim-prefixed function call
                 // (e.g., `primPutStrLn`) and dispatch to its PrimOp.
-                if (PrimOp.fromPreludeName(app.name.base)) |op| {
-                    break :b try self.evalPrimOp(op, app.args);
+                // Only dispatch names starting with "prim" here; unprefixed
+                // names like `putStrLn` must go through the Haskell wrappers
+                // in the Prelude, which correctly walk lazy cons-cell lists
+                // character-by-character.  Bypassing them causes the evaluator
+                // to call charListToString on unevaluated thunks (#627).
+                if (std.mem.startsWith(u8, app.name.base, "prim")) {
+                    if (PrimOp.fromPreludeName(app.name.base)) |op| {
+                        break :b try self.evalPrimOp(op, app.args);
+                    }
                 }
 
                 // IO monad sequencing operators.
@@ -943,8 +950,6 @@ pub const GrinEvaluator = struct {
                 // Try to match against each alternative
                 for (case_expr.alts) |alt| {
                     if (try self.matchPattern(scrutinee_val, alt.pat)) {
-                        // Pattern matched - bind any variables from the pattern
-                        // (This is handled during matchPattern)
                         const result = try self.eval(alt.body);
                         break :b result;
                     }
@@ -2679,23 +2684,24 @@ test "eval: Combined - function that cases on its argument" {
     try testing.expectEqual(@as(i64, 123), result.Lit.Int);
 }
 
-test "PrimOp: fromPreludeName maps prim-prefixed IO function names to PrimOps" {
+test "PrimOp: fromPreludeName maps IO function names to PrimOps" {
     try testing.expectEqual(PrimOp.putStrLn_, PrimOp.fromString("putStrLn_") orelse return);
     try testing.expectEqual(@as(?PrimOp, null), PrimOp.fromString("putStrLn"));
 
-    // fromPreludeName maps only prim-prefixed names (used in foreign
-    // import prim declarations). The unprefixed names (putStrLn, putStr,
-    // putChar) are Haskell wrapper functions that walk lazy cons-cell
-    // lists and must NOT be intercepted as raw primops (#627).
+    // fromPreludeName maps both prim-prefixed and unprefixed names.
+    // The desugarer and GRIN translator use it at compile time for all
+    // names.  The GRIN evaluator guards against dispatching unprefixed
+    // names as raw primops (they must go through Haskell wrappers that
+    // walk lazy cons-cell lists character-by-character, see #627).
     try testing.expectEqual(PrimOp.putStrLn_, PrimOp.fromPreludeName("primPutStrLn") orelse return);
     try testing.expectEqual(PrimOp.write_stdout, PrimOp.fromPreludeName("primPutStr") orelse return);
     try testing.expectEqual(PrimOp.putChar_, PrimOp.fromPreludeName("primPutChar") orelse return);
 
-    // Unprefixed names must NOT resolve — they are Haskell functions.
-    try testing.expect(@as(?PrimOp, null) == PrimOp.fromPreludeName("putStrLn"));
-    try testing.expect(@as(?PrimOp, null) == PrimOp.fromPreludeName("putStr"));
-    try testing.expect(@as(?PrimOp, null) == PrimOp.fromPreludeName("putChar"));
-    try testing.expect(@as(?PrimOp, null) == PrimOp.fromPreludeName("print"));
+    // Unprefixed names also resolve (used by desugarer/translator).
+    try testing.expectEqual(PrimOp.putStrLn_, PrimOp.fromPreludeName("putStrLn") orelse return);
+    try testing.expectEqual(PrimOp.write_stdout, PrimOp.fromPreludeName("putStr") orelse return);
+    try testing.expectEqual(PrimOp.putChar_, PrimOp.fromPreludeName("putChar") orelse return);
+    try testing.expectEqual(PrimOp.write_stdout, PrimOp.fromPreludeName("print") orelse return);
     try testing.expect(@as(?PrimOp, null) == PrimOp.fromPreludeName("nonexistent"));
 }
 

--- a/src/grin/primop.zig
+++ b/src/grin/primop.zig
@@ -348,20 +348,13 @@ pub const PrimOp = enum(u16) {
     /// (via `op.name()`).  Downstream stages (GRIN translator, LLVM backend)
     /// then only need to match canonical names via `fromString()`.
     pub fn fromPreludeName(str: []const u8) ?PrimOp {
-        // Map foreign-import-prim names (prim-prefixed) to their canonical
-        // PrimOp enum variants.  The desugarer uses this to normalise the
-        // inner call name in buildPrimOpWrapper.
-        //
-        // IMPORTANT: Do NOT map the unprefixed Haskell function names
-        // (putStrLn, putStr, putChar, print) here.  Those are Haskell
-        // wrappers defined in the Prelude that correctly walk lazy
-        // cons-cell lists character-by-character.  Mapping them to raw
-        // primops would bypass the Haskell implementation, causing the
-        // evaluator to call charListToString on lists containing
-        // unevaluated thunks, leading to infinite recursion (#627).
+        if (std.mem.eql(u8, str, "putStrLn")) return .putStrLn_;
         if (std.mem.eql(u8, str, "primPutStrLn")) return .putStrLn_;
+        if (std.mem.eql(u8, str, "putStr")) return .write_stdout;
         if (std.mem.eql(u8, str, "primPutStr")) return .write_stdout;
+        if (std.mem.eql(u8, str, "putChar")) return .putChar_;
         if (std.mem.eql(u8, str, "primPutChar")) return .putChar_;
+        if (std.mem.eql(u8, str, "print")) return .write_stdout;
         return null;
     }
 };

--- a/src/repl/server.zig
+++ b/src/repl/server.zig
@@ -51,9 +51,12 @@ pub const ReplServer = struct {
         var session = try Session.init(allocator, io);
         errdefer session.deinit();
 
-        // Show-wrapping: enabled so the WASM REPL displays values using
-        // Haskell Show instances (e.g. `42` → "42", `[1,2]` → "[1,2]").
-        session.pipeline.enable_show_wrapping = true;
+        // Show-wrapping is disabled for the WASM server: the output goes
+        // to stdout via putStrLn but the JSON-RPC protocol returns the
+        // result as a value field.  Until stdout capture is wired into
+        // the response, the GRIN evaluator's ad-hoc formatter handles
+        // display.  Tracked as part of the Show-instance follow-up.
+        session.pipeline.enable_show_wrapping = false;
 
         return .{
             .allocator = allocator,


### PR DESCRIPTION
Closes #627 (partially — infrastructure for constrained instances)

## Summary

Adds infrastructure for dictionary-passing with constrained typeclass instances
(e.g. `instance Show a => Show [a]`), fixes test regressions from the initial
#627 commit, and cleans up the `fromPreludeName` / evaluator interaction.

## Changes

### Constrained instance dictionary-passing (desugar.zig)

1. **Instance dictionary lambda wrapping**: For instances with context constraints
   (e.g. `Show a => Show [a]`), the dictionary binding is now wrapped with lambda
   parameters for each constraint: `dict$Show$List = \dict$Show -> MkDict$Show (...)`.

2. **Context evidence application at call sites**: `buildDictExpr` now applies
   sub-dictionaries as arguments to constrained instance dictionaries, e.g.
   `dict$Show$List dict$Show$Char` for `Show [Char]`.

3. **`htypeHeadName` fix**: Maps `[]` to `"List"` so dictionary name lookup matches
   the instance head name from `instanceHeadName`.

4. **`lookupDictName` helper**: Linear scan lookup that works around `ArrayHashMap`
   issues with externally-seeded dictionary name maps.

### fromPreludeName / evaluator fix (primop.zig, evaluator.zig)

The initial #627 commit removed unprefixed IO function mappings from `fromPreludeName`,
which fixed the GRIN evaluator but broke the desugarer and GRIN translator (used at
compile time for standalone `rhc build`). This commit:

- Restores unprefixed mappings in `fromPreludeName` (needed by desugarer/translator)
- Guards the GRIN evaluator to only dispatch prim-prefixed names (`startsWith("prim")`)
- Fixes 7 e2e test failures introduced by the initial #627 commit

### WASM server (server.zig)

Disables show-wrapping for the WASM server. The JSON-RPC protocol returns values
in the response, but `putStrLn` writes to stdout — until stdout capture is wired
into the response, the GRIN evaluator's ad-hoc formatter handles display.

## What's NOT in this PR

The polymorphic `Show` instances remain commented out in the Prelude. Enabling them
requires evidence plumbing in instance method bodies (the inner `showListWith` call
needs the `dict$Show` parameter). This is tracked as #629.

## Testing

- All 908 tests pass (was 7 e2e failures + wasm-e2e failure before this commit)
- Manually verified GRIN IR for `dict$Show$List` is structurally correct via
  `rhc grin lib/Prelude.hs`
