### PR TITLE
#531: Add Eq type class with instances for Int and Bool

### DIFF
--- a/lib/Prelude.hs
+++ b/lib/Prelude.hs
@@ -13,6 +13,7 @@ module Prelude
     , error
     , intToChar, charToInt
     , max
+    , Eq(..)
     , Show(..), show, showString, showListWith, showListTail
     , intToDigit
     , enumFrom, enumFromTo, enumFromThen, enumFromThenTo
@@ -159,14 +160,8 @@ max x y = case x >= y of
     False -> y
 
 -- ========================================================================
--- Comparison (monomorphic on Int, pending type classes #531)
+-- Comparison (monomorphic on Int, pending Ord class in #531)
 -- ========================================================================
-
-(==) :: Int -> Int -> Bool
-(==) = primEqInt
-
-(/=) :: Int -> Int -> Bool
-(/=) = primNeInt
 
 (<) :: Int -> Int -> Bool
 (<) = primLtInt
@@ -179,6 +174,39 @@ max x y = case x >= y of
 
 (>=) :: Int -> Int -> Bool
 (>=) = primGeInt
+
+-- ========================================================================
+-- Eq type class
+-- ========================================================================
+
+-- Helper functions for Eq Bool — top-level to avoid nested-lambda free-variable
+-- issues in the lambda lifter (tracked in: https://github.com/adinapoli/rusholme/issues/659).
+eqBool :: Bool -> Bool -> Bool
+eqBool True  True  = True
+eqBool True  False = False
+eqBool False True  = False
+eqBool False False = True
+
+neBool :: Bool -> Bool -> Bool
+neBool True  True  = False
+neBool True  False = True
+neBool False True  = True
+neBool False False = False
+
+-- Note: the default method `x /= y = not (x == y)` is intentionally omitted.
+-- A default method in the first class causes subsequent class methods to be
+-- unbound in the typechecker (tracked in: https://github.com/adinapoli/rusholme/issues/660).
+class Eq a where
+  (==) :: a -> a -> Bool
+  (/=) :: a -> a -> Bool
+
+instance Eq Int where
+  (==) = primEqInt
+  (/=) = primNeInt
+
+instance Eq Bool where
+  (==) = eqBool
+  (/=) = neBool
 
 -- ========================================================================
 -- Higher-order combinators

--- a/tests/e2e/e2e_eq_bool.hs
+++ b/tests/e2e/e2e_eq_bool.hs
@@ -1,0 +1,7 @@
+module Main where
+
+main :: IO ()
+main = do
+  print (True == True)
+  print (False == True)
+  print (True /= False)

--- a/tests/e2e/e2e_eq_bool.properties
+++ b/tests/e2e/e2e_eq_bool.properties
@@ -1,0 +1,1 @@
+skip=false

--- a/tests/e2e/e2e_eq_bool.stdout
+++ b/tests/e2e/e2e_eq_bool.stdout
@@ -1,0 +1,3 @@
+True
+False
+True

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -315,3 +315,7 @@ test "e2e: e2e_factorial (#624)" {
 test "e2e: e2e_show_polymorphic" {
     try testE2e(std.testing.allocator, "e2e_show_polymorphic");
 }
+
+test "e2e: e2e_eq_bool (#531)" {
+    try testE2e(std.testing.allocator, "e2e_eq_bool");
+}


### PR DESCRIPTION
Closes #531

## Summary

Adds `class Eq a` with instances for `Int` and `Bool` to `lib/Prelude.hs`, making
`(==)` and `(/=)` fully polymorphic via dictionary-passing.

### Changes

- **`lib/Prelude.hs`**: Replace monomorphic `(==)`/`(/=)` with `class Eq a` declaration,
  `instance Eq Int` (delegating to primEqInt/primNeInt), and `instance Eq Bool`
  via top-level helpers `eqBool`/`neBool`. Export `Eq(..)`.
- **`tests/e2e/e2e_eq_bool.{hs,stdout,properties}`**: New e2e test covering
  `True == True`, `False == True`, and `True /= False`.
- **`tests/e2e_test_runner.zig`**: Register the new test.

### Two compiler bugs discovered and filed

1. **#659** — Lambda lifter propagates outer lambda's parameter as free variable
   from inner lifted lambda. Workaround: `eqBool`/`neBool` are top-level functions
   (not inline lambdas in the instance) so they aren't subject to lifting.

2. **#660** — Default method in a class declaration corrupts subsequent class
   method name resolution in the typechecker. Workaround: `class Eq a` omits
   the default `x /= y = not (x == y)` — both methods must be provided by each
   instance. Both issues are tracked with cross-reference comments in the Prelude.

## Deliverables
- [x] `class Eq a` with `(==)` and `(/=)` methods
- [x] `instance Eq Int`
- [x] `instance Eq Bool`
- [x] `Eq(..)` exported from Prelude
- [x] e2e test `e2e_eq_bool` added and passing
- [x] All 912 existing tests still pass
