### PR TITLE
#699: Attach import declaration span to module_not_found diagnostic

### DIFF
--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -698,6 +698,13 @@ pub fn compileProgram(
     var graph = ModuleGraph.init(alloc);
     defer graph.deinit();
 
+    // Record the source span of the first `import` declaration that names
+    // each imported module. Used in Phase 3 to attach a non-trivial span to
+    // `module_not_found` diagnostics so the terminal renderer can highlight
+    // the offending `import` line instead of pointing nowhere (#699).
+    var import_spans: std.StringHashMapUnmanaged(span_mod.SourceSpan) = .{};
+    defer import_spans.deinit(alloc);
+
     var iter = env.parsed_modules.iterator();
     while (iter.next()) |entry| {
         const mod_name = entry.key_ptr.*;
@@ -705,6 +712,10 @@ pub fn compileProgram(
         _ = try graph.addModule(mod_name);
         for (parsed.imports) |imp| {
             try graph.addEdge(mod_name, imp.module_name);
+            // Only record the first span we see for a given imported name;
+            // it's the one we point at when the import can't be resolved.
+            const gop = try import_spans.getOrPut(alloc, imp.module_name);
+            if (!gop.found_existing) gop.value_ptr.* = imp.span;
         }
     }
 
@@ -768,18 +779,18 @@ pub fn compileProgram(
                     "Could not find module '{s}' in source or any --package-db path",
                     .{mod_name},
                 );
-                // The span points to the invalid position because the topo loop
-                // works on module names, not import declarations. Attaching the
-                // real import span is tracked in:
-                // https://github.com/adinapoli/rusholme/issues/699
-                const zero_span = span_mod.SourceSpan.init(
+                // Point at the first `import <mod_name>` declaration we
+                // recorded during graph build. If — somehow — no source
+                // module imports this name (the topo sort dragged it in by
+                // another route), fall back to invalid positions.
+                const diag_span = import_spans.get(mod_name) orelse span_mod.SourceSpan.init(
                     span_mod.SourcePos.invalid(),
                     span_mod.SourcePos.invalid(),
                 );
                 try env.diags.emit(alloc, .{
                     .severity = .@"error",
                     .code = .module_not_found,
-                    .span = zero_span,
+                    .span = diag_span,
                     .message = msg,
                 });
             }
@@ -1959,6 +1970,14 @@ test "compileProgram: missing import emits module_not_found diagnostic" {
                 "Could not find module 'MissingLib' in source or any --package-db path",
                 d.message,
             );
+            // #699: the span must point at the actual `import` declaration,
+            // not the invalid sentinel position.
+            try testing.expect(d.span.start.isValid());
+            try testing.expect(d.span.end.isValid());
+            try testing.expectEqual(@as(u32, 1), d.span.start.file_id);
+            // The `import MissingLib` line is the second line of the source
+            // above (after `module App where`).
+            try testing.expectEqual(@as(u32, 2), d.span.start.line);
             found = true;
         }
     }

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -1976,8 +1976,10 @@ test "compileProgram: missing import emits module_not_found diagnostic" {
             try testing.expect(d.span.end.isValid());
             try testing.expectEqual(@as(u32, 1), d.span.start.file_id);
             // The `import MissingLib` line is the second line of the source
-            // above (after `module App where`).
+            // above (after `module App where`); the `import` keyword starts
+            // at column 1.
             try testing.expectEqual(@as(u32, 2), d.span.start.line);
+            try testing.expectEqual(@as(u32, 1), d.span.start.column);
             found = true;
         }
     }


### PR DESCRIPTION
Closes #699

## Summary
`module_not_found` diagnostics now carry the `SourceSpan` of the offending `import <X>` declaration, so the terminal renderer can highlight the actual import line instead of pointing nowhere — matching GHC's behaviour.

## Implementation
- During Phase 2 graph build in `compileProgram`, build a `StringHashMapUnmanaged(SourceSpan)` keyed by imported module name, recording the *first* `import` span we see per name.
- In Phase 3, when a module name resolves neither in source nor in any `--package-db`, look up that span and attach it to the diagnostic. A trivial-span fallback is kept defensively (unreachable in practice — every name the topo loop sees was added to the graph via some `import` declaration).
- The first-span policy is intentional: `module_not_found` is one-per-missing-name, not one-per-import-site. If we later want per-site reporting, the right shape is emitting per-edge during graph walk.

## Test changes
The `compileProgram: missing import emits module_not_found diagnostic` test now also asserts the diagnostic's span is valid, lives in the right `file_id`, points at line 2 (where `import MissingLib` lives), and starts at column 1.

## Testing
- `nix develop --command zig build test --summary all`: `1008/1008 tests passed`.
