### PR TITLE
sync: Reconcile ROADMAP with GitHub state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -147,7 +147,7 @@
 | [#288](https://github.com/adinapoli/rusholme/issues/288) | Research: Evaluate zig-graph for dependency and analysis graphs | — | :green_circle: |
 | [#287](https://github.com/adinapoli/rusholme/issues/287) | Research: Evaluate zon2nix and zig2nix for Nix integration | — | :white_circle: |
 | [#291](https://github.com/adinapoli/rusholme/issues/291) | Research: Evaluate benchmarking libraries (zBench, poop) | — | :white_circle: |
-| [#292](https://github.com/adinapoli/rusholme/issues/292) | Research: Evaluate CLI argument parsing libraries (zig-clap, yazap, zli) | — | :yellow_circle: |
+| [#292](https://github.com/adinapoli/rusholme/issues/292) | Research: Evaluate CLI argument parsing libraries (zig-clap, yazap, zli) | — | :green_circle: |
 | [#295](https://github.com/adinapoli/rusholme/issues/295) | Research: Evaluate alternative allocators for compilation phases | — | :white_circle: |
 
 ### Epic [#3](https://github.com/adinapoli/rusholme/issues/3): Structured Error Diagnostics
@@ -172,7 +172,7 @@
 | [#63](https://github.com/adinapoli/rusholme/issues/63) | Implement golden/snapshot test runner | [#62](https://github.com/adinapoli/rusholme/issues/62) | :green_circle: |
 | [#64](https://github.com/adinapoli/rusholme/issues/64) | Implement end-to-end test runner (compile + run + check stdout) | [#63](https://github.com/adinapoli/rusholme/issues/63) | :green_circle: |
 | [#65](https://github.com/adinapoli/rusholme/issues/65) | Research and import simple test programs from GHC's testsuite | [#63](https://github.com/adinapoli/rusholme/issues/63) | :green_circle: |
-| [#415](https://github.com/adinapoli/rusholme/issues/415) | testing: add parse and GRIN output golden variants to test runner | [#63](https://github.com/adinapoli/rusholme/issues/63) | :yellow_circle: |
+| [#415](https://github.com/adinapoli/rusholme/issues/415) | testing: add parse and GRIN output golden variants to test runner | [#63](https://github.com/adinapoli/rusholme/issues/63) | :green_circle: |
 | [#460](https://github.com/adinapoli/rusholme/issues/460) | e2e runner: capture and assert stderr output | [#64](https://github.com/adinapoli/rusholme/issues/64) | :green_circle: |
 | [#462](https://github.com/adinapoli/rusholme/issues/462) | Add M2 Prelude reminder for enabling e2e tests | [#64](https://github.com/adinapoli/rusholme/issues/64) | :white_circle: |
 
@@ -255,7 +255,7 @@
 | [#444](https://github.com/adinapoli/rusholme/issues/444) | Refactor parseImportHeaders to eliminate redundant parsing | [#29](https://github.com/adinapoli/rusholme/issues/29) | :white_circle: |
 | [#538](https://github.com/adinapoli/rusholme/issues/538) | Parser cannot handle `(-)` in export lists | [#29](https://github.com/adinapoli/rusholme/issues/29) | :green_circle: |
 | [#539](https://github.com/adinapoli/rusholme/issues/539) | Parser cannot handle infix operator definitions with parenthesized patterns | [#29](https://github.com/adinapoli/rusholme/issues/29), [#31](https://github.com/adinapoli/rusholme/issues/31) | :green_circle: |
-| [#540](https://github.com/adinapoli/rusholme/issues/540) | Parser cannot handle multiple consecutive parenthesized cons patterns | [#31](https://github.com/adinapoli/rusholme/issues/31) | :yellow_circle: |
+| [#540](https://github.com/adinapoli/rusholme/issues/540) | Parser cannot handle multiple consecutive parenthesized cons patterns | [#31](https://github.com/adinapoli/rusholme/issues/31) | :green_circle: |
 | [#543](https://github.com/adinapoli/rusholme/issues/543) | Layout processor injects virtual tokens inside parenthesized contexts | [#26](https://github.com/adinapoli/rusholme/issues/26) | :green_circle: |
 
 ### CLI
@@ -478,6 +478,7 @@ Previous issues #58–#61 (hardcoded Prelude stubs) are closed as superseded —
 | [#615](https://github.com/adinapoli/rusholme/issues/615) | GRIN evaluator: support dictionary-passing for typeclass dispatch | [#612](https://github.com/adinapoli/rusholme/issues/612) | :green_circle: |
 | [#616](https://github.com/adinapoli/rusholme/issues/616) | Module interface cache (.rhi) does not store ClassEnv or DictNameMap | [#612](https://github.com/adinapoli/rusholme/issues/612) | :green_circle: |
 | [#617](https://github.com/adinapoli/rusholme/issues/617) | Show Char and Show String instances lack escape sequence handling | [#612](https://github.com/adinapoli/rusholme/issues/612) | :green_circle: |
+| [#682](https://github.com/adinapoli/rusholme/issues/682) | showLitChar does not handle non-printable characters above \DEL (codepoint > 127) | [#617](https://github.com/adinapoli/rusholme/issues/617) | :green_circle: |
 | [#618](https://github.com/adinapoli/rusholme/issues/618) | Native LLVM backend segfaults on dictionary-passing codegen | [#612](https://github.com/adinapoli/rusholme/issues/612) | :green_circle: |
 | [#621](https://github.com/adinapoli/rusholme/issues/621) | Unit and integer 0 are indistinguishable in JIT result formatting | [#612](https://github.com/adinapoli/rusholme/issues/612) | :green_circle: |
 | [#623](https://github.com/adinapoli/rusholme/issues/623) | Where-clause bindings not in scope during renaming/typechecking | — | :green_circle: |
@@ -592,7 +593,7 @@ These existing issues must be resolved before any Phase 1 work begins:
 |---|-------|------|--------|
 | [#75](https://github.com/adinapoli/rusholme/issues/75) | Implement basic REPL loop (read-eval-print with interpreter) | [#50](https://github.com/adinapoli/rusholme/issues/50), [#51](https://github.com/adinapoli/rusholme/issues/51) | :green_circle: |
 | [#76](https://github.com/adinapoli/rusholme/issues/76) | Implement REPL auto-completion and multi-line input | [#75](https://github.com/adinapoli/rusholme/issues/75) | :green_circle: |
-| [#487](https://github.com/adinapoli/rusholme/issues/487) | REPL stdin reader drops first byte of subsequent lines in piped mode | [#75](https://github.com/adinapoli/rusholme/issues/75) | :yellow_circle: |
+| [#487](https://github.com/adinapoli/rusholme/issues/487) | REPL stdin reader drops first byte of subsequent lines in piped mode | [#75](https://github.com/adinapoli/rusholme/issues/75) | :green_circle: |
 | [#514](https://github.com/adinapoli/rusholme/issues/514) | Show type error diagnostics in REPL :type command | [#75](https://github.com/adinapoli/rusholme/issues/75) | :green_circle: |
 
 ### Epic: Multi-Backend Architecture


### PR DESCRIPTION
## Summary

5 issues were marked `:yellow_circle:` (in-review) in ROADMAP.md but are actually CLOSED on GitHub. Also adds missing #682 row.

- #292 Research: Evaluate CLI argument parsing libraries — closed
- #415 testing: add parse and GRIN output golden variants to test runner — closed
- #487 REPL stdin reader drops first byte of subsequent lines in piped mode — closed
- #540 Parser cannot handle multiple consecutive parenthesized cons patterns — closed
- #682 showLitChar does not handle non-printable characters above \DEL — added + marked done

All updated to `:green_circle:`.