### PR TITLE
#679: Implement deriving mechanism for stock typeclasses

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -336,7 +336,7 @@
 | [#378](https://github.com/adinapoli/rusholme/issues/378) | Tier 3: Optimal decision trees with exhaustiveness/redundancy checking | [#377](https://github.com/adinapoli/rusholme/issues/377) | :white_circle: |
 | [#297](https://github.com/adinapoli/rusholme/issues/297) | Compare Core IR emitted by GHC vs Rusholme | [#38](https://github.com/adinapoli/rusholme/issues/38) | :white_circle: |
 | [#309](https://github.com/adinapoli/rusholme/issues/309) | Implement list comprehension (ListComp) support | [#38](https://github.com/adinapoli/rusholme/issues/38) | :white_circle: |
-| [#679](https://github.com/adinapoli/rusholme/issues/679) | Implement `deriving` mechanism for stock classes (`Eq`, `Ord`, `Show`, `Bounded`, `Enum`) and newtype strategy | [#33](https://github.com/adinapoli/rusholme/issues/33), [#530](https://github.com/adinapoli/rusholme/issues/530) | :white_circle: |
+| [#679](https://github.com/adinapoli/rusholme/issues/679) | Implement `deriving` mechanism for stock classes (`Eq`, `Ord`, `Show`, `Bounded`, `Enum`) and newtype strategy | [#33](https://github.com/adinapoli/rusholme/issues/33), [#530](https://github.com/adinapoli/rusholme/issues/530) | :yellow_circle: |
 | [#680](https://github.com/adinapoli/rusholme/issues/680) | Implement `deriving Generic` / `Generic1` and `GHC.Generics` compatibility module | [#679](https://github.com/adinapoli/rusholme/issues/679), [#655](https://github.com/adinapoli/rusholme/issues/655) | :white_circle: |
 
 ### Epic [#6](https://github.com/adinapoli/rusholme/issues/6): GRIN IR and Core→GRIN Translation

--- a/docs/superpowers/specs/2026-05-17-deriving-mechanism-design.md
+++ b/docs/superpowers/specs/2026-05-17-deriving-mechanism-design.md
@@ -1,0 +1,465 @@
+# Design: `deriving` Mechanism for Stock Classes
+
+**Issue:** [#679](https://github.com/adinapoli/rusholme/issues/679)
+**Date:** 2026-05-17
+**Status:** Approved (brainstorming)
+
+## Summary
+
+Implement Haskell 2010 `deriving` clauses for the stock classes `Eq`, `Ord`,
+`Show`, `Bounded`, and `Enum`, plus newtype deriving (via stock-equivalence,
+since `coerce` is deferred). The parser already preserves `deriving` lists on
+data/newtype declarations; this work adds a new pipeline pass that walks the
+parsed module, synthesizes surface-level `InstanceDecl` AST nodes for every
+clause, and inserts them before the renamer runs. The renamer and typechecker
+then process the synthesized instances exactly as if the user had written them.
+
+## Scope
+
+**In scope:**
+
+- Synthesize `Eq`, `Ord`, `Show`, `Bounded`, `Enum` instances from `deriving`
+  clauses on `data` and `newtype` declarations.
+- Honour standalone `deriving instance C T` declarations (existing
+  `DerivingDecl` AST node) by lowering to the same synthesis path.
+- Newtype deriving for the five stock classes implemented as stock-equivalence
+  on the single underlying field (semantically identical to GHC for these
+  classes).
+- Add the missing `Ord`, `Bounded`, `Enum` class definitions and built-in
+  instances to `lib/Prelude.hs`.
+- Add diagnostic codes and span-faithful error reporting for non-derivable
+  clauses.
+
+**Out of scope (file follow-up issues):**
+
+- `Coercible` class, `coerce` primop, role system, full `deriving newtype`
+  strategy for arbitrary classes.
+- `deriving Generic`, `Generic1`, `GHC.Generics` compatibility (already
+  tracked by [#680](https://github.com/adinapoli/rusholme/issues/680)).
+- `DerivingVia`, `DerivingStrategies` GHC extensions.
+- Full `ShowS` / `showsPrec` / precedence-aware `Show` (Prelude uses the
+  simplified single-method form; matching that here).
+- Derived `Read`.
+- Optimisation of `compare` cross-constructor dispatch beyond the naive nested
+  case.
+
+## Decisions
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Class scope | All 5 stock + newtype; extend Prelude to add missing classes |
+| 2 | Pipeline placement | New pass between parser and renamer |
+| 3 | PR slicing | Single PR closing #679 (Prelude additions + deriving pass together) |
+| 4 | Newtype strategy | Stock-equivalence (defer `coerce` to follow-up) |
+| 5 | Synthesis approach | Source-AST template construction (Approach A) |
+
+## Architecture
+
+### Pipeline placement
+
+```
+source
+  → frontend/parser   (preserves `deriving` clauses on DataDecl/NewtypeDecl)
+  → deriving/deriving (NEW: walks module, synthesizes InstanceDecl per clause)
+  → renamer
+  → typechecker
+  → core/desugar
+  → grin → backend
+```
+
+### Entry point
+
+```zig
+// src/deriving/deriving.zig
+pub fn derive(
+    arena: std.mem.Allocator,
+    module: *ast.Module,
+    diags: *DiagnosticCollector,
+) DeriveError!void
+```
+
+Mutates `module.decls` in place, appending one `InstanceDecl` per
+`(data type, class name)` pair found in every `DataDecl.deriving`,
+`NewtypeDecl.deriving`, and standalone `DerivingDecl`. Pure of side effects
+beyond `module.decls` and `diags`. No global state, no class env access — the
+typechecker is the sole arbiter of whether the synthesised body is
+well-formed.
+
+### Module layout
+
+```
+src/deriving/
+├── deriving.zig          -- entry point: derive(arena, module, diags)
+├── eq.zig                -- synthEqInstance
+├── ord.zig               -- synthOrdInstance
+├── show.zig              -- synthShowInstance
+├── bounded.zig           -- synthBoundedInstance
+├── enum_class.zig        -- synthEnumInstance
+├── builder.zig           -- shared AST construction helpers
+└── shape.zig             -- DataShape classification
+```
+
+`builder.zig` provides small constructors that wrap the tedium of building
+`ast.Expr`, `ast.Pat`, `ast.Match`, `ast.InstanceDecl` nodes with explicit
+spans:
+
+```zig
+pub fn mkVar(arena, name, span) ast.Expr
+pub fn mkApp(arena, f, args, span) ast.Expr
+pub fn mkConPat(arena, name, sub_pats, span) ast.Pat
+pub fn mkCase(arena, scrutinee, arms, span) ast.Expr
+pub fn mkInstance(arena, ctx, head, binds, span) ast.InstanceDecl
+pub fn mkAndChain(arena, exprs, span) ast.Expr   -- folds with &&, base True
+```
+
+`shape.zig` classifies a `DataDecl` (or `NewtypeDecl` treated as a one-con
+data) into one of:
+
+- `Enumeration` — all constructors are nullary. Legal for Eq, Ord, Show,
+  Bounded, Enum.
+- `SingleProduct` — exactly one constructor with at least one field. Legal for
+  Eq, Ord, Show, Bounded.
+- `SumOfProducts` — multiple constructors, at least one with fields. Legal
+  for Eq, Ord, Show.
+- `Empty` — zero constructors. Legal for Eq, Ord; Show with empty `case`.
+
+Each per-class file dispatches on `DataShape` and returns either an
+`ast.InstanceDecl` or emits a diagnostic and returns `error.NotDerivable`. The
+top-level `derive` collects successful instances, skips erroring ones, and
+continues, so a single compile run surfaces every undérivable clause.
+
+## Per-class synthesis semantics
+
+Every synthesised AST node carries `class_name_span` — the span of the class
+identifier inside the `deriving (...)` clause — so downstream diagnostics
+point at the user's source, not at a phantom location.
+
+### Eq
+
+Synthesises `(==)`. Instance context: `Eq a` for every type variable `a` that
+appears in any field type.
+
+```haskell
+data T a b = C1 a | C2 a b | C3
+-- becomes:
+instance (Eq a, Eq b) => Eq (T a b) where
+  C1 x1     == C1 y1     = x1 == y1
+  C2 x1 x2  == C2 y1 y2  = x1 == y1 && x2 == y2
+  C3        == C3        = True
+  _         == _         = False
+```
+
+The catch-all `_ == _ = False` clause is omitted when the type has exactly
+one constructor.
+
+### Ord
+
+Synthesises `compare`. Constructor order = order of declaration in the source.
+Field comparison is lexicographic.
+
+```haskell
+instance (Ord a, Ord b) => Ord (T a b) where
+  compare (C1 x1)    (C1 y1)    = compare x1 y1
+  compare (C2 x1 x2) (C2 y1 y2) = case compare x1 y1 of
+      EQ -> compare x2 y2
+      o  -> o
+  compare C3 C3 = EQ
+  compare a b   = compare (conTag a) (conTag b)
+```
+
+`conTag` is a hidden helper synthesised alongside the instance for any
+`SumOfProducts`/`Enumeration` shape, returning the constructor's positional
+tag as `Int`. For pure `Enumeration` shapes the tag mapping can be inlined.
+
+### Show
+
+Uses the simplified single-method `show :: a -> String` already present in
+Prelude. Format:
+
+- Nullary constructor: `"ConName"`
+- Constructor with args: `"ConName" ++ " " ++ show arg1 ++ " " ++ show arg2 ...`
+
+```haskell
+instance (Show a, Show b) => Show (T a b) where
+  show (C1 x1)    = "C1 " ++ show x1
+  show (C2 x1 x2) = "C2 " ++ show x1 ++ " " ++ show x2
+  show C3         = "C3"
+```
+
+Record syntax, infix operators, and precedence-aware parens are out of scope
+for this iteration (the simplified Show has no `showsPrec`).
+
+### Bounded
+
+Legal for `Enumeration` (no context) and `SingleProduct` (one `Bounded`
+constraint per field type).
+
+```haskell
+-- enumeration
+data Day = Mon | Tue | Wed
+instance Bounded Day where
+  minBound = Mon
+  maxBound = Wed
+
+-- single product
+data P a b = P a b
+instance (Bounded a, Bounded b) => Bounded (P a b) where
+  minBound = P minBound minBound
+  maxBound = P maxBound maxBound
+```
+
+### Enum
+
+Legal only for `Enumeration` shape. Synthesises `fromEnum`, `toEnum`, `succ`,
+`pred`.
+
+```haskell
+instance Enum Day where
+  fromEnum Mon = 0
+  fromEnum Tue = 1
+  fromEnum Wed = 2
+  toEnum 0 = Mon
+  toEnum 1 = Tue
+  toEnum 2 = Wed
+  toEnum _ = error "Enum.toEnum: out of range"
+  succ Mon = Tue
+  succ Tue = Wed
+  succ Wed = error "Enum.succ: bad argument"
+  pred Mon = error "Enum.pred: bad argument"
+  pred Tue = Mon
+  pred Wed = Tue
+```
+
+### Newtype (stock-equivalence)
+
+```haskell
+newtype N a = MkN (Inner a) deriving Eq
+```
+
+Treated by `shape.zig` exactly as the equivalent
+`data N a = MkN (Inner a) deriving Eq` (a `SingleProduct`). The same per-class
+synthesisers run. For the five stock classes this is behaviourally identical
+to GHC's newtype deriving; the distinction only matters for arbitrary
+classes, which requires `coerce` (deferred).
+
+## Prelude additions
+
+Add to `lib/Prelude.hs`. Manual instances are written exactly the way derived
+ones would render, fixing the spec the synthesiser must reproduce.
+
+### Ord
+
+```haskell
+class Eq a => Ord a where
+  compare :: a -> a -> Ordering
+  (<)  :: a -> a -> Bool
+  x < y = case compare x y of { LT -> True;  _  -> False }
+  (<=) :: a -> a -> Bool
+  x <= y = case compare x y of { GT -> False; _  -> True  }
+  (>)  :: a -> a -> Bool
+  x > y = case compare x y of { GT -> True;  _  -> False }
+  (>=) :: a -> a -> Bool
+  x >= y = case compare x y of { LT -> False; _  -> True  }
+
+instance Ord Int where ...
+instance Ord Bool where ...
+instance Ord Char where compare x y = compare (charToInt x) (charToInt y)
+instance Ord Ordering where ...
+instance (Ord a) => Ord [a] where ...
+instance (Ord a) => Ord (Maybe a) where ...
+```
+
+**Open verification item:** the existing monomorphic `<`, `<=`, `>`, `>=`
+primops on `Int` may conflict with the new class methods of the same name.
+Implementation must verify and resolve — likely by leaving the primops named
+`ltInt`, `leInt`, etc., and routing class methods through them. To be
+confirmed during plan writing.
+
+### Bounded
+
+```haskell
+class Bounded a where
+  minBound :: a
+  maxBound :: a
+
+instance Bounded Bool     where minBound = False; maxBound = True
+instance Bounded Char     where ... -- platform Char range
+instance Bounded Int      where ... -- Int64 range
+instance Bounded Ordering where minBound = LT; maxBound = GT
+```
+
+### Enum
+
+```haskell
+class Enum a where
+  succ :: a -> a
+  pred :: a -> a
+  fromEnum :: a -> Int
+  toEnum :: Int -> a
+
+instance Enum Int      where ...
+instance Enum Bool     where ...
+instance Enum Char     where ...
+instance Enum Ordering where ...
+```
+
+### Export list
+
+Extend Prelude's export list with: `Ord(..)`, `Bounded(..)`, `Enum(..)`,
+`compare`, `(<)`, `(<=)`, `(>)`, `(>=)`, `minBound`, `maxBound`, `succ`,
+`pred`, `fromEnum`, `toEnum`.
+
+## Error handling and diagnostics
+
+### New `DiagnosticCode` variants
+
+```zig
+deriving_unsupported_class,        // e.g. `deriving Functor`
+deriving_shape_mismatch,           // e.g. `deriving Enum` on non-enumeration
+deriving_empty_bounded,            // `deriving Bounded` on zero-constructor type
+deriving_field_no_instance,        // wraps typechecker missing-instance with
+                                   // deriving-aware text
+deriving_standalone_type_mismatch, // malformed standalone deriving instance
+```
+
+### Two-stage error reporting
+
+1. **Pre-synthesis** (in the deriving pass): class-name supportedness, shape
+   eligibility, standalone-deriving form. Spans point at the offending class
+   identifier in the `deriving (...)` clause.
+2. **Post-synthesis** (in the typechecker): field-level missing instances
+   (e.g. `data T = T (Int -> Int) deriving Eq`). The typechecker default
+   error is `no instance for Eq (Int -> Int)`; when the surrounding instance
+   was synthesised, the message is wrapped:
+   *"Cannot derive `Eq (T)`: field of type `Int -> Int` has no `Eq`
+   instance."*
+
+To enable wrapping, extend `InstanceInfo` in `class_env.zig`:
+
+```zig
+pub const DerivingOrigin = struct {
+    data_type_span: SourceSpan,
+    class_name_span: SourceSpan,
+};
+
+pub const InstanceInfo = struct {
+    // ... existing fields ...
+    origin: ?DerivingOrigin = null,
+};
+```
+
+The deriving pass populates `origin`; the typechecker checks it when emitting
+missing-instance diagnostics for class constraints originating inside a
+synthesised body.
+
+### One-pass error aggregation
+
+The `derive` pass processes all clauses even after one fails, so a single
+compile run reports every undérivable clause. The typechecker similarly
+continues after one missing-instance error within a synthesised body.
+
+### No catch-all class dispatch
+
+Per CLAUDE.md ("don't take 'kitchen sink' shortcuts"), the unsupported-class
+path is explicit:
+
+```zig
+const stock = std.StaticStringMap(StockClass).initComptime(.{
+    .{ "Eq",      .eq },
+    .{ "Ord",     .ord },
+    .{ "Show",    .show },
+    .{ "Bounded", .bounded },
+    .{ "Enum",    .enum_ },
+});
+
+switch (stock.get(class_name) orelse {
+    diags.emit(.deriving_unsupported_class, class_name_span, ...);
+    return error.NotDerivable;
+}) {
+    .eq      => return synthEqInstance(arena, data, span),
+    .ord     => return synthOrdInstance(arena, data, span),
+    .show    => return synthShowInstance(arena, data, span),
+    .bounded => return synthBoundedInstance(arena, data, span),
+    .enum_   => return synthEnumInstance(arena, data, span),
+}
+```
+
+## Testing strategy
+
+All tests use `std.testing.allocator` (or `ArenaAllocator` wrapping it) per
+the zero-leak policy.
+
+### 1. Unit tests in each `src/deriving/*.zig`
+
+Build a `DataDecl` AST manually, call the synthesiser, pretty-print the
+result, compare against a literal expected string. Covers every `DataShape`
+branch per class.
+
+### 2. Golden tests `tests/golden/deriving/`
+
+End-to-end: an `.hs` input file with deriving clauses, paired with the
+expected post-deriving-pass module dump. Catches AST construction
+regressions across the full pipeline.
+
+```
+tests/golden/deriving/
+├── eq_sum.hs                ├── eq_sum.expected
+├── ord_enum.hs              ├── ord_enum.expected
+├── show_records.hs          ├── show_records.expected
+├── bounded_enum.hs          ├── bounded_enum.expected
+├── enum_class.hs            ├── enum_class.expected
+├── newtype_eq.hs            ├── newtype_eq.expected
+└── unsupported_class.hs     └── unsupported_class.stderr
+```
+
+### 3. E2E behaviour tests `tests/e2e/deriving/`
+
+Compile and run programs that exercise derived methods, check stdout.
+Minimum coverage: one program per stock class, one newtype, one cross-feature
+test (e.g. derived `Ord` consuming derived `Eq` superclass).
+
+```haskell
+-- tests/e2e/deriving/eq_runtime.hs
+data Color = Red | Green | Blue deriving (Eq, Show)
+main = do
+  print (Red == Red)        -- True
+  print (Red == Blue)       -- False
+  print [Red, Green, Blue]  -- [Red,Green,Blue]
+```
+
+### 4. Diagnostic tests `tests/diagnostics/deriving/`
+
+For each new `DiagnosticCode`, a fixture asserting code, span, and message
+text.
+
+### Test discovery
+
+Add `_ = @import("deriving/deriving.zig");` (and per-class imports as needed)
+to `src/root.zig` so `zig build test` picks up the new test blocks.
+
+## Risks and open items
+
+1. **Ord vs existing `<` primop on Int.** Need to verify how the existing
+   monomorphic `<` primop coexists with a new `Ord Int` class method named
+   `<`. Most likely the primops are renamed to `ltInt` etc. and the class
+   method delegates. Verify during plan writing.
+2. **`error` calls in synthesised `succ`/`pred`/`toEnum`.** Requires `error`
+   to be in scope (it is, in current Prelude) and to terminate program
+   execution cleanly under GRIN's lazy semantics.
+3. **Context inference for polymorphic data types.** Need to walk constructor
+   field types and collect every type variable that appears. Existing
+   typechecker code probably has a helper; confirm during plan writing.
+4. **Empty data type (`data Void`).** Derived `Eq`/`Ord` should produce
+   instances with no equations (only reachable when scrutinee exists, which
+   it cannot for `Void`). Verify pretty-printer and renamer handle an
+   `InstanceDecl` with zero bindings.
+
+## Follow-up issues to file before PR opens
+
+- `coerce` primop + `Coercible` class + role system (prerequisite for full
+  `deriving newtype` strategy for arbitrary classes).
+- Full `Show` class with `showsPrec` and precedence-aware parens.
+- Derived `Read`.
+- Optimisation of `compare`'s cross-constructor dispatch (replace nested case
+  on `conTag` with a primop or jump table).
+- Support for record syntax in derived `Show`.

--- a/lib/Prelude.hs
+++ b/lib/Prelude.hs
@@ -4,7 +4,7 @@ module Prelude
     , String
     , not, (&&), (||), otherwise
     , (+), (-), (*), negate, abs, div, mod
-    , (==), (/=), (<), (>), (<=), (>=)
+    , (==), (/=), (<), (>), (<=), (>=), compare
     , id, const, flip, (.), ($)
     , map, filter, (++), head, tail, null, length
     , foldr, foldl, concat, take, drop
@@ -14,6 +14,7 @@ module Prelude
     , intToChar, charToInt
     , max
     , Eq(..)
+    , Ord(..)
     , Show(..), show, showString, showLitChar, showListWith, showListTail
     , intToDigit
     , enumFrom, enumFromTo, enumFromThen, enumFromThenTo
@@ -160,22 +161,6 @@ max x y = case x >= y of
     False -> y
 
 -- ========================================================================
--- Comparison (monomorphic on Int, pending Ord class in #531)
--- ========================================================================
-
-(<) :: Int -> Int -> Bool
-(<) = primLtInt
-
-(>) :: Int -> Int -> Bool
-(>) = primGtInt
-
-(<=) :: Int -> Int -> Bool
-(<=) = primLeInt
-
-(>=) :: Int -> Int -> Bool
-(>=) = primGeInt
-
--- ========================================================================
 -- Eq type class
 -- ========================================================================
 
@@ -208,6 +193,36 @@ instance Eq Int where
 instance Eq Bool where
   (==) = eqBool
   (/=) = neBool
+
+-- ========================================================================
+-- Ord type class
+-- ========================================================================
+
+-- `compareInt` is a top-level helper rather than an inline instance method
+-- body because nested case-of inside instance methods historically tripped
+-- desugarer/lifter bugs (now fixed by #704).  Kept top-level for clarity
+-- and to avoid relying on the still-experimental default-method machinery
+-- in the first class declaration (#660).
+compareInt :: Int -> Int -> Ordering
+compareInt x y = case primLtInt x y of
+    True  -> LT
+    False -> case primEqInt x y of
+        True  -> EQ
+        False -> GT
+
+class Ord a where
+  compare :: a -> a -> Ordering
+  (<)     :: a -> a -> Bool
+  (<=)    :: a -> a -> Bool
+  (>)     :: a -> a -> Bool
+  (>=)    :: a -> a -> Bool
+
+instance Ord Int where
+  compare = compareInt
+  (<)  = primLtInt
+  (<=) = primLeInt
+  (>)  = primGtInt
+  (>=) = primGeInt
 
 -- ========================================================================
 -- Higher-order combinators

--- a/src/core/lift.zig
+++ b/src/core/lift.zig
@@ -260,32 +260,55 @@ pub const LambdaLifter = struct {
                 const is_leading = leading_lams.contains(@intFromPtr(expr));
                 const needs_lifting = !is_leading;
 
-                const lambda_id = try self.registerLambda(expr);
-                const param_id = l.binder.name.unique.value;
-
                 if (needs_lifting) {
                     // Expression lambda: will be lifted to top level.
                     //
-                    // Scope resets to top-level vars + own parameter.
-                    // Enclosing lambda parameters are NOT in scope for the
-                    // lifted function — they become free variables passed as
-                    // extra arguments at the call site.
+                    // Peel the entire leading Lam chain and register it as
+                    // a single multi-parameter lifted function.  Per-Lam
+                    // registration (each level its own lifted_N) makes the
+                    // outer lifted function arity-1 — it returns a partial
+                    // application of the next level.  When the dictionary
+                    // slot for a multi-arg method holds that partial, the
+                    // LLVM call lowering performs a direct call at the
+                    // call-site arity and silently drops all but the first
+                    // argument.  Coalescing the chain into one N-arg lifted
+                    // function makes the dict slot's function pointer
+                    // arity-correct for direct invocation.
+                    //
+                    // Scope resets to top-level vars plus every peeled
+                    // parameter.  Enclosing lambda parameters remain free
+                    // variables passed at the call site.
                     var inner_scope = try self.top_level_vars.clone(self.alloc);
                     defer inner_scope.deinit(self.alloc);
-                    try inner_scope.add(self.alloc, param_id);
 
-                    var inner_fvs = try self.collectFreeVarsOf(l.body, inner_scope, leading_lams);
+                    var params_list: std.ArrayListUnmanaged(Id) = .empty;
+                    defer params_list.deinit(self.alloc);
+
+                    var deep_body: *const Expr = expr;
+                    while (true) {
+                        switch (deep_body.*) {
+                            .Lam => |inner_l| {
+                                try params_list.append(self.alloc, inner_l.binder);
+                                try inner_scope.add(self.alloc, inner_l.binder.name.unique.value);
+                                deep_body = inner_l.body;
+                            },
+                            else => break,
+                        }
+                    }
+
+                    const lambda_id = try self.registerLambda(expr);
+
+                    var inner_fvs = try self.collectFreeVarsOf(deep_body, inner_scope, leading_lams);
                     defer inner_fvs.deinit(self.alloc);
 
-                    // Complete lambda registration with free variables.
                     const fvs_slice = try inner_fvs.toSlice(self.alloc);
                     // Heap-allocate the params slice so it outlives this scope.
                     // Using a temporary `&.{l.binder}` would create a dangling
                     // reference — all lifted lambdas would share the same
                     // (overwritten) stack slot.
-                    const param_slice = try self.alloc.alloc(Id, 1);
-                    param_slice[0] = l.binder;
-                    try self.completeLambda(lambda_id, fvs_slice, param_slice, l.body, l.binder.ty, needs_lifting);
+                    const param_slice = try self.alloc.alloc(Id, params_list.items.len);
+                    @memcpy(param_slice, params_list.items);
+                    try self.completeLambda(lambda_id, fvs_slice, param_slice, deep_body, l.binder.ty, needs_lifting);
 
                     // Compute function type with free vars added as parameters.
                     var lifted_ty = l.binder.ty;
@@ -312,6 +335,8 @@ pub const LambdaLifter = struct {
                         }
                     }
                 } else {
+                    const lambda_id = try self.registerLambda(expr);
+                    const param_id = l.binder.name.unique.value;
                     // Parameter lambda: part of the leading chain on a
                     // top-level binding RHS. Keep in place — translateDef
                     // will peel it as a function parameter.
@@ -1202,7 +1227,7 @@ test "VarSet: clone" {
     try testing.expect(!set1.contains(3));
 }
 
-test "lambdaLift: two-arg expression lambda does not propagate own param as free var (#659)" {
+test "lambdaLift: chained expression lambdas coalesce into a single multi-arg lifted function" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const alloc = arena.allocator();
@@ -1259,8 +1284,14 @@ test "lambdaLift: two-arg expression lambda does not propagate own param as free
 
     const lifted = try lambdaLift(alloc, program, null, 0);
 
-    // Should have 3 bindings: lifted \y, lifted \x, rewritten g.
-    try testing.expectEqual(@as(usize, 3), lifted.program.binds.len);
+    // The chained Lams `\x -> \y -> x` coalesce into a SINGLE lifted
+    // function with two parameters, so we expect 2 bindings: one lifted
+    // and the rewritten g.  Per-Lam splitting (one lifted per level)
+    // would emit a 1-arg outer that returns a partial application —
+    // when the dict slot of a 2-arg method holds that partial, the
+    // LLVM call lowering does a 2-arg direct call and silently drops
+    // the second argument.
+    try testing.expectEqual(@as(usize, 2), lifted.program.binds.len);
 
     // Also verify via direct lifter inspection.
     var lifter = LambdaLifter.init(alloc);
@@ -1274,22 +1305,22 @@ test "lambdaLift: two-arg expression lambda does not propagate own param as free
     var result_fvs = try lifter.collectFreeVarsOf(g_bind.NonRec.rhs, lifter.top_level_vars, &leading_lams);
     result_fvs.deinit(alloc);
 
-    // Check each lifted lambda.
+    // The single lifted function takes [x, y] as parameters and has
+    // zero free vars (x is its own param, so it does not propagate
+    // upward — the original #659 assertion).
     var lifted_it = lifter.lambdas.iterator();
+    var saw_coalesced = false;
     while (lifted_it.next()) |entry| {
         const info = &entry.value_ptr.*;
         if (!info.needs_lifting) continue;
 
-        if (info.params.len == 1 and info.params[0].name.unique.value == y_id.name.unique.value) {
-            // \y -> x: should have x (unique=1) as free var.
-            try testing.expectEqual(@as(usize, 1), info.free_vars.len);
-            try testing.expectEqual(@as(u64, 1), info.free_vars[0]);
-        } else if (info.params.len == 1 and info.params[0].name.unique.value == x_id.name.unique.value) {
-            // \x -> (\y -> x): x is own param, so ZERO free vars.
-            // This is the core assertion for #659.
-            try testing.expectEqual(@as(usize, 0), info.free_vars.len);
-        }
+        try testing.expectEqual(@as(usize, 2), info.params.len);
+        try testing.expectEqual(x_id.name.unique.value, info.params[0].name.unique.value);
+        try testing.expectEqual(y_id.name.unique.value, info.params[1].name.unique.value);
+        try testing.expectEqual(@as(usize, 0), info.free_vars.len);
+        saw_coalesced = true;
     }
+    try testing.expect(saw_coalesced);
 }
 
 test "lambdaLift: doubly-nested expression lambda — lifted body is rewritten (#623)" {

--- a/src/deriving/bounded.zig
+++ b/src/deriving/bounded.zig
@@ -1,0 +1,115 @@
+//! Synthesise a `Bounded` instance.
+//!
+//! Legal shapes:
+//!   - Enumeration: `minBound = <first con>`, `maxBound = <last con>`.
+//!   - SingleProduct: each field's bound, requires `Bounded` per field type.
+//!
+//! Other shapes (sum-of-products, empty) emit a `deriving_shape_mismatch`
+//! diagnostic and return `error.NotDerivable`.
+
+const std = @import("std");
+const ast = @import("../frontend/ast.zig");
+const span_mod = @import("../diagnostics/span.zig");
+const diag_mod = @import("../diagnostics/diagnostic.zig");
+
+const builder = @import("builder.zig");
+const shape_mod = @import("shape.zig");
+
+const SourceSpan = span_mod.SourceSpan;
+const Allocator = std.mem.Allocator;
+const NormalizedDecl = shape_mod.NormalizedDecl;
+
+pub const Error = error{ OutOfMemory, NotDerivable };
+
+pub const Synthesised = struct {
+    helpers: []const ast.Decl,
+    instance: ast.InstanceDecl,
+};
+
+pub fn synth(
+    arena: Allocator,
+    decl: NormalizedDecl,
+    span: SourceSpan,
+    diags: *diag_mod.DiagnosticCollector,
+) Error!Synthesised {
+    const shape = shape_mod.classify(decl);
+    switch (shape) {
+        .Enumeration => {
+            const first = decl.constructors[0];
+            const last = decl.constructors[decl.constructors.len - 1];
+            const min_body = builder.mkVar(first.name, span);
+            const max_body = builder.mkVar(last.name, span);
+            const min_m = try builder.mkMatch(arena, &.{}, min_body, span);
+            const max_m = try builder.mkMatch(arena, &.{}, max_body, span);
+            const min_fb = try builder.mkFunBind(arena, "minBound", &.{min_m}, span);
+            const max_fb = try builder.mkFunBind(arena, "maxBound", &.{max_m}, span);
+            return .{ .helpers = &.{}, .instance = try finalize(arena, decl, &.{ min_fb, max_fb }, span, false) };
+        },
+        .SingleProduct => {
+            const con = decl.constructors[0];
+            const arity = con.fields.len;
+            const min_args = try arena.alloc(ast.Expr, arity);
+            const max_args = try arena.alloc(ast.Expr, arity);
+            for (0..arity) |i| {
+                min_args[i] = builder.mkVar("minBound", span);
+                max_args[i] = builder.mkVar("maxBound", span);
+            }
+            const min_body = try builder.mkApp(arena, builder.mkVar(con.name, span), min_args);
+            const max_body = try builder.mkApp(arena, builder.mkVar(con.name, span), max_args);
+            const min_m = try builder.mkMatch(arena, &.{}, min_body, span);
+            const max_m = try builder.mkMatch(arena, &.{}, max_body, span);
+            const min_fb = try builder.mkFunBind(arena, "minBound", &.{min_m}, span);
+            const max_fb = try builder.mkFunBind(arena, "maxBound", &.{max_m}, span);
+            return .{ .helpers = &.{}, .instance = try finalize(arena, decl, &.{ min_fb, max_fb }, span, true) };
+        },
+        .Empty => {
+            try emitDiag(arena, diags, .deriving_empty_bounded, span,
+                "Cannot derive `Bounded` for an empty data type",
+            );
+            return error.NotDerivable;
+        },
+        .SumOfProducts => {
+            try emitDiag(arena, diags, .deriving_shape_mismatch, span,
+                "Cannot derive `Bounded`: type must be an enumeration or single-constructor product",
+            );
+            return error.NotDerivable;
+        },
+    }
+}
+
+fn finalize(
+    arena: Allocator,
+    decl: NormalizedDecl,
+    bindings: []const ast.FunBinding,
+    span: SourceSpan,
+    with_field_context: bool,
+) Allocator.Error!ast.InstanceDecl {
+    var ctx: ?ast.Context = null;
+    if (with_field_context) {
+        var seen: std.StringArrayHashMapUnmanaged(void) = .empty;
+        try builder.collectTypeVars(arena, decl.constructors, &seen);
+        var pairs: std.ArrayListUnmanaged(builder.ClassVarPair) = .empty;
+        for (seen.keys()) |tv| {
+            try pairs.append(arena, .{ .class_name = "Bounded", .tyvar = tv });
+        }
+        ctx = try builder.mkContext(arena, pairs.items);
+    }
+    const applied = try builder.mkAppliedTypeCon(arena, decl.name, decl.tyvars, span);
+    const head = try builder.mkInstanceHead(arena, "Bounded", applied, span);
+    return builder.mkInstance(arena, ctx, head, bindings, span);
+}
+
+fn emitDiag(
+    alloc: Allocator,
+    diags: *diag_mod.DiagnosticCollector,
+    code: diag_mod.DiagnosticCode,
+    span: SourceSpan,
+    msg: []const u8,
+) Allocator.Error!void {
+    try diags.emit(alloc, .{
+        .severity = .@"error",
+        .code = code,
+        .span = span,
+        .message = msg,
+    });
+}

--- a/src/deriving/builder.zig
+++ b/src/deriving/builder.zig
@@ -1,0 +1,292 @@
+//! AST construction helpers for the deriving pass.
+//!
+//! All synthesised nodes carry the same `SourceSpan` (typically the data
+//! decl's deriving-clause span) so diagnostics point at the user's
+//! `deriving (...)` clause rather than at phantom internal locations.
+
+const std = @import("std");
+const ast = @import("../frontend/ast.zig");
+const span_mod = @import("../diagnostics/span.zig");
+
+pub const SourceSpan = span_mod.SourceSpan;
+pub const Allocator = std.mem.Allocator;
+
+pub fn alloc(arena: Allocator, comptime T: type, value: T) Allocator.Error!*const T {
+    const ptr = try arena.create(T);
+    ptr.* = value;
+    return ptr;
+}
+
+pub fn mkQName(name: []const u8, span: SourceSpan) ast.QName {
+    return .{ .module_name = null, .name = name, .span = span };
+}
+
+pub fn mkVar(name: []const u8, span: SourceSpan) ast.Expr {
+    return .{ .Var = mkQName(name, span) };
+}
+
+pub fn mkVarPat(name: []const u8, span: SourceSpan) ast.Pattern {
+    return .{ .Var = .{ .name = name, .span = span } };
+}
+
+pub fn mkWildPat(span: SourceSpan) ast.Pattern {
+    return .{ .Wild = span };
+}
+
+pub fn mkConPat(
+    arena: Allocator,
+    name: []const u8,
+    args: []const ast.Pattern,
+    span: SourceSpan,
+) Allocator.Error!ast.Pattern {
+    const owned = try arena.alloc(ast.Pattern, args.len);
+    @memcpy(owned, args);
+    return .{ .Con = .{
+        .name = mkQName(name, span),
+        .args = owned,
+        .span = span,
+    } };
+}
+
+/// Wrap a constructor pattern in parens for use as a function argument
+/// pattern (`f (Con x) = ...`).  Required to mirror the AST shape the
+/// parser produces, which downstream phases rely on.
+pub fn mkConPatParen(
+    arena: Allocator,
+    name: []const u8,
+    args: []const ast.Pattern,
+    span: SourceSpan,
+) Allocator.Error!ast.Pattern {
+    const inner = try mkConPat(arena, name, args, span);
+    if (args.len == 0) return inner; // bare nullary cons need no parens
+    const boxed = try arena.create(ast.Pattern);
+    boxed.* = inner;
+    return .{ .Paren = .{ .pat = boxed, .span = span } };
+}
+
+pub fn mkApp(
+    arena: Allocator,
+    func: ast.Expr,
+    args: []const ast.Expr,
+) Allocator.Error!ast.Expr {
+    if (args.len == 0) return func;
+    var current = func;
+    for (args) |a| {
+        const fn_box = try alloc(arena, ast.Expr, current);
+        const arg_box = try alloc(arena, ast.Expr, a);
+        current = .{ .App = .{ .fn_expr = fn_box, .arg_expr = arg_box } };
+    }
+    return current;
+}
+
+pub fn mkInfix(
+    arena: Allocator,
+    left: ast.Expr,
+    op: []const u8,
+    right: ast.Expr,
+    span: SourceSpan,
+) Allocator.Error!ast.Expr {
+    return .{ .InfixApp = .{
+        .left = try alloc(arena, ast.Expr, left),
+        .op = mkQName(op, span),
+        .right = try alloc(arena, ast.Expr, right),
+    } };
+}
+
+pub fn mkStrLit(s: []const u8, span: SourceSpan) ast.Expr {
+    return .{ .Lit = .{ .String = .{ .value = s, .span = span } } };
+}
+
+pub fn mkIntLit(n: i64, span: SourceSpan) ast.Expr {
+    return .{ .Lit = .{ .Int = .{ .value = n, .span = span } } };
+}
+
+pub fn mkCase(
+    arena: Allocator,
+    scrutinee: ast.Expr,
+    alts: []const ast.Alt,
+) Allocator.Error!ast.Expr {
+    const owned_alts = try arena.alloc(ast.Alt, alts.len);
+    @memcpy(owned_alts, alts);
+    return .{ .Case = .{
+        .scrutinee = try alloc(arena, ast.Expr, scrutinee),
+        .alts = owned_alts,
+    } };
+}
+
+pub fn mkUngRhs(expr: ast.Expr) ast.Rhs {
+    return .{ .UnGuarded = expr };
+}
+
+pub fn mkMatch(
+    arena: Allocator,
+    patterns: []const ast.Pattern,
+    body: ast.Expr,
+    span: SourceSpan,
+) Allocator.Error!ast.Match {
+    const owned = try arena.alloc(ast.Pattern, patterns.len);
+    @memcpy(owned, patterns);
+    return .{
+        .patterns = owned,
+        .rhs = mkUngRhs(body),
+        .where_clause = null,
+        .span = span,
+    };
+}
+
+pub fn mkAlt(pat: ast.Pattern, body: ast.Expr, span: SourceSpan) ast.Alt {
+    return .{
+        .pattern = pat,
+        .rhs = mkUngRhs(body),
+        .where_clause = null,
+        .span = span,
+    };
+}
+
+pub fn mkFunBind(
+    arena: Allocator,
+    name: []const u8,
+    equations: []const ast.Match,
+    span: SourceSpan,
+) Allocator.Error!ast.FunBinding {
+    const owned = try arena.alloc(ast.Match, equations.len);
+    @memcpy(owned, equations);
+    return .{ .name = name, .equations = owned, .span = span };
+}
+
+/// Build an instance head type: `App([Con("ClassName"), <type>])`.
+pub fn mkInstanceHead(
+    arena: Allocator,
+    class_name: []const u8,
+    instance_type: ast.Type,
+    span: SourceSpan,
+) Allocator.Error!ast.Type {
+    const parts = try arena.alloc(*const ast.Type, 2);
+    parts[0] = try alloc(arena, ast.Type, .{ .Con = mkQName(class_name, span) });
+    parts[1] = try alloc(arena, ast.Type, instance_type);
+    return .{ .App = parts };
+}
+
+/// Build the `T a b ...` type-application expression for a parametric data
+/// type's instance head argument.  For nullary type constructors this is
+/// just `Con(T)`.
+pub fn mkAppliedTypeCon(
+    arena: Allocator,
+    type_name: []const u8,
+    tyvars: []const []const u8,
+    span: SourceSpan,
+) Allocator.Error!ast.Type {
+    const head: ast.Type = .{ .Con = mkQName(type_name, span) };
+    if (tyvars.len == 0) return head;
+    const parts = try arena.alloc(*const ast.Type, 1 + tyvars.len);
+    parts[0] = try alloc(arena, ast.Type, head);
+    for (tyvars, 0..) |tv, i| {
+        parts[1 + i] = try alloc(arena, ast.Type, .{ .Var = tv });
+    }
+    return .{ .App = parts };
+}
+
+pub const ClassVarPair = struct { class_name: []const u8, tyvar: []const u8 };
+
+/// Build an instance context of the form `(C1 v1, C2 v2, ...) =>` from
+/// pairs of (class_name, type_variable).
+pub fn mkContext(
+    arena: Allocator,
+    class_var_pairs: []const ClassVarPair,
+) Allocator.Error!?ast.Context {
+    if (class_var_pairs.len == 0) return null;
+    const constraints = try arena.alloc(ast.Assertion, class_var_pairs.len);
+    for (class_var_pairs, 0..) |pair, i| {
+        const types = try arena.alloc(ast.Type, 1);
+        types[0] = .{ .Var = pair.tyvar };
+        constraints[i] = .{ .class_name = pair.class_name, .types = types };
+    }
+    return .{ .constraints = constraints };
+}
+
+pub fn mkInstance(
+    arena: Allocator,
+    context: ?ast.Context,
+    head: ast.Type,
+    bindings: []const ast.FunBinding,
+    span: SourceSpan,
+) Allocator.Error!ast.InstanceDecl {
+    const owned = try arena.alloc(ast.FunBinding, bindings.len);
+    @memcpy(owned, bindings);
+    return .{
+        .context = context,
+        .constructor_type = head,
+        .bindings = owned,
+        .span = span,
+    };
+}
+
+/// Fold a sequence of expressions with infix `&&`, producing `True` for an
+/// empty input. Used by the synthesised `Eq` body.
+pub fn mkAndChain(
+    arena: Allocator,
+    exprs: []const ast.Expr,
+    span: SourceSpan,
+) Allocator.Error!ast.Expr {
+    if (exprs.len == 0) return mkVar("True", span);
+    if (exprs.len == 1) return exprs[0];
+    var acc = exprs[exprs.len - 1];
+    var i: usize = exprs.len - 1;
+    while (i > 0) : (i -= 1) {
+        acc = try mkInfix(arena, exprs[i - 1], "&&", acc, span);
+    }
+    return acc;
+}
+
+/// Fold a sequence of expressions with infix `++`. Empty input returns `""`.
+pub fn mkAppendChain(
+    arena: Allocator,
+    exprs: []const ast.Expr,
+    span: SourceSpan,
+) Allocator.Error!ast.Expr {
+    if (exprs.len == 0) return mkStrLit("", span);
+    if (exprs.len == 1) return exprs[0];
+    var acc = exprs[exprs.len - 1];
+    var i: usize = exprs.len - 1;
+    while (i > 0) : (i -= 1) {
+        acc = try mkInfix(arena, exprs[i - 1], "++", acc, span);
+    }
+    return acc;
+}
+
+/// Collect every distinct type-variable name appearing in a list of field
+/// types, in deterministic order of first appearance. Used to infer instance
+/// contexts for parametric data types.
+pub fn collectTypeVars(
+    arena: Allocator,
+    constructors: []const ast.ConDecl,
+    seen: *std.StringArrayHashMapUnmanaged(void),
+) Allocator.Error!void {
+    for (constructors) |c| {
+        for (c.fields) |f| {
+            const t = switch (f) {
+                .Plain => |t| t,
+                .Record => |r| r.type,
+            };
+            try collectTypeVarsIn(arena, t, seen);
+        }
+    }
+}
+
+fn collectTypeVarsIn(
+    arena: Allocator,
+    t: ast.Type,
+    seen: *std.StringArrayHashMapUnmanaged(void),
+) Allocator.Error!void {
+    switch (t) {
+        .Var => |v| try seen.put(arena, v, {}),
+        .Con => {},
+        .App => |parts| for (parts) |p| try collectTypeVarsIn(arena, p.*, seen),
+        .Fun => |parts| for (parts) |p| try collectTypeVarsIn(arena, p.*, seen),
+        .Tuple => |parts| for (parts) |p| try collectTypeVarsIn(arena, p.*, seen),
+        .List => |p| try collectTypeVarsIn(arena, p.*, seen),
+        .Forall => |fa| try collectTypeVarsIn(arena, fa.type.*, seen),
+        .Paren => |p| try collectTypeVarsIn(arena, p.*, seen),
+        .IParam => |ip| try collectTypeVarsIn(arena, ip.type.*, seen),
+    }
+}

--- a/src/deriving/deriving.zig
+++ b/src/deriving/deriving.zig
@@ -1,0 +1,207 @@
+//! Deriving pass: synthesise `InstanceDecl` nodes for every `deriving`
+//! clause on data/newtype declarations (and for every standalone
+//! `DerivingDecl`) and append them to the module's declaration list.
+//!
+//! Runs between the parser and the renamer, so synthesised instances pass
+//! through renaming and typechecking exactly as if the user had written
+//! them by hand.
+//!
+//! Issue: https://github.com/adinapoli/rusholme/issues/679
+
+const std = @import("std");
+const ast = @import("../frontend/ast.zig");
+const span_mod = @import("../diagnostics/span.zig");
+const diag_mod = @import("../diagnostics/diagnostic.zig");
+
+const shape_mod = @import("shape.zig");
+const builder = @import("builder.zig");
+const eq_mod = @import("eq.zig");
+const ord_mod = @import("ord.zig");
+const show_mod = @import("show.zig");
+const bounded_mod = @import("bounded.zig");
+const enum_mod = @import("enum_class.zig");
+
+pub const SourceSpan = span_mod.SourceSpan;
+pub const Allocator = std.mem.Allocator;
+pub const DeriveError = error{OutOfMemory};
+
+const StockClass = enum { eq, ord, show, bounded, enum_ };
+
+const stock_classes = std.StaticStringMap(StockClass).initComptime(.{
+    .{ "Eq", .eq },
+    .{ "Ord", .ord },
+    .{ "Show", .show },
+    .{ "Bounded", .bounded },
+    .{ "Enum", .enum_ },
+});
+
+/// Walk `module.declarations`, synthesise `InstanceDecl` nodes for every
+/// `deriving` clause, and append them.  The pass mutates the module by
+/// replacing the `declarations` slice with a freshly allocated one.
+///
+/// Synthesis errors are reported through `diags` but do not halt the pass —
+/// every clause is processed so the user sees all problems in one compile.
+pub fn derive(
+    arena: Allocator,
+    module: *ast.Module,
+    diags: *diag_mod.DiagnosticCollector,
+) DeriveError!void {
+    var out: std.ArrayListUnmanaged(ast.Decl) = .empty;
+
+    // Synthesise instances inline, placing the helpers + instance
+    // immediately after the data/newtype declaration that triggered them.
+    // This keeps each type with its derived machinery together and matches
+    // the declaration order a user would write by hand.
+    for (module.declarations) |decl| {
+        try out.append(arena, decl);
+        switch (decl) {
+            .Data => |d| {
+                if (d.deriving.len == 0) continue;
+                const norm = shape_mod.NormalizedDecl.fromData(d);
+                try processDeriveList(arena, norm, d.deriving, d.span, diags, &out);
+            },
+            .Newtype => |n| {
+                if (n.deriving.len == 0) continue;
+                const norm = try shape_mod.NormalizedDecl.fromNewtype(arena, n);
+                try processDeriveList(arena, norm, n.deriving, n.span, diags, &out);
+            },
+            .Deriving => |sd| {
+                try processStandalone(arena, sd, module.*, diags, &out);
+            },
+            else => {},
+        }
+    }
+
+    module.declarations = try out.toOwnedSlice(arena);
+}
+
+fn processDeriveList(
+    arena: Allocator,
+    decl: shape_mod.NormalizedDecl,
+    classes: []const []const u8,
+    span: SourceSpan,
+    diags: *diag_mod.DiagnosticCollector,
+    out: *std.ArrayListUnmanaged(ast.Decl),
+) DeriveError!void {
+    for (classes) |class_name| {
+        const r = synthOne(arena, decl, class_name, span, diags) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.NotDerivable => continue,
+        };
+        for (r.helpers) |h| try out.append(arena, h);
+        try out.append(arena, .{ .Instance = r.instance });
+    }
+}
+
+fn processStandalone(
+    arena: Allocator,
+    sd: ast.DerivingDecl,
+    module: ast.Module,
+    diags: *diag_mod.DiagnosticCollector,
+    out: *std.ArrayListUnmanaged(ast.Decl),
+) DeriveError!void {
+    // Find the data/newtype decl that `sd.type` refers to so that we can
+    // walk its constructors.  `sd.type` may be a `Con T` or `App [Con T, ...]`.
+    const type_name = extractTypeName(sd.type) orelse {
+        try diags.emit(arena, .{
+            .severity = .@"error",
+            .code = .deriving_shape_mismatch,
+            .span = sd.span,
+            .message = "Cannot derive standalone instance: target type is not a simple data/newtype constructor",
+        });
+        return;
+    };
+
+    var norm: ?shape_mod.NormalizedDecl = null;
+    for (module.declarations) |d| {
+        switch (d) {
+            .Data => |dd| if (std.mem.eql(u8, dd.name, type_name)) {
+                norm = shape_mod.NormalizedDecl.fromData(dd);
+                break;
+            },
+            .Newtype => |nn| if (std.mem.eql(u8, nn.name, type_name)) {
+                norm = try shape_mod.NormalizedDecl.fromNewtype(arena, nn);
+                break;
+            },
+            else => {},
+        }
+    }
+    const ndecl = norm orelse {
+        try diags.emit(arena, .{
+            .severity = .@"error",
+            .code = .deriving_shape_mismatch,
+            .span = sd.span,
+            .message = "Cannot derive standalone instance: target type not found in module",
+        });
+        return;
+    };
+
+    for (sd.classes) |class_name| {
+        const r = synthOne(arena, ndecl, class_name, sd.span, diags) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.NotDerivable => continue,
+        };
+        for (r.helpers) |h| try out.append(arena, h);
+        try out.append(arena, .{ .Instance = r.instance });
+    }
+}
+
+fn extractTypeName(t: ast.Type) ?[]const u8 {
+    return switch (t) {
+        .Con => |q| q.name,
+        .App => |parts| if (parts.len >= 1) extractTypeName(parts[0].*) else null,
+        .Paren => |p| extractTypeName(p.*),
+        else => null,
+    };
+}
+
+const SynthError = error{ OutOfMemory, NotDerivable };
+
+const Synthesised = struct {
+    helpers: []const ast.Decl,
+    instance: ast.InstanceDecl,
+};
+
+fn synthOne(
+    arena: Allocator,
+    decl: shape_mod.NormalizedDecl,
+    class_name: []const u8,
+    span: SourceSpan,
+    diags: *diag_mod.DiagnosticCollector,
+) SynthError!Synthesised {
+    const kind = stock_classes.get(class_name) orelse {
+        try diags.emit(arena, .{
+            .severity = .@"error",
+            .code = .deriving_unsupported_class,
+            .span = span,
+            .message = std.fmt.allocPrint(
+                arena,
+                "Cannot derive `{s}`: only Eq, Ord, Show, Bounded, Enum are supported",
+                .{class_name},
+            ) catch "Cannot derive: unsupported class",
+        });
+        return error.NotDerivable;
+    };
+    return switch (kind) {
+        .eq => blk: {
+            const r = try eq_mod.synth(arena, decl, span);
+            break :blk .{ .helpers = r.helpers, .instance = r.instance };
+        },
+        .ord => blk: {
+            const r = try ord_mod.synth(arena, decl, span);
+            break :blk .{ .helpers = r.helpers, .instance = r.instance };
+        },
+        .show => blk: {
+            const r = try show_mod.synth(arena, decl, span);
+            break :blk .{ .helpers = r.helpers, .instance = r.instance };
+        },
+        .bounded => blk: {
+            const r = try bounded_mod.synth(arena, decl, span, diags);
+            break :blk .{ .helpers = r.helpers, .instance = r.instance };
+        },
+        .enum_ => blk: {
+            const r = try enum_mod.synth(arena, decl, span, diags);
+            break :blk .{ .helpers = r.helpers, .instance = r.instance };
+        },
+    };
+}

--- a/src/deriving/enum_class.zig
+++ b/src/deriving/enum_class.zig
@@ -1,0 +1,149 @@
+//! Synthesise an `Enum` instance.  Only legal for enumeration types (all
+//! constructors nullary).  Each method is a single equation with a case
+//! body.
+//!
+//! - `fromEnum x = case x of { Cn -> n }`              (n = positional idx)
+//! - `toEnum n = case n of { 0 -> C0; 1 -> C1; ...; _ -> error }`
+//! - `succ x = case x of { Cn -> C{n+1} | error if last }`
+//! - `pred x = case x of { Cn -> C{n-1} | error if first }`
+
+const std = @import("std");
+const ast = @import("../frontend/ast.zig");
+const span_mod = @import("../diagnostics/span.zig");
+const diag_mod = @import("../diagnostics/diagnostic.zig");
+
+const builder = @import("builder.zig");
+const shape_mod = @import("shape.zig");
+
+const SourceSpan = span_mod.SourceSpan;
+const Allocator = std.mem.Allocator;
+const NormalizedDecl = shape_mod.NormalizedDecl;
+
+pub const Error = error{ OutOfMemory, NotDerivable };
+
+pub const Synthesised = struct {
+    helpers: []const ast.Decl,
+    instance: ast.InstanceDecl,
+};
+
+pub fn synth(
+    arena: Allocator,
+    decl: NormalizedDecl,
+    span: SourceSpan,
+    diags: *diag_mod.DiagnosticCollector,
+) Error!Synthesised {
+    const shape = shape_mod.classify(decl);
+    if (shape != .Enumeration) {
+        try diags.emit(arena, .{
+            .severity = .@"error",
+            .code = .deriving_shape_mismatch,
+            .span = span,
+            .message = "Cannot derive `Enum`: type must be an enumeration (all constructors nullary)",
+        });
+        return error.NotDerivable;
+    }
+
+    // fromEnum
+    var from_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
+    for (decl.constructors, 0..) |c, idx| {
+        const pat = try builder.mkConPat(arena, c.name, &.{}, span);
+        try from_alts.append(arena, builder.mkAlt(
+            pat,
+            builder.mkIntLit(@intCast(idx), span),
+            span,
+        ));
+    }
+    const from_body = try builder.mkCase(arena, builder.mkVar("x", span), from_alts.items);
+    const from_match = try builder.mkMatch(
+        arena,
+        &.{builder.mkVarPat("x", span)},
+        from_body,
+        span,
+    );
+    const from_fb = try builder.mkFunBind(arena, "fromEnum", &.{from_match}, span);
+
+    // toEnum
+    var to_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
+    for (decl.constructors, 0..) |c, idx| {
+        const lit_pat: ast.Pattern = .{ .Lit = .{ .Int = .{
+            .value = @intCast(idx),
+            .span = span,
+        } } };
+        try to_alts.append(arena, builder.mkAlt(
+            lit_pat,
+            builder.mkVar(c.name, span),
+            span,
+        ));
+    }
+    const to_err = try builder.mkApp(
+        arena,
+        builder.mkVar("error", span),
+        &.{builder.mkStrLit("Enum.toEnum: out of range", span)},
+    );
+    try to_alts.append(arena, builder.mkAlt(builder.mkWildPat(span), to_err, span));
+    const to_body = try builder.mkCase(arena, builder.mkVar("n", span), to_alts.items);
+    const to_match = try builder.mkMatch(
+        arena,
+        &.{builder.mkVarPat("n", span)},
+        to_body,
+        span,
+    );
+    const to_fb = try builder.mkFunBind(arena, "toEnum", &.{to_match}, span);
+
+    // succ
+    var succ_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
+    for (decl.constructors, 0..) |c, idx| {
+        const pat = try builder.mkConPat(arena, c.name, &.{}, span);
+        const body = if (idx + 1 < decl.constructors.len)
+            builder.mkVar(decl.constructors[idx + 1].name, span)
+        else
+            try builder.mkApp(
+                arena,
+                builder.mkVar("error", span),
+                &.{builder.mkStrLit("Enum.succ: bad argument", span)},
+            );
+        try succ_alts.append(arena, builder.mkAlt(pat, body, span));
+    }
+    const succ_body = try builder.mkCase(arena, builder.mkVar("x", span), succ_alts.items);
+    const succ_match = try builder.mkMatch(
+        arena,
+        &.{builder.mkVarPat("x", span)},
+        succ_body,
+        span,
+    );
+    const succ_fb = try builder.mkFunBind(arena, "succ", &.{succ_match}, span);
+
+    // pred
+    var pred_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
+    for (decl.constructors, 0..) |c, idx| {
+        const pat = try builder.mkConPat(arena, c.name, &.{}, span);
+        const body = if (idx == 0)
+            try builder.mkApp(
+                arena,
+                builder.mkVar("error", span),
+                &.{builder.mkStrLit("Enum.pred: bad argument", span)},
+            )
+        else
+            builder.mkVar(decl.constructors[idx - 1].name, span);
+        try pred_alts.append(arena, builder.mkAlt(pat, body, span));
+    }
+    const pred_body = try builder.mkCase(arena, builder.mkVar("x", span), pred_alts.items);
+    const pred_match = try builder.mkMatch(
+        arena,
+        &.{builder.mkVarPat("x", span)},
+        pred_body,
+        span,
+    );
+    const pred_fb = try builder.mkFunBind(arena, "pred", &.{pred_match}, span);
+
+    const applied = try builder.mkAppliedTypeCon(arena, decl.name, decl.tyvars, span);
+    const head = try builder.mkInstanceHead(arena, "Enum", applied, span);
+    const instance = try builder.mkInstance(
+        arena,
+        null,
+        head,
+        &.{ from_fb, to_fb, succ_fb, pred_fb },
+        span,
+    );
+    return .{ .helpers = &.{}, .instance = instance };
+}

--- a/src/deriving/eq.zig
+++ b/src/deriving/eq.zig
@@ -1,21 +1,19 @@
 //! Synthesise an `Eq` instance.
 //!
-//! Emits a top-level helper `derivedEq_<TypeName> x y = case x of …; case y of …`
-//! and an instance whose `(==)` method is eta-reduced to that helper:
-//!
-//!     derivedEq_Color x y = case x of
-//!       Red   -> case y of Red   -> True; _ -> False
-//!       Green -> case y of Green -> True; _ -> False
-//!       Blue  -> case y of Blue  -> True; _ -> False
+//! Emits a single instance with method bodies in the canonical shape
 //!
 //!     instance Eq Color where
-//!       (==) = derivedEq_Color
+//!       (==) x y = case x of
+//!         Red   -> case y of Red   -> True; _ -> False
+//!         Green -> case y of Green -> True; _ -> False
+//!         Blue  -> case y of Blue  -> True; _ -> False
 //!       (/=) x y = not (x == y)
 //!
-//! Placing the nested-case body at the top level (rather than directly
-//! inside the instance method) sidesteps an instance-method desugaring
-//! bug where nested `case` expressions in the method body always take
-//! the wildcard branch (filed as follow-up).
+//! The desugarer hoists each method's lambda chain to a top-level
+//! binding (`_inst$Eq$<TypeName>$<method>`), so the dictionary slot
+//! holds a Var reference to a properly-arited function rather than a
+//! 1-argument outer lambda — without this hoist the LLVM call-lowering
+//! drops the second argument when the dict method is called with two.
 
 const std = @import("std");
 const ast = @import("../frontend/ast.zig");
@@ -88,7 +86,7 @@ pub fn synth(
         try outer_alts.append(arena, builder.mkAlt(outer_con, inner_case, span));
     }
 
-    const helper_body: ast.Expr = if (decl.constructors.len == 0)
+    const eq_body: ast.Expr = if (decl.constructors.len == 0)
         try builder.mkApp(
             arena,
             builder.mkVar("error", span),
@@ -101,31 +99,15 @@ pub fn synth(
             outer_alts.items,
         );
 
-    // Top-level helper: `derivedEq_<TypeName> x y = case x of ...`.
-    // The instance method (==) is eta-reduced to point at this helper
-    // because nested case expressions inside instance method bodies
-    // misbehave in the current desugarer.
-    const helper_name = try std.fmt.allocPrint(arena, "derivedEq_{s}", .{decl.name});
-    const helper_match = try builder.mkMatch(
-        arena,
-        &.{ builder.mkVarPat("x", span), builder.mkVarPat("y", span) },
-        helper_body,
-        span,
-    );
-    const helper_fb = try builder.mkFunBind(arena, helper_name, &.{helper_match}, span);
-    const helper_decl: ast.Decl = .{ .FunBind = helper_fb };
-
-    // `(==) = derivedEq_<TypeName>` — eta-reduced binding.
     const eq_method_match = try builder.mkMatch(
         arena,
-        &.{},
-        builder.mkVar(helper_name, span),
+        &.{ builder.mkVarPat("x", span), builder.mkVarPat("y", span) },
+        eq_body,
         span,
     );
     const eq_fb = try builder.mkFunBind(arena, "==", &.{eq_method_match}, span);
 
-    // `(/=) x y = not (x == y)` — inline; uses the class method so the
-    // dictionary dispatch resolves through (==).
+    // `(/=) x y = not (x == y)`.
     const ne_body_eq = try builder.mkInfix(
         arena,
         builder.mkVar("x", span),
@@ -158,7 +140,5 @@ pub fn synth(
     const head = try builder.mkInstanceHead(arena, "Eq", applied, span);
     const instance = try builder.mkInstance(arena, ctx, head, &.{ eq_fb, ne_fb }, span);
 
-    const helpers = try arena.alloc(ast.Decl, 1);
-    helpers[0] = helper_decl;
-    return .{ .helpers = helpers, .instance = instance };
+    return .{ .helpers = &.{}, .instance = instance };
 }

--- a/src/deriving/eq.zig
+++ b/src/deriving/eq.zig
@@ -1,0 +1,164 @@
+//! Synthesise an `Eq` instance.
+//!
+//! Emits a top-level helper `derivedEq_<TypeName> x y = case x of …; case y of …`
+//! and an instance whose `(==)` method is eta-reduced to that helper:
+//!
+//!     derivedEq_Color x y = case x of
+//!       Red   -> case y of Red   -> True; _ -> False
+//!       Green -> case y of Green -> True; _ -> False
+//!       Blue  -> case y of Blue  -> True; _ -> False
+//!
+//!     instance Eq Color where
+//!       (==) = derivedEq_Color
+//!       (/=) x y = not (x == y)
+//!
+//! Placing the nested-case body at the top level (rather than directly
+//! inside the instance method) sidesteps an instance-method desugaring
+//! bug where nested `case` expressions in the method body always take
+//! the wildcard branch (filed as follow-up).
+
+const std = @import("std");
+const ast = @import("../frontend/ast.zig");
+const span_mod = @import("../diagnostics/span.zig");
+
+const builder = @import("builder.zig");
+const shape_mod = @import("shape.zig");
+
+const SourceSpan = span_mod.SourceSpan;
+const Allocator = std.mem.Allocator;
+const NormalizedDecl = shape_mod.NormalizedDecl;
+
+pub const Synthesised = struct {
+    helpers: []const ast.Decl,
+    instance: ast.InstanceDecl,
+};
+
+pub fn synth(
+    arena: Allocator,
+    decl: NormalizedDecl,
+    span: SourceSpan,
+) Allocator.Error!Synthesised {
+    var outer_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
+
+    for (decl.constructors) |c_outer| {
+        const arity = c_outer.fields.len;
+
+        const outer_pats = try arena.alloc(ast.Pattern, arity);
+        for (0..arity) |i| {
+            const n = try std.fmt.allocPrint(arena, "x{d}", .{i});
+            outer_pats[i] = builder.mkVarPat(n, span);
+        }
+        const outer_con = try builder.mkConPat(arena, c_outer.name, outer_pats, span);
+
+        // Inner case on y: matching the same constructor returns the
+        // conjunction of field equalities; anything else is False.
+        const inner_pats = try arena.alloc(ast.Pattern, arity);
+        var field_eqs: std.ArrayListUnmanaged(ast.Expr) = .empty;
+        for (0..arity) |i| {
+            const xn = try std.fmt.allocPrint(arena, "x{d}", .{i});
+            const yn = try std.fmt.allocPrint(arena, "y{d}", .{i});
+            inner_pats[i] = builder.mkVarPat(yn, span);
+            const eq_e = try builder.mkInfix(
+                arena,
+                builder.mkVar(xn, span),
+                "==",
+                builder.mkVar(yn, span),
+                span,
+            );
+            try field_eqs.append(arena, eq_e);
+        }
+        const inner_con = try builder.mkConPat(arena, c_outer.name, inner_pats, span);
+        const matched_body = try builder.mkAndChain(arena, field_eqs.items, span);
+
+        var inner_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
+        try inner_alts.append(arena, builder.mkAlt(inner_con, matched_body, span));
+        if (decl.constructors.len > 1) {
+            try inner_alts.append(arena, builder.mkAlt(
+                builder.mkWildPat(span),
+                builder.mkVar("False", span),
+                span,
+            ));
+        }
+        const inner_case = try builder.mkCase(
+            arena,
+            builder.mkVar("y", span),
+            inner_alts.items,
+        );
+
+        try outer_alts.append(arena, builder.mkAlt(outer_con, inner_case, span));
+    }
+
+    const helper_body: ast.Expr = if (decl.constructors.len == 0)
+        try builder.mkApp(
+            arena,
+            builder.mkVar("error", span),
+            &.{builder.mkStrLit("Eq.==: empty type", span)},
+        )
+    else
+        try builder.mkCase(
+            arena,
+            builder.mkVar("x", span),
+            outer_alts.items,
+        );
+
+    // Top-level helper: `derivedEq_<TypeName> x y = case x of ...`.
+    // The instance method (==) is eta-reduced to point at this helper
+    // because nested case expressions inside instance method bodies
+    // misbehave in the current desugarer.
+    const helper_name = try std.fmt.allocPrint(arena, "derivedEq_{s}", .{decl.name});
+    const helper_match = try builder.mkMatch(
+        arena,
+        &.{ builder.mkVarPat("x", span), builder.mkVarPat("y", span) },
+        helper_body,
+        span,
+    );
+    const helper_fb = try builder.mkFunBind(arena, helper_name, &.{helper_match}, span);
+    const helper_decl: ast.Decl = .{ .FunBind = helper_fb };
+
+    // `(==) = derivedEq_<TypeName>` — eta-reduced binding.
+    const eq_method_match = try builder.mkMatch(
+        arena,
+        &.{},
+        builder.mkVar(helper_name, span),
+        span,
+    );
+    const eq_fb = try builder.mkFunBind(arena, "==", &.{eq_method_match}, span);
+
+    // `(/=) x y = not (x == y)` — inline; uses the class method so the
+    // dictionary dispatch resolves through (==).
+    const ne_body_eq = try builder.mkInfix(
+        arena,
+        builder.mkVar("x", span),
+        "==",
+        builder.mkVar("y", span),
+        span,
+    );
+    const ne_body = try builder.mkApp(
+        arena,
+        builder.mkVar("not", span),
+        &.{ne_body_eq},
+    );
+    const ne_match = try builder.mkMatch(
+        arena,
+        &.{ builder.mkVarPat("x", span), builder.mkVarPat("y", span) },
+        ne_body,
+        span,
+    );
+    const ne_fb = try builder.mkFunBind(arena, "/=", &.{ne_match}, span);
+
+    var seen: std.StringArrayHashMapUnmanaged(void) = .empty;
+    try builder.collectTypeVars(arena, decl.constructors, &seen);
+    var pairs: std.ArrayListUnmanaged(builder.ClassVarPair) = .empty;
+    for (seen.keys()) |tv| {
+        try pairs.append(arena, .{ .class_name = "Eq", .tyvar = tv });
+    }
+    const ctx = try builder.mkContext(arena, pairs.items);
+
+    const applied = try builder.mkAppliedTypeCon(arena, decl.name, decl.tyvars, span);
+    const head = try builder.mkInstanceHead(arena, "Eq", applied, span);
+    const instance = try builder.mkInstance(arena, ctx, head, &.{ eq_fb, ne_fb }, span);
+
+    const helpers = try arena.alloc(ast.Decl, 1);
+    helpers[0] = helper_decl;
+    return .{ .helpers = helpers, .instance = instance };
+}

--- a/src/deriving/ord.zig
+++ b/src/deriving/ord.zig
@@ -142,7 +142,91 @@ pub fn synth(
         span,
     );
     const fb = try builder.mkFunBind(arena, "compare", &.{m}, span);
-    return .{ .helpers = &.{}, .instance = try finalize(arena, decl, &.{fb}, span) };
+
+    // `(<) x y = case compare x y of LT -> True; _ -> False`
+    const lt_fb = try mkOrdRelation(arena, "<", "LT", span);
+    // `(>) x y = case compare x y of GT -> True; _ -> False`
+    const gt_fb = try mkOrdRelation(arena, ">", "GT", span);
+    // `(<=) x y = case compare x y of GT -> False; _ -> True`
+    const le_fb = try mkOrdNegRelation(arena, "<=", "GT", span);
+    // `(>=) x y = case compare x y of LT -> False; _ -> True`
+    const ge_fb = try mkOrdNegRelation(arena, ">=", "LT", span);
+
+    return .{
+        .helpers = &.{},
+        .instance = try finalize(
+            arena,
+            decl,
+            &.{ fb, lt_fb, gt_fb, le_fb, ge_fb },
+            span,
+        ),
+    };
+}
+
+/// Synthesise a binding of the form
+///   `op x y = case compare x y of <ordering> -> True; _ -> False`
+fn mkOrdRelation(
+    arena: Allocator,
+    op: []const u8,
+    ordering_con: []const u8,
+    span: SourceSpan,
+) Allocator.Error!ast.FunBinding {
+    const cmp = try builder.mkApp(
+        arena,
+        builder.mkVar("compare", span),
+        &.{ builder.mkVar("x", span), builder.mkVar("y", span) },
+    );
+    const match_alt = builder.mkAlt(
+        try builder.mkConPat(arena, ordering_con, &.{}, span),
+        builder.mkVar("True", span),
+        span,
+    );
+    const wild_alt = builder.mkAlt(
+        builder.mkWildPat(span),
+        builder.mkVar("False", span),
+        span,
+    );
+    const body = try builder.mkCase(arena, cmp, &.{ match_alt, wild_alt });
+    const m = try builder.mkMatch(
+        arena,
+        &.{ builder.mkVarPat("x", span), builder.mkVarPat("y", span) },
+        body,
+        span,
+    );
+    return builder.mkFunBind(arena, op, &.{m}, span);
+}
+
+/// Synthesise a binding of the form
+///   `op x y = case compare x y of <ordering> -> False; _ -> True`
+fn mkOrdNegRelation(
+    arena: Allocator,
+    op: []const u8,
+    ordering_con: []const u8,
+    span: SourceSpan,
+) Allocator.Error!ast.FunBinding {
+    const cmp = try builder.mkApp(
+        arena,
+        builder.mkVar("compare", span),
+        &.{ builder.mkVar("x", span), builder.mkVar("y", span) },
+    );
+    const match_alt = builder.mkAlt(
+        try builder.mkConPat(arena, ordering_con, &.{}, span),
+        builder.mkVar("False", span),
+        span,
+    );
+    const wild_alt = builder.mkAlt(
+        builder.mkWildPat(span),
+        builder.mkVar("True", span),
+        span,
+    );
+    const body = try builder.mkCase(arena, cmp, &.{ match_alt, wild_alt });
+    const m = try builder.mkMatch(
+        arena,
+        &.{ builder.mkVarPat("x", span), builder.mkVarPat("y", span) },
+        body,
+        span,
+    );
+    return builder.mkFunBind(arena, op, &.{m}, span);
 }
 
 /// Build `case compare x0 y0 of { EQ -> case compare x1 y1 of { ... }; o -> o }`

--- a/src/deriving/ord.zig
+++ b/src/deriving/ord.zig
@@ -1,0 +1,204 @@
+//! Synthesise an `Ord` instance.  Uses `compare :: a -> a -> Ordering` as
+//! the primary method.  The body is a nested case expression that handles
+//! every constructor pairing:
+//!
+//!   compare a b = case a of
+//!     C1 x1 .. -> case b of
+//!         C1 y1 .. -> <lex-compare fields>
+//!         _        -> LT  -- later constructor on the right
+//!     C2 x1 .. -> case b of
+//!         C1 _ .. -> GT   -- earlier constructor on the right
+//!         C2 y1 .. -> <lex-compare fields>
+//!         _        -> LT
+//!     ...
+//!
+//! Constructor order = order of declaration.
+
+const std = @import("std");
+const ast = @import("../frontend/ast.zig");
+const span_mod = @import("../diagnostics/span.zig");
+
+const builder = @import("builder.zig");
+const shape_mod = @import("shape.zig");
+
+const SourceSpan = span_mod.SourceSpan;
+const Allocator = std.mem.Allocator;
+const NormalizedDecl = shape_mod.NormalizedDecl;
+
+pub const Synthesised = struct {
+    helpers: []const ast.Decl,
+    instance: ast.InstanceDecl,
+};
+
+pub fn synth(
+    arena: Allocator,
+    decl: NormalizedDecl,
+    span: SourceSpan,
+) Allocator.Error!Synthesised {
+    // Build the outer `case a of` alts.
+    var outer_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
+
+    for (decl.constructors, 0..) |c_outer, outer_idx| {
+        const outer_arity = c_outer.fields.len;
+        const outer_pats = try arena.alloc(ast.Pattern, outer_arity);
+        for (0..outer_arity) |i| {
+            const n = try std.fmt.allocPrint(arena, "x{d}", .{i});
+            outer_pats[i] = builder.mkVarPat(n, span);
+        }
+        const outer_con = try builder.mkConPat(arena, c_outer.name, outer_pats, span);
+
+        // Build the inner `case b of` alts.
+        var inner_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
+
+        for (decl.constructors, 0..) |c_inner, inner_idx| {
+            if (inner_idx == outer_idx) {
+                // Equal-constructor case: lex compare fields.
+                const inner_arity = c_inner.fields.len;
+                const inner_pats = try arena.alloc(ast.Pattern, inner_arity);
+                for (0..inner_arity) |j| {
+                    const n = try std.fmt.allocPrint(arena, "y{d}", .{j});
+                    inner_pats[j] = builder.mkVarPat(n, span);
+                }
+                const inner_con = try builder.mkConPat(
+                    arena,
+                    c_inner.name,
+                    inner_pats,
+                    span,
+                );
+                const body = try lexCompare(arena, inner_arity, span);
+                try inner_alts.append(arena, builder.mkAlt(inner_con, body, span));
+            } else if (inner_idx < outer_idx) {
+                // Right is an earlier constructor → left > right.
+                const inner_arity = c_inner.fields.len;
+                const wild_pats = try arena.alloc(ast.Pattern, inner_arity);
+                for (0..inner_arity) |j| wild_pats[j] = builder.mkWildPat(span);
+                const inner_con = try builder.mkConPat(
+                    arena,
+                    c_inner.name,
+                    wild_pats,
+                    span,
+                );
+                try inner_alts.append(arena, builder.mkAlt(
+                    inner_con,
+                    builder.mkVar("GT", span),
+                    span,
+                ));
+            } else {
+                // inner_idx > outer_idx: right is later → left < right.
+                const inner_arity = c_inner.fields.len;
+                const wild_pats = try arena.alloc(ast.Pattern, inner_arity);
+                for (0..inner_arity) |j| wild_pats[j] = builder.mkWildPat(span);
+                const inner_con = try builder.mkConPat(
+                    arena,
+                    c_inner.name,
+                    wild_pats,
+                    span,
+                );
+                try inner_alts.append(arena, builder.mkAlt(
+                    inner_con,
+                    builder.mkVar("LT", span),
+                    span,
+                ));
+            }
+        }
+
+        const inner_case = try builder.mkCase(
+            arena,
+            builder.mkVar("b", span),
+            inner_alts.items,
+        );
+        try outer_alts.append(arena, builder.mkAlt(outer_con, inner_case, span));
+    }
+
+    // Empty data type: `compare _ _ = error "Ord.compare: empty type"`.
+    if (decl.constructors.len == 0) {
+        const err_call = try builder.mkApp(
+            arena,
+            builder.mkVar("error", span),
+            &.{builder.mkStrLit("Ord.compare: empty type", span)},
+        );
+        const m = try builder.mkMatch(
+            arena,
+            &.{ builder.mkWildPat(span), builder.mkWildPat(span) },
+            err_call,
+            span,
+        );
+        const fb = try builder.mkFunBind(arena, "compare", &.{m}, span);
+        return .{ .helpers = &.{}, .instance = try finalize(arena, decl, &.{fb}, span) };
+    }
+
+    const outer_case = try builder.mkCase(
+        arena,
+        builder.mkVar("a", span),
+        outer_alts.items,
+    );
+    const m = try builder.mkMatch(
+        arena,
+        &.{
+            builder.mkVarPat("a", span),
+            builder.mkVarPat("b", span),
+        },
+        outer_case,
+        span,
+    );
+    const fb = try builder.mkFunBind(arena, "compare", &.{m}, span);
+    return .{ .helpers = &.{}, .instance = try finalize(arena, decl, &.{fb}, span) };
+}
+
+/// Build `case compare x0 y0 of { EQ -> case compare x1 y1 of { ... }; o -> o }`
+/// down through `arity` field positions.  Returns `EQ` for arity 0.
+fn lexCompare(
+    arena: Allocator,
+    arity: usize,
+    span: SourceSpan,
+) Allocator.Error!ast.Expr {
+    if (arity == 0) return builder.mkVar("EQ", span);
+    return lexCompareFrom(arena, 0, arity, span);
+}
+
+fn lexCompareFrom(
+    arena: Allocator,
+    i: usize,
+    arity: usize,
+    span: SourceSpan,
+) Allocator.Error!ast.Expr {
+    const x = try std.fmt.allocPrint(arena, "x{d}", .{i});
+    const y = try std.fmt.allocPrint(arena, "y{d}", .{i});
+    const cmp = try builder.mkApp(
+        arena,
+        builder.mkVar("compare", span),
+        &.{ builder.mkVar(x, span), builder.mkVar(y, span) },
+    );
+    if (i + 1 == arity) return cmp;
+    // Otherwise wrap in `case cmp of { EQ -> rest; o -> o }`.
+    const rest = try lexCompareFrom(arena, i + 1, arity, span);
+    const eq_alt = builder.mkAlt(
+        try builder.mkConPat(arena, "EQ", &.{}, span),
+        rest,
+        span,
+    );
+    const o_alt = builder.mkAlt(
+        builder.mkVarPat("o", span),
+        builder.mkVar("o", span),
+        span,
+    );
+    return builder.mkCase(arena, cmp, &.{ eq_alt, o_alt });
+}
+
+fn finalize(
+    arena: Allocator,
+    decl: NormalizedDecl,
+    bindings: []const ast.FunBinding,
+    span: SourceSpan,
+) Allocator.Error!ast.InstanceDecl {
+    var seen: std.StringArrayHashMapUnmanaged(void) = .empty;
+    try builder.collectTypeVars(arena, decl.constructors, &seen);
+    var pairs: std.ArrayListUnmanaged(builder.ClassVarPair) = .empty;
+    for (seen.keys()) |tv| {
+        try pairs.append(arena, .{ .class_name = "Ord", .tyvar = tv });
+    }
+    const ctx = try builder.mkContext(arena, pairs.items);
+    const applied = try builder.mkAppliedTypeCon(arena, decl.name, decl.tyvars, span);
+    const head = try builder.mkInstanceHead(arena, "Ord", applied, span);
+    return builder.mkInstance(arena, ctx, head, bindings, span);
+}

--- a/src/deriving/shape.zig
+++ b/src/deriving/shape.zig
@@ -1,0 +1,136 @@
+//! Classify a data/newtype declaration into a `DataShape` for the deriving
+//! pass.  The shape drives which classes a type may legally derive and which
+//! synthesis strategy applies.
+
+const std = @import("std");
+const ast = @import("../frontend/ast.zig");
+const span_mod = @import("../diagnostics/span.zig");
+const SourceSpan = span_mod.SourceSpan;
+const SourcePos = span_mod.SourcePos;
+
+pub const DataShape = enum {
+    /// All constructors are nullary (e.g. `data Day = Mon | Tue | Wed`).
+    /// Legal: Eq, Ord, Show, Bounded, Enum.
+    Enumeration,
+    /// Exactly one constructor with at least one field
+    /// (e.g. `data P = P Int Int` or any `newtype`).
+    /// Legal: Eq, Ord, Show, Bounded.
+    SingleProduct,
+    /// Multiple constructors, at least one with fields.
+    /// Legal: Eq, Ord, Show.
+    SumOfProducts,
+    /// Zero constructors (`data Void`).
+    /// Legal: Eq, Ord; Show with empty case.
+    Empty,
+};
+
+/// A uniform view over data and newtype declarations: a name, type variables,
+/// and a list of constructors.  Newtypes appear here as a single-constructor
+/// data with one field.
+pub const NormalizedDecl = struct {
+    name: []const u8,
+    tyvars: []const []const u8,
+    constructors: []const ast.ConDecl,
+    span: SourceSpan,
+
+    pub fn fromData(d: ast.DataDecl) NormalizedDecl {
+        return .{
+            .name = d.name,
+            .tyvars = d.tyvars,
+            .constructors = d.constructors,
+            .span = d.span,
+        };
+    }
+
+    pub fn fromNewtype(
+        arena: std.mem.Allocator,
+        d: ast.NewtypeDecl,
+    ) std.mem.Allocator.Error!NormalizedDecl {
+        const cons = try arena.alloc(ast.ConDecl, 1);
+        cons[0] = d.constructor;
+        return .{
+            .name = d.name,
+            .tyvars = d.tyvars,
+            .constructors = cons,
+            .span = d.span,
+        };
+    }
+};
+
+pub fn classify(decl: NormalizedDecl) DataShape {
+    if (decl.constructors.len == 0) return .Empty;
+
+    var all_nullary = true;
+    for (decl.constructors) |c| {
+        if (c.fields.len != 0) {
+            all_nullary = false;
+            break;
+        }
+    }
+    if (all_nullary) return .Enumeration;
+
+    if (decl.constructors.len == 1) return .SingleProduct;
+    return .SumOfProducts;
+}
+
+fn testSpan() SourceSpan {
+    const p = SourcePos.init(1, 1, 1);
+    return SourceSpan.init(p, p);
+}
+
+test "classify: enumeration" {
+    const cons = [_]ast.ConDecl{
+        .{ .name = "A", .fields = &.{}, .span = testSpan() },
+        .{ .name = "B", .fields = &.{}, .span = testSpan() },
+    };
+    const decl = NormalizedDecl{
+        .name = "T",
+        .tyvars = &.{},
+        .constructors = &cons,
+        .span = testSpan(),
+    };
+    try std.testing.expectEqual(DataShape.Enumeration, classify(decl));
+}
+
+test "classify: single product" {
+    const fields = [_]ast.FieldDecl{
+        .{ .Plain = .{ .Var = "a" } },
+    };
+    const cons = [_]ast.ConDecl{
+        .{ .name = "P", .fields = &fields, .span = testSpan() },
+    };
+    const decl = NormalizedDecl{
+        .name = "P",
+        .tyvars = &.{"a"},
+        .constructors = &cons,
+        .span = testSpan(),
+    };
+    try std.testing.expectEqual(DataShape.SingleProduct, classify(decl));
+}
+
+test "classify: sum of products" {
+    const fields = [_]ast.FieldDecl{
+        .{ .Plain = .{ .Var = "a" } },
+    };
+    const cons = [_]ast.ConDecl{
+        .{ .name = "Just", .fields = &fields, .span = testSpan() },
+        .{ .name = "Nothing", .fields = &.{}, .span = testSpan() },
+    };
+    const decl = NormalizedDecl{
+        .name = "Maybe",
+        .tyvars = &.{"a"},
+        .constructors = &cons,
+        .span = testSpan(),
+    };
+    try std.testing.expectEqual(DataShape.SumOfProducts, classify(decl));
+}
+
+test "classify: empty" {
+    const decl = NormalizedDecl{
+        .name = "Void",
+        .tyvars = &.{},
+        .constructors = &.{},
+        .span = testSpan(),
+    };
+    try std.testing.expectEqual(DataShape.Empty, classify(decl));
+}

--- a/src/deriving/show.zig
+++ b/src/deriving/show.zig
@@ -1,0 +1,104 @@
+//! Synthesise a `Show` instance.
+//!
+//! Uses `show = \x -> case x of ...` so that the method body is a single
+//! binding to a lambda — this avoids the desugarer/typechecker issue with
+//! multi-equation instance methods AND the dict-resolution bug that
+//! affects top-level helpers mutually recursive with the instance.
+
+const std = @import("std");
+const ast = @import("../frontend/ast.zig");
+const span_mod = @import("../diagnostics/span.zig");
+
+const builder = @import("builder.zig");
+const shape_mod = @import("shape.zig");
+
+const SourceSpan = span_mod.SourceSpan;
+const Allocator = std.mem.Allocator;
+const NormalizedDecl = shape_mod.NormalizedDecl;
+
+pub const Synthesised = struct {
+    helpers: []const ast.Decl,
+    instance: ast.InstanceDecl,
+};
+
+pub fn synth(
+    arena: Allocator,
+    decl: NormalizedDecl,
+    span: SourceSpan,
+) Allocator.Error!Synthesised {
+    var alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
+
+    for (decl.constructors) |c| {
+        const arity = c.fields.len;
+        if (arity == 0) {
+            const pat = try builder.mkConPat(arena, c.name, &.{}, span);
+            try alts.append(arena, builder.mkAlt(
+                pat,
+                builder.mkStrLit(c.name, span),
+                span,
+            ));
+            continue;
+        }
+
+        const pats = try arena.alloc(ast.Pattern, arity);
+        var parts: std.ArrayListUnmanaged(ast.Expr) = .empty;
+        // Emit a single combined string prefix `"ConName "` (with trailing
+        // space) then alternating `show xN` and `" "` separators — matches
+        // how a user would write the body by hand.
+        const prefix = try std.fmt.allocPrint(arena, "{s} ", .{c.name});
+        try parts.append(arena, builder.mkStrLit(prefix, span));
+        for (0..arity) |i| {
+            const xn = try std.fmt.allocPrint(arena, "x{d}", .{i});
+            pats[i] = builder.mkVarPat(xn, span);
+            if (i > 0) try parts.append(arena, builder.mkStrLit(" ", span));
+            const show_call = try builder.mkApp(
+                arena,
+                builder.mkVar("show", span),
+                &.{builder.mkVar(xn, span)},
+            );
+            try parts.append(arena, show_call);
+        }
+        const con_pat = try builder.mkConPat(arena, c.name, pats, span);
+        const body = try builder.mkAppendChain(arena, parts.items, span);
+        try alts.append(arena, builder.mkAlt(con_pat, body, span));
+    }
+
+    // `show x = case x of ...` — match the same shape Prelude's hand-written
+    // Show instances use.  `show = \x -> case x of ...` (single-binding to
+    // a Lambda) is treated differently by the typechecker and resolves
+    // inner `show` references through the outer instance's dictionary.
+    const body: ast.Expr = if (decl.constructors.len == 0)
+        try builder.mkApp(
+            arena,
+            builder.mkVar("error", span),
+            &.{builder.mkStrLit("Show.show: empty type", span)},
+        )
+    else
+        try builder.mkCase(
+            arena,
+            builder.mkVar("x", span),
+            alts.items,
+        );
+
+    const method_match = try builder.mkMatch(
+        arena,
+        &.{builder.mkVarPat("x", span)},
+        body,
+        span,
+    );
+    const fb = try builder.mkFunBind(arena, "show", &.{method_match}, span);
+
+    var seen: std.StringArrayHashMapUnmanaged(void) = .empty;
+    try builder.collectTypeVars(arena, decl.constructors, &seen);
+    var pairs: std.ArrayListUnmanaged(builder.ClassVarPair) = .empty;
+    for (seen.keys()) |tv| {
+        try pairs.append(arena, .{ .class_name = "Show", .tyvar = tv });
+    }
+    const ctx = try builder.mkContext(arena, pairs.items);
+
+    const applied = try builder.mkAppliedTypeCon(arena, decl.name, decl.tyvars, span);
+    const head = try builder.mkInstanceHead(arena, "Show", applied, span);
+    const instance = try builder.mkInstance(arena, ctx, head, &.{fb}, span);
+
+    return .{ .helpers = &.{}, .instance = instance };
+}

--- a/src/diagnostics/diagnostic.zig
+++ b/src/diagnostics/diagnostic.zig
@@ -46,6 +46,9 @@ pub const DiagnosticCode = enum {
     import_cycle,
     unknown_primop,
     module_not_found,
+    deriving_unsupported_class,
+    deriving_shape_mismatch,
+    deriving_empty_bounded,
 
     /// Returns a stable string code like "E001" for programmatic use.
     pub fn code(self: DiagnosticCode) []const u8 {
@@ -61,6 +64,9 @@ pub const DiagnosticCode = enum {
             .import_cycle => "E009",
             .unknown_primop => "E010",
             .module_not_found => "E011",
+            .deriving_unsupported_class => "E012",
+            .deriving_shape_mismatch => "E013",
+            .deriving_empty_bounded => "E014",
         };
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -51,6 +51,7 @@ const TerminalRenderer = rusholme.diagnostics.terminal.TerminalRenderer;
 const DiagnosticCollector = rusholme.diagnostics.diagnostic.DiagnosticCollector;
 const FileId = rusholme.FileId;
 const renamer_mod = rusholme.renamer.renamer;
+const deriving_mod = rusholme.deriving.deriving;
 const infer_mod = rusholme.tc.infer;
 const htype_mod = rusholme.tc.htype;
 
@@ -383,7 +384,7 @@ fn cmdCheck(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
         std.process.exit(1);
     };
 
-    const module = parser.parseModule() catch {
+    var module = parser.parseModule() catch {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
     };
@@ -417,6 +418,7 @@ fn cmdCheck(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
         prelude_result = loadPrelude(arena_alloc, io, &pipeline_check, &u_supply, &rename_env, &ty_env, &mv_supply, &diags) catch null;
     }
 
+    try deriving_mod.derive(arena_alloc, &module, &diags);
     const renamed = try renamer_mod.rename(module, &rename_env);
 
     if (diags.hasErrors()) {
@@ -491,7 +493,7 @@ fn cmdCore(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
     };
-    const module = parser.parseModule() catch {
+    var module = parser.parseModule() catch {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
     };
@@ -518,6 +520,7 @@ fn cmdCore(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
         prelude_result = loadPrelude(arena_alloc, io, &pipeline_core, &u_supply, &rename_env, &ty_env, &mv_supply, &diags) catch null;
     }
 
+    try deriving_mod.derive(arena_alloc, &module, &diags);
     const renamed = try renamer_mod.rename(module, &rename_env);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
@@ -591,7 +594,7 @@ fn cmdGrin(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
     };
-    const module = parser.parseModule() catch {
+    var module = parser.parseModule() catch {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
     };
@@ -619,6 +622,7 @@ fn cmdGrin(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
         prelude_result = loadPrelude(arena_alloc, io, &pipeline_grin, &u_supply, &rename_env, &ty_env, &mv_supply, &diags) catch null;
     }
 
+    try deriving_mod.derive(arena_alloc, &module, &diags);
     const renamed = try renamer_mod.rename(module, &rename_env);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
@@ -709,7 +713,7 @@ fn cmdLl(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
     };
-    const module = parser.parseModule() catch {
+    var module = parser.parseModule() catch {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
     };
@@ -737,6 +741,7 @@ fn cmdLl(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
         prelude_result = loadPrelude(arena_alloc, io, &pipeline_ll, &u_supply, &rename_env, &ty_env, &mv_supply, &diags) catch null;
     }
 
+    try deriving_mod.derive(arena_alloc, &module, &diags);
     const renamed = try renamer_mod.rename(module, &rename_env);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -57,6 +57,7 @@ const layout_mod = @import("../frontend/layout.zig");
 const parser_mod = @import("../frontend/parser.zig");
 const ast_mod = @import("../frontend/ast.zig");
 const renamer_mod = @import("../renamer/renamer.zig");
+const deriving_mod = @import("../deriving/deriving.zig");
 const htype_mod = @import("../typechecker/htype.zig");
 const env_mod = @import("../typechecker/env.zig");
 const infer_mod = @import("../typechecker/infer.zig");
@@ -434,11 +435,28 @@ pub const CompileEnv = struct {
         // Unless the module carries {-# LANGUAGE NoImplicitPrelude #-} or
         // already has an explicit `import Prelude`, prepend a synthetic
         // `import Prelude` to the import list.
-        const module = if (parsed.language_extensions.contains(.NoImplicitPrelude) or
+        var module = if (parsed.language_extensions.contains(.NoImplicitPrelude) or
             mentionsPrelude(parsed.imports))
             parsed
         else
             try injectImplicitPrelude(self.alloc, parsed);
+
+        // ── Deriving (issue #679) ────────────────────────────────────────
+        // Walk the parsed module, synthesise `InstanceDecl` nodes for every
+        // `deriving` clause, and append them to the declaration list before
+        // the renamer runs.
+        try deriving_mod.derive(self.alloc, &module, &self.diags);
+        if (self.diags.hasErrors()) return null;
+
+        if (std.c.getenv("RHC_DUMP_DERIVING") != null) {
+            const pretty_mod = @import("../frontend/pretty.zig");
+            var pp = pretty_mod.PrettyPrinter.init(self.alloc);
+            defer pp.deinit();
+            const s = pp.printModule(module) catch null;
+            if (s) |out| {
+                std.debug.print("--- after deriving ---\n{s}\n----------------------\n", .{out});
+            }
+        }
 
         // ── Rename ───────────────────────────────────────────────────────
         const no_implicit_prelude = parsed.language_extensions.contains(.NoImplicitPrelude);

--- a/src/repl/pipeline.zig
+++ b/src/repl/pipeline.zig
@@ -373,7 +373,30 @@ pub const Pipeline = struct {
         }
 
         // ── Lambda lift ────────────────────────────────────────────
-        const lift_result = lift_mod.lambdaLift(alloc, desugar_result.program, null, 0) catch {
+        // Thread the unique IDs of all previously-known bindings (Prelude
+        // and earlier REPL inputs) into the lifter as its external scope.
+        // Without this, references to top-level functions like `not` or
+        // `(==)` from within a lifted lambda body are mis-classified as
+        // free variables; the rewriter then synthesises Var nodes with
+        // `base = "fv"` for them, the GRIN translator's var_map locks in
+        // that synthetic base, and downstream lookups for the real
+        // symbol (e.g. `not_1035`) emit `fv_1035` — which the JIT cannot
+        // resolve.
+        var external_unique_list: std.ArrayListUnmanaged(u64) = .empty;
+        defer external_unique_list.deinit(alloc);
+        if (external_arities) |arities| {
+            var it = arities.iterator();
+            while (it.next()) |entry| {
+                try external_unique_list.append(alloc, entry.key_ptr.*);
+            }
+        }
+        if (external_dict_names) |dicts| {
+            var it = dicts.iterator();
+            while (it.next()) |entry| {
+                try external_unique_list.append(alloc, entry.value_ptr.*.unique.value);
+            }
+        }
+        const lift_result = lift_mod.lambdaLift(alloc, desugar_result.program, external_unique_list.items, 0) catch {
             module_types.deinit(alloc);
             return CompileError.OutOfMemory;
         };

--- a/src/repl/pipeline.zig
+++ b/src/repl/pipeline.zig
@@ -24,6 +24,7 @@ const parser_mod = @import("../frontend/parser.zig");
 const Parser = parser_mod.Parser;
 
 const renamer_mod = @import("../renamer/renamer.zig");
+const deriving_mod = @import("../deriving/deriving.zig");
 const RenameEnv = renamer_mod.RenameEnv;
 
 const diag_mod = @import("../diagnostics/diagnostic.zig");
@@ -324,8 +325,14 @@ pub const Pipeline = struct {
         var parser = Parser.init(alloc, &layout, diags) catch {
             return CompileError.ParserInitFailed;
         };
-        const module = parser.parseModule() catch {
+        var module = parser.parseModule() catch {
             return CompileError.CompilationFailed;
+        };
+        if (diags.hasErrors()) return CompileError.CompilationFailed;
+
+        // ── Deriving (issue #679) ──────────────────────────────────
+        deriving_mod.derive(alloc, &module, diags) catch {
+            return CompileError.OutOfMemory;
         };
         if (diags.hasErrors()) return CompileError.CompilationFailed;
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -30,6 +30,18 @@ pub const renamer = struct {
     pub const renamer = @import("renamer/renamer.zig");
 };
 
+// Deriving pass (runs between parser and renamer)
+pub const deriving = struct {
+    pub const deriving = @import("deriving/deriving.zig");
+    pub const shape = @import("deriving/shape.zig");
+    pub const builder = @import("deriving/builder.zig");
+    pub const eq = @import("deriving/eq.zig");
+    pub const ord = @import("deriving/ord.zig");
+    pub const show = @import("deriving/show.zig");
+    pub const bounded = @import("deriving/bounded.zig");
+    pub const enum_class = @import("deriving/enum_class.zig");
+};
+
 // Type checking
 pub const typechecker = @import("typechecker.zig");
 

--- a/tests/e2e/e2e_679_deriving_eq.hs
+++ b/tests/e2e/e2e_679_deriving_eq.hs
@@ -1,0 +1,9 @@
+module Main where
+
+data Color = Red | Green | Blue deriving Eq
+
+main :: IO ()
+main = do
+  print (Red == Red)
+  print (Red == Green)
+  print (Blue == Blue)

--- a/tests/e2e/e2e_679_deriving_eq.stdout
+++ b/tests/e2e/e2e_679_deriving_eq.stdout
@@ -1,0 +1,3 @@
+True
+False
+True

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -432,3 +432,7 @@ test "e2e: e2e_617_show_escape (#617)" {
 test "e2e: e2e_show_nonascii_char (#682)" {
     try testE2e(std.testing.allocator, "e2e_show_nonascii_char");
 }
+
+test "e2e: e2e_679_deriving_eq (#679)" {
+    try testE2e(std.testing.allocator, "e2e_679_deriving_eq");
+}


### PR DESCRIPTION
Closes #679

## Summary

Implements the `deriving` pass for the five Haskell 2010 stock typeclasses (`Eq`, `Ord`, `Show`, `Bounded`, `Enum`) plus standalone `DerivingDecl` support. The pass runs between parsing and renaming, so synthesised instances flow through the rest of the pipeline indistinguishably from user-written instances.

## Deliverables

- [x] `Eq` synthesizer — emits a top-level helper `derivedEq_<TypeName>` plus instance methods (helper workaround for #704)
- [x] `Ord` synthesizer — `compare` via nested case + lexicographic field comparison
- [x] `Show` synthesizer — `show` via single case + constructor-name + space-separated `show`d fields
- [x] `Bounded` synthesizer — `minBound`/`maxBound` as first/last constructor; reports diagnostic for empty types
- [x] `Enum` synthesizer — `fromEnum` via constructor index
- [x] Standalone `DerivingDecl` (`deriving instance Show T`) supported via the same code path
- [x] Wired into the REPL pipeline, `CompileEnv`, and the four `rhc` subcommands that re-implement the frontend
- [x] Three new diagnostic codes (E012-E014): unsupported class, shape mismatch, empty-type Bounded
- [x] e2e test `tests/e2e/e2e_679_deriving_eq.hs` exercising `deriving Eq` end-to-end
- [x] Design spec at `docs/superpowers/specs/2026-05-17-deriving-mechanism-design.md`

## Out of scope (filed as follow-ups)

- [#704](https://github.com/adinapoli/rusholme/issues/704) — desugarer bug: nested case-of in instance method body falls through to wildcard. Worked around in `Eq` synthesis by emitting a top-level helper.
- [#705](https://github.com/adinapoli/rusholme/issues/705) — newtype deriving via `coerce` (H2010 §11.2). Currently newtypes go through the stock synthesizer.
- [#706](https://github.com/adinapoli/rusholme/issues/706) — Prelude is missing `Ord`/`Bounded`/`Enum` classes and exports, so those derivations are not yet end-to-end testable.

## Testing

- `nix develop --command zig build test --summary all` — 1006/1006 tests pass, including the new `e2e_679_deriving_eq` (#679) test
- Manual: `data Color = Red | Green | Blue deriving Eq` → `Red == Red`, `Red == Green`, `Blue == Blue` print `True False True`
- `RHC_DUMP_DERIVING=1` env var dumps the post-deriving AST for inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
