### PR TITLE
#592: Fix GRIN evaluator dropping first IO action in >> App handler

### DIFF
--- a/src/grin/evaluator.zig
+++ b/src/grin/evaluator.zig
@@ -874,6 +874,11 @@ pub const GrinEvaluator = struct {
                 // argument as its parameter.
                 if (std.mem.eql(u8, app.name.base, ">>")) {
                     if (app.args.len != 2) return error.ArityMismatch;
+                    // Evaluate the first action for its side effects (#592).
+                    // Without this, eta-reduced IO bindings like
+                    // `putStrLn = primPutStrLn` lose the first action's
+                    // side effects when `>>` reaches the App handler.
+                    _ = try self.resolveVal(@constCast(&app.args[0]));
                     break :b try self.resolveVal(@constCast(&app.args[1]));
                 }
                 if (std.mem.eql(u8, app.name.base, ">>=")) {

--- a/tests/repl/wasm_e2e_tests.zig
+++ b/tests/repl/wasm_e2e_tests.zig
@@ -548,11 +548,8 @@ test "wasm e2e: putStrLn produces output" {
 }
 
 test "wasm e2e: do-notation with multiple putStrLn" {
-    // Known issue: with the Prelude loaded (#591), putStrLn resolves to
-    // the Prelude's eta-reduced `putStrLn = primPutStrLn` instead of the
-    // built-in primop. The GRIN evaluator drops the first IO action in
-    // a do-block when putStrLn is an eta-reduced alias. Only the last
-    // action produces output. Tracked in: https://github.com/adinapoli/rusholme/issues/592
+    // Both IO actions should produce output — the >> operator must
+    // evaluate the first action for its side effects (#592).
     const input =
         \\{"jsonrpc":"2.0","id":1,"method":"init"}
         \\{"jsonrpc":"2.0","id":2,"method":"eval","params":["do { putStrLn \"Hello\" ; putStrLn \"World\" }"]}
@@ -563,8 +560,7 @@ test "wasm e2e: do-notation with multiple putStrLn" {
 
     try testing.expectEqual(process.Child.Term{ .exited = 0 }, result.term);
 
-    // Once the Prelude eta-reduced IO issue is fixed (#592), both lines
-    // should appear. For now only the last action produces output.
+    try expectContains(result.stdout, "Hello\n");
     try expectContains(result.stdout, "World\n");
 }
 


### PR DESCRIPTION
Closes #592

## Summary

The `>>` operator's App handler in the GRIN evaluator only resolved the second argument without evaluating the first for its side effects. When `>>` reached this code path (e.g. with eta-reduced IO bindings like `putStrLn = primPutStrLn`), the first IO action was silently dropped.

**Fix:** Evaluate `args[0]` for side effects before resolving `args[1]`. The normal translation path (`>>` → GRIN Bind expression) already handles this correctly; this fix covers the fallback App path.

## Deliverables
- [x] Fix `>>` App handler to evaluate first argument for side effects
- [x] Update WASM e2e test to assert both "Hello" and "World" appear

## Testing
925/925 tests pass. The WASM e2e test now verifies:
```haskell
do { putStrLn "Hello" ; putStrLn "World" }
```
produces both lines of output.
