### PR TITLE
#675: Replace hardcoded VERSION constant with build-time version in package store

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -525,6 +525,7 @@ These existing issues must be resolved before any Phase 1 work begins:
 |---|-------|------|--------|
 | [#649](https://github.com/adinapoli/rusholme/issues/649) | Implement `.rhc-pkg` package descriptor format and parser | — | :green_circle: |
 | [#650](https://github.com/adinapoli/rusholme/issues/650) | Implement package store layout at `~/.rhc/store/` | [#649](https://github.com/adinapoli/rusholme/issues/649) | :green_circle: |
+| [#675](https://github.com/adinapoli/rusholme/issues/675) | Package store: replace hardcoded VERSION constant with build-time version | [#650](https://github.com/adinapoli/rusholme/issues/650) | :yellow_circle: |
 | [#651](https://github.com/adinapoli/rusholme/issues/651) | Implement `rhc-pkg` tool (list/describe/install/unregister/check) | [#650](https://github.com/adinapoli/rusholme/issues/650) | :white_circle: |
 | [#652](https://github.com/adinapoli/rusholme/issues/652) | Add `--package-db` flag to `rhc` compiler | [#650](https://github.com/adinapoli/rusholme/issues/650) | :white_circle: |
 

--- a/build.zig
+++ b/build.zig
@@ -88,6 +88,15 @@ pub fn build(b: *std.Build) void {
     // to our consumers. We must give it a name because a Zig package can expose
     // multiple modules and consumers will need to be able to specify which
     // module they want to access.
+    // ── Compiler version ──────────────────────────────────────────────────────
+    // The canonical version string for the Rusholme compiler.  Exposed as a
+    // build-time constant so that any module (e.g. src/packages/store.zig) can
+    // consume it without hard-coding the literal string.  Update this single
+    // definition whenever the version changes.
+    const compiler_version = "0.1.0";
+    const build_options = b.addOptions();
+    build_options.addOption([]const u8, "version", compiler_version);
+
     const mod = b.addModule("rusholme", .{
         // The root source file is the "entry point" of this module. Users of
         // this module will only be able to access public declarations contained
@@ -100,6 +109,7 @@ pub fn build(b: *std.Build) void {
         // which requires us to specify a target.
         .target = target,
     });
+    mod.addOptions("build_options", build_options);
 
     // Wire LLVM-C headers and shared library for the backend.
     // This must be called before any compilation step that transitively

--- a/src/packages/store.zig
+++ b/src/packages/store.zig
@@ -11,6 +11,7 @@
 const std = @import("std");
 const descriptor = @import("descriptor.zig");
 const builtin = @import("builtin");
+const build_options = @import("build_options");
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
@@ -261,15 +262,14 @@ pub const Error = error{
 /// Path components:
 /// - `arch`: from `builtin.cpu.arch` (e.g., "x86_64")
 /// - `os`: from `builtin.os.tag` (e.g., "linux", "macos", "windows")
-/// - `version`: the compiler version (hardcoded as "0.1.0" for now)
+/// - `version`: the compiler version injected by the build system via `build_options`
 ///
 /// Returns `error.HomeDirectoryUnset` if `HOME` is not in the environment.
 /// The caller owns the returned string and must free it with `alloc.free`.
 ///
-// tracked in: https://github.com/adinapoli/rusholme/issues/675
 pub fn defaultPath(alloc: std.mem.Allocator) Error![]const u8 {
     // tracked in: https://github.com/adinapoli/rusholme/issues/676
-    const VERSION = "0.1.0";
+    const VERSION = build_options.version;
     const arch = switch (builtin.cpu.arch) {
         .x86_64 => "x86_64",
         .aarch64 => "aarch64",


### PR DESCRIPTION
Closes #675

## Summary

- Added a canonical `compiler_version` constant (`"0.1.0"`) in `build.zig`, exposed via `b.addOptions()` as `build_options` and wired to the `rusholme` module with `mod.addOptions("build_options", build_options)`
- Removed the hardcoded `const VERSION = "0.1.0";` from `defaultPath` in `src/packages/store.zig`
- `defaultPath` now reads `build_options.version` — the version string changes in lock-step with any future update to the single definition in `build.zig`

## Deliverables

- [x] Canonical compiler version defined once in `build.zig`
- [x] Exposed as a build-time constant via `b.addOptions()`
- [x] `defaultPath` in `src/packages/store.zig` consumes `build_options.version`
- [x] Hardcoded `VERSION` literal removed entirely from `store.zig`
- [x] ROADMAP.md updated to add #675 with `:yellow_circle:` status

## Testing

`nix develop --command zig build test --summary all` — 976/976 tests passed.
