### PR TITLE
#696: Hide internal --repl flag from rhc build --help output

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -218,12 +218,23 @@ pub fn main(init: std.process.Init) !void {
         },
 
         .build => {
+            // Internal flags (e.g. `--repl`) are accepted by the parser but
+            // omitted from `--help` output so they don't appear as user-facing
+            // options. See issue #696.
             const build_params = comptime clap.parseParamsComptime(
                 \\-h, --help                   Display this help and exit.
                 \\-o, --output <str>           Output file name (default: stem of first input).
                 \\    --backend <str>          Backend: native (default), jit, wasm, c.
                 \\    --package-db <str>...    Package database path (may be repeated).
                 \\    --repl                   Compile for REPL use (internal).
+                \\<str>...
+                \\
+            );
+            const build_params_help = comptime clap.parseParamsComptime(
+                \\-h, --help                   Display this help and exit.
+                \\-o, --output <str>           Output file name (default: stem of first input).
+                \\    --backend <str>          Backend: native (default), jit, wasm, c.
+                \\    --package-db <str>...    Package database path (may be repeated).
                 \\<str>...
                 \\
             );
@@ -240,7 +251,7 @@ pub fn main(init: std.process.Init) !void {
             if (build_res.args.help != 0) {
                 var buf: [4096]u8 = undefined;
                 var fw: File.Writer = .init(.stdout(), io, &buf);
-                try clap.help(&fw.interface, clap.Help, &build_params, .{});
+                try clap.help(&fw.interface, clap.Help, &build_params_help, .{});
                 try fw.interface.flush();
                 return;
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -230,6 +230,10 @@ pub fn main(init: std.process.Init) !void {
                 \\<str>...
                 \\
             );
+            // Keep in sync with `build_params` above: this slice MUST equal
+            // `build_params` minus internal-only flags. zig-clap v0.11.0 has
+            // no built-in hidden-parameter support, so we maintain two
+            // comptime slices.
             const build_params_help = comptime clap.parseParamsComptime(
                 \\-h, --help                   Display this help and exit.
                 \\-o, --output <str>           Output file name (default: stem of first input).


### PR DESCRIPTION
Closes #696

## Summary
Hide the internal `--repl` flag from `rhc build --help` output. The flag is still accepted by the argument parser (so the REPL build pipeline continues to work), but no longer surfaces in user-facing help.

## Implementation
zig-clap v0.11.0 has no built-in "hidden parameter" support, so two comptime parameter slices are maintained:
- `build_params` — full set, used for `clap.parseEx` (still accepts `--repl`).
- `build_params_help` — public subset minus internal-only flags, passed to `clap.help`.

A comment above `build_params_help` documents the maintenance contract (keep in sync; difference is internal-only flags).

## Testing
- `rhc build --help` no longer lists `--repl`.
- `rhc build --repl <file>` still parses (verified via `--help` short-circuit after `--repl`).
- `zig build test --summary all` passes.
