### PR TITLE
Fix exponential blowup in compilation of nested constructor patterns

### DIFF
--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -824,6 +824,13 @@ pub const GrinTranslator = struct {
     /// Keyed by `Name.unique.value` so that variables with the same base name
     /// but different uniques (e.g. `arg_20`, `arg_21`) are kept distinct.
     params: std.AutoHashMap(u64, llvm.Value),
+    /// Per-function cache for translated GRIN Case expressions.  The
+    /// sequential pattern-match desugarer creates shared fallback nodes
+    /// (a DAG) that would be re-translated exponentially without caching.
+    /// Keyed by the GRIN expression pointer (as usize); value is the LLVM
+    /// basic block where the translated case's dispatch logic starts.
+    /// Cleared at the start of each `translateDef` call.
+    case_entry_cache: std.AutoHashMap(usize, llvm.BasicBlock),
     /// Constructor tag discriminants, built before translation.
     tag_table: TagTable,
     /// HPT-lite type environment for type-correct LLVM codegen.
@@ -861,6 +868,7 @@ pub const GrinTranslator = struct {
             .builder = llvm.createBuilder(ctx),
             .allocator = allocator,
             .params = std.AutoHashMap(u64, llvm.Value).init(allocator),
+            .case_entry_cache = std.AutoHashMap(usize, llvm.BasicBlock).init(allocator),
             .tag_table = TagTable.init(),
             .type_env = TypeEnv.init(),
             .current_func = null,
@@ -869,6 +877,7 @@ pub const GrinTranslator = struct {
 
     pub fn deinit(self: *GrinTranslator) void {
         self.params.deinit();
+        self.case_entry_cache.deinit();
         self.tag_table.deinit(self.allocator);
         self.type_env.deinit(self.allocator);
         llvm.disposeBuilder(self.builder);
@@ -1226,6 +1235,11 @@ pub const GrinTranslator = struct {
         self.params.deinit();
         self.params = std.AutoHashMap(u64, llvm.Value).init(self.allocator);
 
+        // Clear the per-function case expression cache.  The cache prevents
+        // exponential re-translation of shared GRIN expressions produced by the
+        // sequential pattern-match compiler.
+        self.case_entry_cache.clearRetainingCapacity();
+
         // Store each parameter as a named value in the params map.
         for (def.params, 0..) |param_name, i| {
             const param_val = c.LLVMGetParam(func, @intCast(i));
@@ -1330,7 +1344,28 @@ pub const GrinTranslator = struct {
         switch (expr.*) {
             .App => |app| try self.translateApp(app.name, app.args),
             .Bind => |b| try self.translateBind(b.lhs, b.pat, b.rhs),
-            .Case => |case_| try self.translateCase(case_.scrutinee, case_.alts),
+            .Case => |case_| {
+                // The sequential pattern-match desugarer creates shared
+                // fallback nodes (a DAG).  Without caching, each shared
+                // node is re-translated at every occurrence, causing
+                // exponential blowup in basic blocks and compile time.
+                //
+                // Cache by GRIN expression pointer: if we've already
+                // translated this exact Case node, branch to its entry
+                // block instead of re-emitting the dispatch logic.
+                const expr_key = @intFromPtr(expr);
+                if (self.case_entry_cache.get(expr_key)) |cached_entry| {
+                    _ = c.LLVMBuildBr(self.builder, cached_entry);
+                    return;
+                }
+                // First encounter: create an entry block, cache it, then
+                // translate the case normally.
+                const case_entry = c.LLVMAppendBasicBlock(self.current_func, "case.shared");
+                _ = c.LLVMBuildBr(self.builder, case_entry);
+                llvm.positionBuilderAtEnd(self.builder, case_entry);
+                self.case_entry_cache.put(expr_key, case_entry) catch return error.OutOfMemory;
+                try self.translateCase(case_.scrutinee, case_.alts);
+            },
             .Store => |val| try self.translateStore(val),
             .Fetch => |f| try self.translateFetch(f.ptr, f.index),
             .Update => |u| try self.translateUpdate(u.ptr, u.val),
@@ -1454,7 +1489,27 @@ pub const GrinTranslator = struct {
             },
             .Case => |case_expr| {
                 // Case expression in value-producing context (e.g., nested in a bind RHS).
-                // Use translateCaseToValue to generate phi nodes instead of returns.
+                //
+                // Shared GRIN Case nodes (from the desugarer's DAG) may appear
+                // multiple times in alt bodies.  If we've already translated this
+                // exact Case node, branch to its cached entry block instead of
+                // re-translating.  The cached code terminates with ret/br so
+                // control never returns — we emit a dead placeholder block for
+                // the caller to continue emitting without LLVM errors.
+                const expr_key = @intFromPtr(expr);
+                if (self.case_entry_cache.get(expr_key)) |cached_entry| {
+                    _ = c.LLVMBuildBr(self.builder, cached_entry);
+                    const dead_bb = c.LLVMAppendBasicBlock(self.current_func, "dead.cached");
+                    llvm.positionBuilderAtEnd(self.builder, dead_bb);
+                    return @as(?llvm.Value, c.LLVMConstPointerNull(ptrType()));
+                }
+                // First encounter: create an entry block and cache it before
+                // translating, so that subsequent encounters of this shared
+                // Case node can branch here directly.
+                const case_entry = c.LLVMAppendBasicBlock(self.current_func, "caseval.shared");
+                _ = c.LLVMBuildBr(self.builder, case_entry);
+                llvm.positionBuilderAtEnd(self.builder, case_entry);
+                self.case_entry_cache.put(expr_key, case_entry) catch return error.OutOfMemory;
                 return try self.translateCaseToValue(case_expr.scrutinee, case_expr.alts, result_name);
             },
             else => {

--- a/src/core/lift.zig
+++ b/src/core/lift.zig
@@ -139,6 +139,12 @@ pub const LambdaLifter = struct {
     expr_to_lambda: std.AutoHashMapUnmanaged(usize, u64),
     /// Stack of frames representing nested scopes.
     frames: std.ArrayListUnmanaged(Frame),
+    /// Memoization cache for rewriteExpr, keyed by source expression pointer.
+    /// Preserves pointer sharing from the desugarer: the sequential
+    /// pattern-match algorithm produces shared fallback nodes (a DAG), and
+    /// without this cache rewriteExpr would clone each shared subtree at
+    /// every occurrence, causing exponential blowup in AST size.
+    rewrite_cache: std.AutoHashMapUnmanaged(usize, *Expr) = .{},
 
     pub fn init(alloc: std.mem.Allocator) LambdaLifter {
         return .{
@@ -160,6 +166,7 @@ pub const LambdaLifter = struct {
         self.lambdas.deinit(self.alloc);
         self.expr_to_lambda.deinit(self.alloc);
         self.frames.deinit(self.alloc);
+        self.rewrite_cache.deinit(self.alloc);
     }
 
     /// Push a new scope frame.
@@ -499,6 +506,12 @@ pub const LambdaLifter = struct {
 
     /// Rewrite an expression, replacing lifted lambdas with function calls.
     fn rewriteExpr(self: *LambdaLifter, expr: *const Expr, current_binders: []const u64) LifterError!*Expr {
+        // Memoize: if we've already rewritten this exact expression, reuse
+        // the result.  This preserves pointer sharing from the desugarer's
+        // sequential pattern-match algorithm (shared fallback nodes).
+        const expr_key = @intFromPtr(expr);
+        if (self.rewrite_cache.get(expr_key)) |cached| return cached;
+
         const new_expr = try self.alloc.create(Expr);
 
         switch (expr.*) {
@@ -629,6 +642,7 @@ pub const LambdaLifter = struct {
             },
         }
 
+        self.rewrite_cache.put(self.alloc, expr_key, new_expr) catch return error.OutOfMemory;
         return new_expr;
     }
 

--- a/src/grin/translate.zig
+++ b/src/grin/translate.zig
@@ -114,6 +114,12 @@ const TranslateCtx = struct {
     // Non-App complex expressions in constructor arguments are lifted into
     // helper functions so they can be suspended as F-tagged thunks (issue #518).
     lifted_defs: std.ArrayListUnmanaged(GrinDef) = .{},
+    // Cache for translated Core expressions, preserving pointer sharing.
+    // The sequential pattern-match desugarer creates shared fallback nodes
+    // (a DAG).  Without this cache, each shared node produces a separate
+    // GRIN expression, and the LLVM backend's eval-loop-per-case construction
+    // causes exponential blowup (see e2e_007_inductive_list).
+    expr_cache: std.AutoHashMapUnmanaged(usize, *GrinExpr) = .{},
 
     pub fn init(alloc: std.mem.Allocator) TranslateCtx {
         return .{
@@ -130,6 +136,7 @@ const TranslateCtx = struct {
         // arity_map ownership is transferred to GrinProgram - do not deinit
         self.con_map.deinit(self.alloc);
         self.lifted_defs.deinit(self.alloc);
+        self.expr_cache.deinit(self.alloc);
 
         // Note: con_field_types and arities ownership transferred to GrinProgram in translateProgram
         // The caller (translateProgram) takes ownership and handles cleanup
@@ -682,6 +689,13 @@ fn translateDef(ctx: *TranslateCtx, pair: CoreBindPair) !GrinDef {
 
 /// Translate a Core expression to a GRIN expression.
 fn translateExpr(ctx: *TranslateCtx, expr: *const CoreExpr) !*GrinExpr {
+    // Preserve pointer sharing from the Core AST.  The sequential
+    // pattern-match desugarer produces shared fallback nodes (a DAG);
+    // without this cache each occurrence creates a separate GRIN tree,
+    // which the LLVM backend then translates exponentially many times.
+    const expr_key = @intFromPtr(expr);
+    if (ctx.expr_cache.get(expr_key)) |cached| return cached;
+
     const new_expr = try ctx.alloc.create(GrinExpr);
 
     switch (expr.*) {
@@ -766,6 +780,7 @@ fn translateExpr(ctx: *TranslateCtx, expr: *const CoreExpr) !*GrinExpr {
         },
     }
 
+    try ctx.expr_cache.put(ctx.alloc, expr_key, new_expr);
     return new_expr;
 }
 


### PR DESCRIPTION
## Summary

Fixes exponential blowup in compilation of programs with nested constructor patterns (e.g. `intToString (Succ (Succ Zero)) = "2"`). Both `e2e_007_inductive_list` and `e2e_006_peano` were hanging indefinitely during compilation; they now compile in ~1s.

## Root Cause

The sequential pattern-match desugarer (Sestoft's algorithm in `desugarMatch`) produces shared fallback nodes — the Core AST is a DAG, not a tree. Each equation's default branch points to the same `current_body` expression from the previous equation. Three downstream passes destroyed this sharing by cloning nodes independently:

1. **Lambda lifter** (`rewriteExpr`): allocated a fresh `Expr` for every node unconditionally, turning the shared DAG into an exponentially large tree. For `intToString` (8 equations, depth 6), this produced ~5,000+ duplicate Case subtrees.

2. **GRIN translator** (`translateExpr`): created a fresh `GrinExpr` for each Core node, propagating the exponential tree into the GRIN AST.

3. **LLVM backend** (`translateCase`/`translateCaseToValue`): emitted a full eval loop (with N F-tag basic blocks each) per Case node, amplifying each duplicate into ~30+ LLVM basic blocks — hundreds of thousands total.

## Fix

Add memoization caches at all three levels, keyed by source expression pointer. No translation logic is changed — the caches simply ensure each shared subtree is translated exactly once:

- **`LambdaLifter.rewrite_cache`** — preserves Core AST sharing through lambda lifting (the primary fix)
- **`TranslateCtx.expr_cache`** — preserves sharing from Core into the GRIN AST
- **`GrinTranslator.case_entry_cache`** — prevents re-translating shared GRIN Case nodes into duplicate LLVM basic blocks; used by both the `translateExpr` (ret-based) and `translateExprToValue` (phi-based) paths; cleared per function in `translateDef`

## Testing

- `e2e_007_inductive_list`: was hanging indefinitely, now compiles in ~1s and outputs `3` ✅
- `e2e_006_peano`: was hanging indefinitely, now compiles in ~1s and outputs `5` ✅
- Full test suite: 908/908 tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
