### PR TITLE
#512: Remove unused LambdaInfo.expr field

### DIFF
--- a/src/core/lift.zig
+++ b/src/core/lift.zig
@@ -43,8 +43,6 @@ const SourceSpan = core.SourceSpan;
 const LambdaInfo = struct {
     /// Unique ID for tracking this lambda during collection.
     id: u64,
-    /// Pointer to the original lambda expression (for identification).
-    expr: *const Expr,
     /// Body of the lambda (needed for reconstruction during lifting).
     body: *const Expr,
     /// Free variables of this lambda (by unique ID).
@@ -200,7 +198,6 @@ pub const LambdaLifter = struct {
 
         const info = LambdaInfo{
             .id = lambda_id,
-            .expr = body,
             .body = body,
             .free_vars = free_vars,
             .params = params,


### PR DESCRIPTION
Closes #512

## Summary
Remove the unused `LambdaInfo.expr` field in the lambda lifter.

The field's doc-comment claimed it pointed at "the original lambda expression," but the value written at the single construction site (`completeLambda`) was always the lambda's *body*, identical to `body` — and no code ever read it. Net effect: a confusing, dead field. Dropping it removes the contradiction and keeps `body` as the single source of truth.

## Testing
- `nix develop --command zig build test --summary all`: `1008/1008 tests passed`.
