### PR TITLE
Fix REPL segfault after :l by persisting tag table discriminants

### DIFF
--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -290,7 +290,7 @@ const PrimOpResult = union(enum) {
 /// discriminants even when they share the same name unique.
 ///
 /// See: https://github.com/adinapoli/rusholme/issues/449
-const TagTable = struct {
+pub const TagTable = struct {
     /// Discriminant assigned to each tag, keyed by composite `tagKey`.
     discriminants: std.AutoHashMapUnmanaged(u64, i64),
     /// Number of fields for each tag, keyed by composite `tagKey`.
@@ -329,7 +329,7 @@ const TagTable = struct {
     // Closure=0x200). This matches rts/node.zig Tag.Data = 0x1000.
     const first_discriminant: i64 = 0x1000;
 
-    fn init() TagTable {
+    pub fn init() TagTable {
         return .{
             .discriminants = .{},
             .field_counts = .{},
@@ -343,7 +343,66 @@ const TagTable = struct {
         };
     }
 
-    fn deinit(self: *TagTable, alloc: std.mem.Allocator) void {
+    /// Deep-copy this tag table.  The clone owns independent copies of
+    /// all heap-allocated field-type slices, so it can be mutated and
+    /// freed without affecting the original.
+    pub fn clone(self: *const TagTable, alloc: std.mem.Allocator) !TagTable {
+        var result = TagTable{
+            .discriminants = .{},
+            .field_counts = .{},
+            .field_types = .{},
+            .fun_tags = .{},
+            .fun_tag_names = .{},
+            .partial_tags = .{},
+            .partial_tag_info = .{},
+            .con_name_to_disc = .{},
+            .next = self.next,
+        };
+        errdefer result.deinit(alloc);
+
+        // Clone simple maps (values are scalars or small structs).
+        {
+            var it = self.discriminants.iterator();
+            while (it.next()) |e| try result.discriminants.put(alloc, e.key_ptr.*, e.value_ptr.*);
+        }
+        {
+            var it = self.field_counts.iterator();
+            while (it.next()) |e| try result.field_counts.put(alloc, e.key_ptr.*, e.value_ptr.*);
+        }
+        {
+            var it = self.fun_tags.iterator();
+            while (it.next()) |e| try result.fun_tags.put(alloc, e.key_ptr.*, {});
+        }
+        {
+            var it = self.fun_tag_names.iterator();
+            while (it.next()) |e| try result.fun_tag_names.put(alloc, e.key_ptr.*, e.value_ptr.*);
+        }
+        {
+            var it = self.partial_tags.iterator();
+            while (it.next()) |e| try result.partial_tags.put(alloc, e.key_ptr.*, {});
+        }
+        {
+            var it = self.partial_tag_info.iterator();
+            while (it.next()) |e| try result.partial_tag_info.put(alloc, e.key_ptr.*, e.value_ptr.*);
+        }
+        {
+            var it = self.con_name_to_disc.iterator();
+            while (it.next()) |e| try result.con_name_to_disc.put(alloc, e.key_ptr.*, e.value_ptr.*);
+        }
+
+        // Deep-copy field_types: each value is a heap-allocated []FieldType.
+        {
+            var it = self.field_types.iterator();
+            while (it.next()) |e| {
+                const duped = try alloc.dupe(FieldType, e.value_ptr.*);
+                try result.field_types.put(alloc, e.key_ptr.*, duped);
+            }
+        }
+
+        return result;
+    }
+
+    pub fn deinit(self: *TagTable, alloc: std.mem.Allocator) void {
         self.discriminants.deinit(alloc);
         self.field_counts.deinit(alloc);
         // Free each field_types slice
@@ -876,37 +935,33 @@ pub const GrinTranslator = struct {
     /// The module is owned by this translator's context — do not dispose it
     /// separately; it is freed when the translator is deinited.
     pub fn translateProgramToModule(self: *GrinTranslator, program: grin.Program) TranslationError!llvm.Module {
-        // Build the tag table by scanning extra defs FIRST (from prior
-        // REPL sessions like the Prelude), then the current program.
-        // Order matters: scanning extra defs first ensures that
-        // constructors from prior sessions receive the same discriminants
-        // they had when they were originally compiled. If we scanned the
-        // current program first, its constructors would claim discriminants
-        // 0, 1, 2... and prior session constructors would get different
-        // values, causing tag mismatches at runtime (e.g. [] gets
-        // discriminant 5 in the Prelude but 0 in the expression).
-        self.tag_table = TagTable.init();
-        // Phase 1: scan extra_tag_defs (Prelude) bodies for F-tags.
-        for (self.extra_tag_defs) |def| {
-            scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
-        }
-        // Phase 2: pre-register ALL extra_tag_defs as potential F-tags BEFORE
-        // scanning the current program's bodies. This ensures Prelude functions
-        // like `enumFrom` and `enumFromTo` — which never appear as thunk stores
-        // within the Prelude itself — receive their discriminants in the same
-        // order as the shared __rhc_force module (built during `addDeclarations`
-        // from the same extra_tag_defs). Without this, the expression body scan
-        // (Phase 3) might assign `F(enumFrom)` a discriminant different from the
-        // one the force module uses, silently dispatching to the wrong function.
-        for (self.extra_tag_defs) |def| {
-            if (def.params.len > 0) {
-                const fun_tag = grin.Tag{ .name = def.name, .tag_type = .Fun };
-                self.tag_table.register(self.allocator, fun_tag, @intCast(def.params.len)) catch return error.OutOfMemory;
+        // If the tag table has been pre-seeded by the JIT engine (from
+        // a persistent base_tag_table), all prior discriminant assignments
+        // are already present.  Skip Phases 1–2 (extra_tag_defs scanning)
+        // so that new defs in extra_tag_defs cannot shift existing
+        // discriminants — only the current program's defs are scanned.
+        //
+        // Without pre-seeding, build from scratch (batch compiler path
+        // and first REPL compilation before a base table exists).
+        const preseeded = self.tag_table.discriminants.count() > 0;
+        if (!preseeded) {
+            self.tag_table = TagTable.init();
+            // Phase 1: scan extra_tag_defs (Prelude) bodies for tags.
+            for (self.extra_tag_defs) |def| {
+                scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
+            }
+            // Phase 2: pre-register ALL extra_tag_defs as potential F-tags
+            // BEFORE scanning the current program's bodies.
+            for (self.extra_tag_defs) |def| {
+                if (def.params.len > 0) {
+                    const fun_tag = grin.Tag{ .name = def.name, .tag_type = .Fun };
+                    self.tag_table.register(self.allocator, fun_tag, @intCast(def.params.len)) catch return error.OutOfMemory;
+                }
             }
         }
-        // Phase 3: scan the current program's defs. Tags already registered in
-        // Phases 1–2 are skipped (register is idempotent), so shared tags keep
-        // their prior discriminants.
+        // Phase 3: scan the current program's defs. Tags already registered
+        // (from pre-seeding or Phases 1–2) are skipped (register is
+        // idempotent), so existing tags keep their prior discriminants.
         for (program.defs) |def| {
             scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
         }
@@ -1004,29 +1059,27 @@ pub const GrinTranslator = struct {
     ///
     /// Any previously held tag table is released.
     pub fn prepareGlobalTagTable(self: *GrinTranslator, all_prog: grin.Program) TranslationError!void {
-        self.tag_table.deinit(self.allocator);
-        // Scan extra_tag_defs FIRST (from prior REPL sessions like the
-        // Prelude), then the current program's defs. Order matters:
-        // scanning extra defs first ensures discriminant assignments are
-        // consistent with expression compilations that also use
-        // extra_tag_defs. Tags already registered are idempotent, so
-        // shared tags keep their prior discriminants.
-        self.tag_table = TagTable.init();
-        // Phase 1: scan extra_tag_defs (Prelude) bodies for F-tags.
-        for (self.extra_tag_defs) |def| {
-            scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
-        }
-        // Phase 2: pre-register ALL extra_tag_defs as potential F-tags BEFORE
-        // scanning all_prog.defs bodies. This mirrors the ordering used by
-        // translateProgramToModule so that expression compilations and the force
-        // module agree on discriminant values for every Prelude function.
-        for (self.extra_tag_defs) |def| {
-            if (def.params.len > 0) {
-                const fun_tag = grin.Tag{ .name = def.name, .tag_type = .Fun };
-                self.tag_table.register(self.allocator, fun_tag, @intCast(def.params.len)) catch return error.OutOfMemory;
+        // If the tag table has been pre-seeded by the JIT engine, all
+        // prior discriminant assignments are present.  Skip Phases 1–2
+        // (extra_tag_defs scanning) to avoid shifting discriminants.
+        const preseeded = self.tag_table.discriminants.count() > 0;
+        if (!preseeded) {
+            self.tag_table.deinit(self.allocator);
+            self.tag_table = TagTable.init();
+            // Phase 1: scan extra_tag_defs bodies for tags.
+            for (self.extra_tag_defs) |def| {
+                scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
+            }
+            // Phase 2: pre-register ALL extra_tag_defs as potential F-tags.
+            for (self.extra_tag_defs) |def| {
+                if (def.params.len > 0) {
+                    const fun_tag = grin.Tag{ .name = def.name, .tag_type = .Fun };
+                    self.tag_table.register(self.allocator, fun_tag, @intCast(def.params.len)) catch return error.OutOfMemory;
+                }
             }
         }
-        // Phase 3: scan all_prog.defs bodies.
+        // Phase 3: scan all_prog.defs bodies.  Existing tags are
+        // skipped (register is idempotent).
         for (all_prog.defs) |def| {
             scanExprForTags(self.allocator, def.body, &self.tag_table) catch return error.OutOfMemory;
         }

--- a/src/repl/jit_engine.zig
+++ b/src/repl/jit_engine.zig
@@ -75,6 +75,13 @@ pub const JitEngine = struct {
     /// that expression compilation can scan them for F-tag registration,
     /// enabling `forceValueToWhnf` to handle thunks from any session.
     accumulated_grin_defs: std.ArrayListUnmanaged(grin_ast.Def) = .{},
+    /// Persistent tag table accumulated across `addDeclarations` calls.
+    /// Cloned into each new translator to ensure discriminant stability:
+    /// once a tag receives a discriminant, all future compilations reuse
+    /// it.  Without this, loading a file via `:l` can shift Prelude
+    /// F-tag discriminants, causing segfaults when expression code
+    /// creates thunks that the Prelude's already-JIT'd code forces.
+    base_tag_table: grin_to_llvm.TagTable = grin_to_llvm.TagTable.init(),
     /// Constructor discriminants from Prelude compilation for result formatting.
     known_tags: KnownTags = .{},
     /// Resource tracker for the shared `__rhc_force` module.
@@ -118,6 +125,7 @@ pub const JitEngine = struct {
             c.LLVMOrcReleaseResourceTracker(tracker);
         }
         self.force_ftag_uniques.deinit(self.allocator);
+        self.base_tag_table.deinit(self.allocator);
         self.accumulated_grin_defs.deinit(self.allocator);
         if (self.jit) |jit| {
             const err = c.LLVMOrcDisposeLLJIT(jit);
@@ -205,9 +213,25 @@ pub const JitEngine = struct {
         // expression compilations that also scan these defs.
         translator.extra_tag_defs = self.accumulated_grin_defs.items;
 
-        // Build a global tag table from all defs.
+        // Pre-seed the translator's tag table from the persistent base
+        // so that all prior discriminant assignments are preserved.
+        // prepareGlobalTagTable will skip Phases 1–2 (extra_tag_defs
+        // scanning) and only scan the new program's defs.
+        if (self.base_tag_table.discriminants.count() > 0) {
+            translator.tag_table.deinit(self.allocator);
+            translator.tag_table = self.base_tag_table.clone(self.allocator) catch
+                return JitError.OutOfMemory;
+        }
+
+        // Build the tag table: extends the pre-seeded base (or builds
+        // from scratch on first call) with the new program's tags.
         translator.prepareGlobalTagTable(program.*) catch
             return JitError.TranslationFailed;
+
+        // Persist the extended tag table for future compilations.
+        self.base_tag_table.deinit(self.allocator);
+        self.base_tag_table = translator.tag_table.clone(self.allocator) catch
+            return JitError.OutOfMemory;
 
         // Capture constructor discriminants for result formatting.
         self.known_tags = translator.getKnownTagDiscriminants();
@@ -282,6 +306,14 @@ pub const JitEngine = struct {
         // Seed with accumulated defs from prior declaration sessions so
         // that the tag table includes F-tags for all known functions.
         translator.extra_tag_defs = self.accumulated_grin_defs.items;
+
+        // Pre-seed the translator's tag table from the persistent base
+        // so that discriminants are consistent with already-JIT'd code.
+        if (self.base_tag_table.discriminants.count() > 0) {
+            translator.tag_table.deinit(self.allocator);
+            translator.tag_table = self.base_tag_table.clone(self.allocator) catch
+                return JitError.OutOfMemory;
+        }
 
         const ir_text = translator.translateProgram(patched_program) catch {
             return JitError.TranslationFailed;

--- a/tests/repl/repl_tests.zig
+++ b/tests/repl/repl_tests.zig
@@ -995,3 +995,46 @@ test "repl: load file with comments then evaluate main (issue #494)" {
     };
     try testing.expectEqual(Status.silent, main_result.status);
 }
+
+// ── Regression: :l + expression must not segfault ────────────────────
+
+test "repl: expression after :l file does not crash (tag table stability)" {
+    // Regression test: loading a file via :l adds defs to accumulated_grin_defs.
+    // Without persistent tag table pre-seeding, the extra defs shift Prelude
+    // F-tag discriminants in subsequent expression compilations, causing a
+    // segfault when Prelude code forces thunks with mismatched tags.
+    //
+    // Reproduction: :l file-with-main, evaluate main, evaluate "a" ++ "b" → segfault.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var session = Session.init(alloc, testing_io) catch |err| {
+        std.debug.panic("Failed to init session: {}", .{err});
+    };
+    defer session.deinit();
+
+    // Step 1: load declarations (simulates :l with a file that uses infinite lists)
+    const file_body =
+        \\main :: IO ()
+        \\main = print (length (take 3 [1..]))
+    ;
+    const load_result = evaluate(alloc, &session, file_body) catch |err| {
+        std.debug.panic("load evaluate failed: {s}", .{@errorName(err)});
+    };
+    try testing.expectEqual(Status.silent, load_result.status);
+
+    // Step 2: evaluate main (exercises Prelude functions and creates thunks)
+    const main_result = evaluate(alloc, &session, "main") catch |err| {
+        std.debug.panic("main evaluate failed: {s}", .{@errorName(err)});
+    };
+    try testing.expectEqual(Status.silent, main_result.status);
+
+    // Step 3: evaluate a string expression — this used to segfault because
+    // the Prelude's (++) code was JIT'd with discriminant X for F-tags
+    // but the expression's tag table assigned discriminant Y.
+    const concat_result = evaluate(alloc, &session, "\"a\" ++ \"b\"") catch |err| {
+        std.debug.panic("concat evaluate failed: {s}", .{@errorName(err)});
+    };
+    try testing.expectEqual(Status.silent, concat_result.status);
+}


### PR DESCRIPTION
## Summary

- Fix REPL segfault when evaluating expressions after `:l` loads a file
- Root cause: F-tag discriminant drift when `extra_tag_defs` grows between compilations (same class as #631)
- Fix: persist the tag table in `JitEngine.base_tag_table` so discriminants are stable across all compilations
- Filed #636 for the principled architectural fix (persistent `TagRegistry`)

## Reproducer

```
rusholme> :l tests/e2e/e2e_018_infinite_list_take.hs
Loaded: tests/e2e/e2e_018_infinite_list_take.hs
rusholme> main
3
rusholme> "a" ++ "b"
Segmentation fault at address 0x7f953e19d428
```

## Root cause

Each `addDeclarations` / `execute` call rebuilt the tag table from scratch. When `:l` added file defs to `extra_tag_defs`, the file's body scan (Phase 1) inserted new tags between Prelude body tags and Prelude F-tag pre-registrations, shifting F-tag discriminants. The Prelude's already-JIT'd code used old discriminants; expression code used shifted ones — thunk forcing dispatched to the wrong case.

## Changes

| File | Change |
|------|--------|
| `src/backend/grin_to_llvm.zig` | Make `TagTable` public, add `clone()`, skip Phases 1-2 when pre-seeded |
| `src/repl/jit_engine.zig` | Add `base_tag_table`, clone into translators, save after `addDeclarations` |
| `tests/repl/repl_tests.zig` | Regression test: `:l` file → `main` → `"a" ++ "b"` |

## Testing

- 908/908 tests pass
- New regression test covers the exact reproduction scenario
- Manual REPL test confirms no segfault

🤖 Generated with [Claude Code](https://claude.com/claude-code)
