### PR TITLE
#711: Add RTS unit test for 0-field thunk update invariant

### DIFF
--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -1808,7 +1808,10 @@ pub const GrinTranslator = struct {
                 //   - translateCaseToValue: unconditional Ind update (line ~2411)
                 //   - emitInlineEval (__rhc_force): unconditional Ind update
                 //   - translateUpdate: unconditional field[0] write
+                // Unit-tested by `rts/node.zig` test
+                // "0-field F-tag thunk: padded slot supports Ind update".
                 // See: https://github.com/adinapoli/rusholme/issues/605
+                // and: https://github.com/adinapoli/rusholme/issues/711
                 if (tag.tag_type == .Fun and n_fields == 0) {
                     n_fields = 1;
                 }

--- a/src/rts/node.zig
+++ b/src/rts/node.zig
@@ -409,3 +409,37 @@ test "rts_load_field reads stored values" {
     try std.testing.expectEqual(@as(u64, 0xDEAD), rts_load_field(n, 0));
     try std.testing.expectEqual(@as(u64, 0xBEEF), rts_load_field(n, 1));
 }
+
+test "0-field F-tag thunk: padded slot supports Ind update" {
+    // Documents the invariant from issue #605 / PR #710: every F-tag thunk
+    // is allocated with at least one field so the eval loop can write an
+    // indirection update (tag := Ind, field[0] := result *Node) after
+    // forcing. This is what makes call-by-need correct for nullary thunks.
+    //
+    // See: backend/grin_to_llvm.zig `translateStoreToValue` (≥1 field
+    // padding for F-tag thunks).
+    heap.init();
+    defer heap.deinit();
+
+    // Allocate a thunk for a nullary GRIN function. The F-tag discriminant
+    // is chosen by the backend at compile time; any value outside the
+    // built-in range works here. The 1-field padding is the load-bearing
+    // part.
+    const f_tag: u64 = 0x2000;
+    const thunk = rts_alloc(f_tag, 1);
+    try std.testing.expectEqual(@as(u32, 1), thunk.n_fields);
+
+    // The padded slot is zero-initialised by rts_alloc.
+    try std.testing.expectEqual(@as(u64, 0), rts_load_field(thunk, 0));
+
+    // Simulate forcing: allocate the WHNF result, then overwrite the
+    // thunk's header (tag → Ind) and field[0] (→ result *Node).
+    const result = createInt(123);
+    thunk.tag = .Ind;
+    rts_store_field(thunk, 0, @intFromPtr(result));
+
+    // The post-update node behaves as a proper indirection.
+    try std.testing.expectEqual(Tag.Ind, thunk.tag);
+    try std.testing.expectEqual(result, indTarget(thunk));
+    try std.testing.expectEqual(@as(i64, 123), intValue(indTarget(thunk)));
+}

--- a/src/rts/node.zig
+++ b/src/rts/node.zig
@@ -438,8 +438,10 @@ test "0-field F-tag thunk: padded slot supports Ind update" {
     thunk.tag = .Ind;
     rts_store_field(thunk, 0, @intFromPtr(result));
 
-    // The post-update node behaves as a proper indirection.
+    // The post-update node behaves as a proper indirection. n_fields is
+    // unchanged — the padded slot is the load-bearing reuse target.
     try std.testing.expectEqual(Tag.Ind, thunk.tag);
+    try std.testing.expectEqual(@as(u32, 1), thunk.n_fields);
     try std.testing.expectEqual(result, indTarget(thunk));
     try std.testing.expectEqual(@as(i64, 123), intValue(indTarget(thunk)));
 }


### PR DESCRIPTION
Closes #711

## Summary
Add a focused Zig unit test for the 1-field padding invariant on nullary F-tag thunks (introduced in PR #710 for #605). Until now this property was only covered end-to-end by `e2e_605_zero_field_thunk`; this PR pins it down at the RTS layer where a regression would actually appear first.

## Deliverables
- [x] Unit test in `src/rts/node.zig`:
  - allocates a thunk with `rts_alloc(<F-tag>, 1)`
  - asserts `rts_store_field(node, 0, value)` succeeds
  - asserts `rts_load_field(node, 0)` round-trips
  - simulates `update` (tag → `Ind`, field[0] → result `*Node`), asserts `Tag.Ind`, `n_fields == 1`, and that `indTarget` chases through to the WHNF payload.
- [x] Comment near `translateStoreToValue` (`src/backend/grin_to_llvm.zig`) names the new test and links #711.

## Testing
- `nix develop --command zig build test --summary all`: `1009/1009 tests passed`.
