### PR TITLE
#535: Wire compile-fail test runner into the build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -468,6 +468,21 @@ pub fn build(b: *std.Build) void {
     });
     const run_parser_tests = b.addRunArtifact(parser_tests);
 
+    // Compile-failure test runner (should_fail_compile/) — covers
+    // post-parser diagnostics (renamer, typechecker, desugarer). The
+    // parser-only should_fail/should_compile tests are handled above.
+    // See issue #535.
+    const compile_fail_test_module = b.createModule(.{
+        .root_source_file = b.path("tests/compile_fail_test_runner.zig"),
+        .target = target,
+        .imports = &.{.{ .name = "rusholme", .module = mod }},
+    });
+    const compile_fail_tests = b.addTest(.{
+        .name = "compile-fail-tests",
+        .root_module = compile_fail_test_module,
+    });
+    const run_compile_fail_tests = b.addRunArtifact(compile_fail_tests);
+
     // Runtime test runner - tests LLVM-based runtime (src/rts/)
     const runtime_test_module = b.createModule(.{
         .root_source_file = b.path("tests/runtime_test_runner.zig"),
@@ -587,6 +602,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_exe_tests.step);
     test_step.dependOn(&run_golden_tests.step);
     test_step.dependOn(&run_parser_tests.step);
+    test_step.dependOn(&run_compile_fail_tests.step);
     test_step.dependOn(&run_runtime_tests.step);
     test_step.dependOn(&run_e2e_tests.step);
     test_step.dependOn(&run_repl_tests.step);

--- a/tests/compile_fail_test_runner.zig
+++ b/tests/compile_fail_test_runner.zig
@@ -67,7 +67,8 @@ fn readProperties(
             const rest = trimmed["expected_code:".len..];
             const code = std.mem.trim(u8, rest, " \t");
             if (code.len > 0) {
-                props.expected_code = code;
+                // Dupe out of `content` so the slice survives the free.
+                props.expected_code = try allocator.dupe(u8, code);
             }
         }
     }
@@ -159,7 +160,7 @@ fn collectCodes(
     arena_alloc: std.mem.Allocator,
 ) !CompileResult {
     const all = try diags.getAll(arena_alloc);
-    var codes = std.ArrayListUnmanaged(DiagnosticCode){};
+    var codes: std.ArrayListUnmanaged(DiagnosticCode) = .empty;
     defer codes.deinit(allocator);
     for (all) |d| {
         if (d.severity == .@"error") {
@@ -181,6 +182,7 @@ fn testShouldFailCompile(
     comptime basename: []const u8,
 ) !void {
     const props = try readProperties(allocator, basename);
+    defer if (props.expected_code) |c| allocator.free(c);
     if (props.skip) return;
 
     const result = try tryCompile(allocator, test_dir ++ "/" ++ basename ++ ".hs");

--- a/tests/should_fail_compile/sfc001_unknown_primop.hs
+++ b/tests/should_fail_compile/sfc001_unknown_primop.hs
@@ -4,7 +4,7 @@ module Sfc001UnknownPrimop where
 -- This should fail during desugaring because "bogus_primop" is not
 -- a recognised primitive operation.
 
-foreign import prim "bogus_primop" primBogus :: Int -> Int
+foreign import prim "bogus_primop" primBogus :: Int -> IO ()
 
 main :: IO ()
 main = primBogus 42


### PR DESCRIPTION
Closes #535

## Summary
`tests/compile_fail_test_runner.zig` and two `.hs/.properties` fixtures had already landed on `main` but were never wired into `build.zig`'s top-level `test` step — so the should_fail_compile category was effectively dead code. This PR adds the wiring and clears three small bugs the runner had been silently hiding.

## Fixes
1. **Build wiring (`build.zig`)** — new `compile-fail-tests` step depending on the existing `compile_fail_test_runner.zig`, added to the top-level `test` step alongside the parser/runtime/e2e runners.

2. **`var codes = std.ArrayListUnmanaged(DiagnosticCode){};`** — no longer compiles under the project's Zig version (missing-field error). Switch to the canonical `: ... = .empty` form used everywhere else in the codebase.

3. **`Properties.expected_code` use-after-free** — the field was a slice into a buffer freed at the end of `readProperties`, so the first `std.mem.eql` deref in the test runner segfaulted. Dupe the string before returning; free it in `testShouldFailCompile`.

4. **`sfc001_unknown_primop.hs` type error masked the target diagnostic** — the fixture declared `primBogus :: Int -> Int` and called it from `main :: IO ()`, hitting `E002` (type_error) before the desugarer could fire `E010` (unknown_primop). Changed the declared type to `Int -> IO ()` so the program type-checks and the desugar pass actually runs.

## Testing
- `nix develop --command zig build test --summary all`:
  - Before: `45/45 steps; 1008/1008 tests passed`.
  - After:  `47/47 steps; 1010/1010 tests passed` (+ `compile-fail-tests: 2 pass`).

## Notes
The earlier worktree `llm-agent/issue-535` (`agent-a426c42d`) carried an in-progress draft of the same work; this PR is the smallest path from the runner+fixtures already on `main` to a working green test step.
