### PR TITLE
#687: Emit module_not_found diagnostic for missing imports

### DIFF
--- a/src/diagnostics/diagnostic.zig
+++ b/src/diagnostics/diagnostic.zig
@@ -45,6 +45,7 @@ pub const DiagnosticCode = enum {
     ambiguous_type,
     import_cycle,
     unknown_primop,
+    module_not_found,
 
     /// Returns a stable string code like "E001" for programmatic use.
     pub fn code(self: DiagnosticCode) []const u8 {
@@ -59,6 +60,7 @@ pub const DiagnosticCode = enum {
             .ambiguous_type => "E008",
             .import_cycle => "E009",
             .unknown_primop => "E010",
+            .module_not_found => "E011",
         };
     }
 

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -726,9 +726,30 @@ pub fn compileProgram(
                 const empty_core = CoreProgram{ .data_decls = &.{}, .binds = &.{} };
                 try env.register(mod_name, iface, empty_core);
             }
-            // Module not found in source or package-db; no diagnostic yet.
-            // tracked in: https://github.com/adinapoli/rusholme/issues/687
-            //
+            // Module not found in source or any package-db: emit a structured
+            // diagnostic so the user gets a clear "Could not find module" error
+            // instead of spurious downstream "unbound variable" messages.
+            else {
+                const msg = try std.fmt.allocPrint(
+                    alloc,
+                    "Could not find module '{s}' in source or any --package-db path",
+                    .{mod_name},
+                );
+                // The span points to the invalid position because the topo loop
+                // works on module names, not import declarations. Attaching the
+                // real import span is tracked in:
+                // https://github.com/adinapoli/rusholme/issues/699
+                const zero_span = span_mod.SourceSpan.init(
+                    span_mod.SourcePos.invalid(),
+                    span_mod.SourcePos.invalid(),
+                );
+                try env.diags.add(alloc, .{
+                    .severity = .@"error",
+                    .code = .module_not_found,
+                    .span = zero_span,
+                    .message = msg,
+                });
+            }
             // Whether or not a package-db hit was found, do not attempt
             // to compile this module from source — skip to the next.
             continue;
@@ -1871,4 +1892,38 @@ test "tryLoadFromPackageDbs: returns null when no .rhi file exists" {
     const tmp_path = try std.Io.Dir.realPathFileAlloc(tmp.dir, io, ".", alloc);
     const result = try tryLoadFromPackageDbs(alloc, io, "NoSuchModule", &.{tmp_path});
     try testing.expect(result == null);
+}
+
+test "compileProgram: missing import emits module_not_found diagnostic" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const io = testing.io;
+
+    // App imports MissingLib which is not provided as source or in any package-db.
+    const source =
+        \\module App where
+        \\import MissingLib
+        \\answer :: Int
+        \\answer = 42
+        \\
+    ;
+    var r = try compileProgram(alloc, io, &.{.{
+        .module_name = "App",
+        .source = source,
+        .file_id = 1,
+    }}, &.{});
+    defer r.env.deinit();
+
+    try testing.expect(r.result.had_errors);
+
+    // At least one diagnostic must be module_not_found for "MissingLib".
+    var found = false;
+    for (r.env.diags.diagnostics.items) |d| {
+        if (d.code == .module_not_found) {
+            try testing.expect(std.mem.indexOf(u8, d.message, "MissingLib") != null);
+            found = true;
+        }
+    }
+    try testing.expect(found);
 }

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -743,15 +743,16 @@ pub fn compileProgram(
                     span_mod.SourcePos.invalid(),
                     span_mod.SourcePos.invalid(),
                 );
-                try env.diags.add(alloc, .{
+                try env.diags.emit(alloc, .{
                     .severity = .@"error",
                     .code = .module_not_found,
                     .span = zero_span,
                     .message = msg,
                 });
             }
-            // Whether or not a package-db hit was found, do not attempt
-            // to compile this module from source — skip to the next.
+            // In both cases (resolved from package-db, or not found anywhere)
+            // this module has no source entry — skip to the next without
+            // attempting source compilation.
             continue;
         }
         const m = src_map.get(mod_name).?;
@@ -1921,7 +1922,10 @@ test "compileProgram: missing import emits module_not_found diagnostic" {
     var found = false;
     for (r.env.diags.diagnostics.items) |d| {
         if (d.code == .module_not_found) {
-            try testing.expect(std.mem.indexOf(u8, d.message, "MissingLib") != null);
+            try testing.expectEqualStrings(
+                "Could not find module 'MissingLib' in source or any --package-db path",
+                d.message,
+            );
             found = true;
         }
     }


### PR DESCRIPTION
Closes #687

## Summary
When `compileProgram` iterates the topological module order and a module is not found in the source list or any `--package-db` path, it now emits a structured `Diagnostic` (error severity, code `E011 module_not_found`) instead of silently continuing. This gives users a clear `Could not find module 'Foo' in source or any --package-db path` error rather than confusing downstream "unbound variable" messages from the renamer.

## Deliverables
- [x] Add `module_not_found` (`E011`) variant to `DiagnosticCode` in `src/diagnostics/diagnostic.zig`
- [x] Emit diagnostic in `compileProgram` when `tryLoadFromPackageDbs` returns null
- [x] Test asserting a missing import triggers this diagnostic
- [x] Filed follow-up issue #699 for attaching the real import source span (currently uses `SourcePos.invalid()`)

## Testing
`zig build test --summary all` — 1001/1001 tests pass.
