### PR TITLE
#534: Accept backend-only primop names in foreign import prim validation

### DIFF
--- a/src/core/desugar.zig
+++ b/src/core/desugar.zig
@@ -380,10 +380,15 @@ pub fn desugarModule(
             },
             .ForeignPrim => |fp| {
                 // Validate the PrimOp name at compile time.
-                // Accept both raw PrimOp enum names (e.g. "add_Int") and
-                // Prelude-level names (e.g. "putStrLn" → putStrLn_).
+                // Accept:
+                //   1. raw PrimOp enum names (e.g. "add_Int") via fromString
+                //   2. Prelude-level aliases (e.g. "putStrLn" → putStrLn_)
+                //   3. backend-only names recognised directly by the LLVM
+                //      backend's `PrimOpMapping` but with no PrimOp enum
+                //      variant (e.g. ">>=", "div#"). See #534.
                 const is_known = primop_mod.PrimOp.fromString(fp.primop_name) != null or
-                    primop_mod.PrimOp.fromPreludeName(fp.primop_name) != null;
+                    primop_mod.PrimOp.fromPreludeName(fp.primop_name) != null or
+                    primop_mod.PrimOp.isBackendOnlyName(fp.primop_name);
                 if (!is_known) {
                     const msg = try std.fmt.allocPrint(
                         alloc,
@@ -417,7 +422,10 @@ pub fn desugarModule(
                 else if (primop_mod.PrimOp.fromPreludeName(fp.primop_name)) |op|
                     op.name()
                 else
-                    fp.primop_name; // validated above — shouldn't reach here
+                    // Backend-only names (#534): pass through unchanged so
+                    // the LLVM backend's `PrimOpMapping` can intercept them
+                    // via string equality. Validated above.
+                    fp.primop_name;
 
                 const primop_name = Name{
                     .base = canonical_base,

--- a/src/grin/primop.zig
+++ b/src/grin/primop.zig
@@ -357,6 +357,27 @@ pub const PrimOp = enum(u16) {
         if (std.mem.eql(u8, str, "print")) return .write_stdout;
         return null;
     }
+
+    /// Backend-only primop names that the LLVM `PrimOpMapping` recognises
+    /// directly via string equality but that have no corresponding
+    /// `PrimOp` enum variant. The desugarer must accept these in
+    /// `foreign import prim` declarations and pass the name through
+    /// unchanged so the backend can intercept it.
+    ///
+    /// Currently:
+    ///   - `>>`, `>>=`   — monad-bind sequencing (#464)
+    ///   - `div#`, `mod#`, `quot#`, `rem#` — hash-suffixed integer aliases
+    ///
+    /// See `src/backend/grin_to_llvm.zig` `PrimOpMapping.lookup` for the
+    /// canonical list. Keep these two locations in sync.  Tracked by #534.
+    pub fn isBackendOnlyName(str: []const u8) bool {
+        return std.mem.eql(u8, str, ">>") or
+            std.mem.eql(u8, str, ">>=") or
+            std.mem.eql(u8, str, "div#") or
+            std.mem.eql(u8, str, "mod#") or
+            std.mem.eql(u8, str, "quot#") or
+            std.mem.eql(u8, str, "rem#");
+    }
 };
 
 /// Categories of PrimOps for documentation and organization.
@@ -422,6 +443,25 @@ test "PrimOp: fromString" {
     try testing.expectEqual(PrimOp.add_Int, PrimOp.fromString("add_Int"));
     try testing.expectEqual(PrimOp.@"error", PrimOp.fromString("error"));
     try testing.expectEqual(@as(?PrimOp, null), PrimOp.fromString("nonexistent"));
+}
+
+test "PrimOp: isBackendOnlyName recognises backend-only aliases (#534)" {
+    // Names the LLVM PrimOpMapping handles directly but that have no
+    // PrimOp enum variant. The desugarer must let these through so users
+    // can write e.g. `foreign import prim ">>="`.
+    try testing.expect(PrimOp.isBackendOnlyName(">>"));
+    try testing.expect(PrimOp.isBackendOnlyName(">>="));
+    try testing.expect(PrimOp.isBackendOnlyName("div#"));
+    try testing.expect(PrimOp.isBackendOnlyName("mod#"));
+    try testing.expect(PrimOp.isBackendOnlyName("quot#"));
+    try testing.expect(PrimOp.isBackendOnlyName("rem#"));
+
+    // Names with a real enum variant are NOT considered backend-only;
+    // they go through fromString/fromPreludeName.
+    try testing.expect(!PrimOp.isBackendOnlyName("add_Int"));
+    try testing.expect(!PrimOp.isBackendOnlyName("error"));
+    try testing.expect(!PrimOp.isBackendOnlyName("putStrLn"));
+    try testing.expect(!PrimOp.isBackendOnlyName("nonexistent"));
 }
 
 test "PrimOpRegistry: stable names" {


### PR DESCRIPTION
Closes #534

## Summary
The desugarer rejected `foreign import prim` declarations whose name has no `PrimOp` enum variant — even names that the LLVM backend's `PrimOpMapping` recognises directly (`>>`, `>>=`, `div#`, `mod#`, `quot#`, `rem#`). Result: a user writing `foreign import prim "error" myError :: String -> a` works (because `error` *is* a PrimOp enum variant), but `foreign import prim "div#" hash_div :: Int -> Int -> Int` would fail with a spurious `unknown_primop` diagnostic.

## Implementation
- Add `PrimOp.isBackendOnlyName(str)` listing the names the LLVM backend handles via string equality with no enum variant. Comment cross-references `src/backend/grin_to_llvm.zig::PrimOpMapping.lookup` so the two stay in sync.
- Extend `desugarProgram`'s `ForeignPrim` validation to accept names matched by any of: `fromString`, `fromPreludeName`, `isBackendOnlyName`.
- The canonical-name fallthrough already preserved the original name unchanged, so the LLVM backend's string-equality match works without further changes; updated its comment to note that backend-only names land there intentionally.

## Tests
`PrimOp: isBackendOnlyName recognises backend-only aliases (#534)` covers each of the six accepted names plus negative cases (`add_Int`, `error`, `putStrLn`, `nonexistent`).

## Testing
- `nix develop --command zig build test --summary all`: `1009/1009 tests passed`.
