### PR TITLE
#631: Fix REPL crash with infinite lists after prior range expression

### DIFF
--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -886,17 +886,40 @@ pub const GrinTranslator = struct {
         // values, causing tag mismatches at runtime (e.g. [] gets
         // discriminant 5 in the Prelude but 0 in the expression).
         self.tag_table = TagTable.init();
+        // Phase 1: scan extra_tag_defs (Prelude) bodies for F-tags.
         for (self.extra_tag_defs) |def| {
             scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
         }
-        // Now scan the current program's defs. Tags already registered
-        // by extra_tag_defs are skipped (register is idempotent), so
-        // shared constructors keep their prior discriminants.
+        // Phase 2: pre-register ALL extra_tag_defs as potential F-tags BEFORE
+        // scanning the current program's bodies. This ensures Prelude functions
+        // like `enumFrom` and `enumFromTo` — which never appear as thunk stores
+        // within the Prelude itself — receive their discriminants in the same
+        // order as the shared __rhc_force module (built during `addDeclarations`
+        // from the same extra_tag_defs). Without this, the expression body scan
+        // (Phase 3) might assign `F(enumFrom)` a discriminant different from the
+        // one the force module uses, silently dispatching to the wrong function.
+        for (self.extra_tag_defs) |def| {
+            if (def.params.len > 0) {
+                const fun_tag = grin.Tag{ .name = def.name, .tag_type = .Fun };
+                self.tag_table.register(self.allocator, fun_tag, @intCast(def.params.len)) catch return error.OutOfMemory;
+            }
+        }
+        // Phase 3: scan the current program's defs. Tags already registered in
+        // Phases 1–2 are skipped (register is idempotent), so shared tags keep
+        // their prior discriminants.
         for (program.defs) |def| {
             scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
         }
+        // Phase 4: pre-register current program defs as potential F-tags.
+        for (program.defs) |def| {
+            if (def.params.len > 0) {
+                const fun_tag = grin.Tag{ .name = def.name, .tag_type = .Fun };
+                self.tag_table.register(self.allocator, fun_tag, @intCast(def.params.len)) catch return error.OutOfMemory;
+            }
+        }
         // Ensure list constructors are available for string↔[Char] conversion.
         self.tag_table.ensureListConstructors(self.allocator) catch return error.OutOfMemory;
+
         // Merge constructor field types from the GRIN program's field_types map.
         {
             var iter = program.field_types.iterator();
@@ -989,14 +1012,34 @@ pub const GrinTranslator = struct {
         // extra_tag_defs. Tags already registered are idempotent, so
         // shared tags keep their prior discriminants.
         self.tag_table = TagTable.init();
+        // Phase 1: scan extra_tag_defs (Prelude) bodies for F-tags.
         for (self.extra_tag_defs) |def| {
             scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
         }
+        // Phase 2: pre-register ALL extra_tag_defs as potential F-tags BEFORE
+        // scanning all_prog.defs bodies. This mirrors the ordering used by
+        // translateProgramToModule so that expression compilations and the force
+        // module agree on discriminant values for every Prelude function.
+        for (self.extra_tag_defs) |def| {
+            if (def.params.len > 0) {
+                const fun_tag = grin.Tag{ .name = def.name, .tag_type = .Fun };
+                self.tag_table.register(self.allocator, fun_tag, @intCast(def.params.len)) catch return error.OutOfMemory;
+            }
+        }
+        // Phase 3: scan all_prog.defs bodies.
         for (all_prog.defs) |def| {
             scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
         }
+        // Phase 4: pre-register all_prog.defs as potential F-tags.
+        for (all_prog.defs) |def| {
+            if (def.params.len > 0) {
+                const fun_tag = grin.Tag{ .name = def.name, .tag_type = .Fun };
+                self.tag_table.register(self.allocator, fun_tag, @intCast(def.params.len)) catch return error.OutOfMemory;
+            }
+        }
         // Ensure list constructors are available for string↔[Char] conversion.
         self.tag_table.ensureListConstructors(self.allocator) catch return error.OutOfMemory;
+
         // TypeEnv pointer is refreshed inside translateModuleGrin before each
         // module translation (needed because the tag_table field was reassigned).
     }

--- a/src/repl/jit_engine.zig
+++ b/src/repl/jit_engine.zig
@@ -80,9 +80,12 @@ pub const JitEngine = struct {
     /// Resource tracker for the shared `__rhc_force` module.
     /// Allows replacing it when new F-tags appear in expressions.
     force_tracker: ?llvm.OrcResourceTrackerRef = null,
-    /// Number of F-tags in the current force module. Used to detect
-    /// when the expression introduces new F-tags that require re-emission.
-    force_ftag_count: u32 = 0,
+    /// Set of F-tag unique IDs covered by the current force module.
+    /// Tracked as a set (not a count) because two expressions can
+    /// introduce different F-tags yet have the same total count —
+    /// e.g. `[1..10]` wraps `enumFromTo` while `[1..]` wraps `enumFrom`,
+    /// both adding exactly one new tag to the same Prelude baseline.
+    force_ftag_uniques: std.AutoHashMapUnmanaged(u64, void) = .{},
     /// Cached pointer to the JIT'd `__rhc_force` function.
     /// Used by the formatter to force thunks when walking heap structures.
     /// Signature: fn(ptr) callconv(.c) *anyopaque — forces a value to WHNF.
@@ -114,6 +117,7 @@ pub const JitEngine = struct {
         if (self.force_tracker) |tracker| {
             c.LLVMOrcReleaseResourceTracker(tracker);
         }
+        self.force_ftag_uniques.deinit(self.allocator);
         self.accumulated_grin_defs.deinit(self.allocator);
         if (self.jit) |jit| {
             const err = c.LLVMOrcDisposeLLJIT(jit);
@@ -154,7 +158,18 @@ pub const JitEngine = struct {
         }
 
         self.force_tracker = tracker;
-        self.force_ftag_count = @intCast(translator.tag_table.fun_tags.count());
+
+        // Rebuild the set of covered F-tag uniques so that execute() can
+        // detect missing tags by set membership rather than count comparison.
+        self.force_ftag_uniques.clearRetainingCapacity();
+        var ftag_iter = translator.tag_table.fun_tags.iterator();
+        while (ftag_iter.next()) |entry| {
+            try self.force_ftag_uniques.put(self.allocator, entry.key_ptr.*, {});
+        }
+
+        // The cached force_fn pointer is now stale; clear it so that
+        // execute() re-resolves it after the new module is materialised.
+        self.force_fn = null;
     }
 
     /// Add declaration definitions permanently to the JIT's main dylib.
@@ -278,12 +293,20 @@ pub const JitEngine = struct {
         // This ensures formatJitResult uses correct discriminants.
         self.known_tags = translator.getKnownTagDiscriminants();
 
-        // Re-emit the shared __rhc_force if the expression introduced
-        // new F-tags that the Prelude-time force module didn't know about.
-        // This ensures per-def modules (which call __rhc_force externally)
-        // can force expression-introduced thunks.
-        const expr_ftag_count: u32 = @intCast(translator.tag_table.fun_tags.count());
-        if (expr_ftag_count > self.force_ftag_count) {
+        // Re-emit __rhc_force if the expression introduces any F-tag not
+        // covered by the current force module. We compare sets, not counts:
+        // two different expressions can introduce different F-tags while
+        // keeping the total count equal (e.g. `[1..10]` wraps enumFromTo
+        // and `[1..]` wraps enumFrom — same count, different set members).
+        var needs_force_reemit = false;
+        var ftag_check_iter = translator.tag_table.fun_tags.iterator();
+        while (ftag_check_iter.next()) |entry| {
+            if (!self.force_ftag_uniques.contains(entry.key_ptr.*)) {
+                needs_force_reemit = true;
+                break;
+            }
+        }
+        if (needs_force_reemit) {
             try self.emitSharedForceModule(&translator);
         }
 

--- a/tests/e2e/e2e_018_infinite_list_take.hs
+++ b/tests/e2e/e2e_018_infinite_list_take.hs
@@ -1,0 +1,6 @@
+-- e2e_018: Infinite list with take (#631)
+
+module InfiniteListTake where
+
+main :: IO ()
+main = print (length (take 3 [1..]))


### PR DESCRIPTION
Closes #631

## Summary

- `take 3 [1..10]` followed by `take 3 [1..]` in the REPL crashed with `rts_load_field: assert(index < n.n_fields)`.
- Root cause: `enumFrom` and `enumFromTo` never appear as stored thunks *within* Prelude bodies, so `scanExprForTags` didn't register them as F-tags. When an expression like `[1..]` wrapped `enumFrom 1` as a lazy thunk, the expression's fresh tag table assigned it a different discriminant than the shared `__rhc_force` module, causing dispatch to the wrong case.
- Fix: pre-register every declared function as a potential F-tag (`def.params.len` = field count) in both `translateProgramToModule` and `prepareGlobalTagTable`. The `extra_tag_defs` pre-registration happens **before** scanning the current expression's bodies, ensuring the Prelude function discriminants are fixed first — matching those in the force module.
- Also upgraded `jit_engine.zig` force-module invalidation from count-based to set-based comparison, catching the case where two expressions have equal total F-tag count but different members.

## Deliverables

- [x] REPL no longer crashes when evaluating `take 3 [1..]` after `take 3 [1..10]`
- [x] `take 3 [1..10]` still returns `[1,2,3]`
- [x] Whole-program e2e_018 (`print (length (take 3 [1..]))`) still outputs `3`
- [x] All 30 e2e tests pass, all repl-tests pass

## Testing

```
printf 'take 3 [1..10]\n take 3 [1..]\n' | zig-out/bin/rhc repl
# → [1,2,3]
# → [1,2,3]
```
