### PR TITLE
#453: Use declared module name for per-module .bc artifacts

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1104,7 +1104,6 @@ fn emitNative(
     all_grin: rusholme.grin.ast.Program,
     output_name: []const u8,
 ) !void {
-    _ = session; // Unused for native backend
     const llvm = rusholme.backend.llvm;
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
@@ -1144,7 +1143,15 @@ fn emitNative(
             std.process.exit(1);
         };
 
-        const bc_path = try std.fmt.allocPrint(arena_alloc, "{s}.bc", .{mod_name});
+        // Prefer the source-declared module name (`module Foo where`) for
+        // the on-disk `.bc` stem so that files given as absolute paths
+        // (e.g. `/tmp/Foo.hs`) produce `Foo.bc` rather than the
+        // path-mangled `.tmp.Foo.bc` `inferModuleName` would yield (#453).
+        const bc_stem: []const u8 = if (session.parsed_modules.get(mod_name)) |parsed|
+            parsed.module_name
+        else
+            mod_name;
+        const bc_path = try std.fmt.allocPrint(arena_alloc, "{s}.bc", .{bc_stem});
         llvm.writeBitcodeToFile(llvm_mod, bc_path) catch |err| {
             var stderr_buf: [4096]u8 = undefined;
             var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);


### PR DESCRIPTION
Partially addresses #453

## Summary
For source files given as absolute paths (e.g. `/tmp/Foo.hs`), `inferModuleName` produces a path-mangled string like `.tmp.Foo`, which `emitNative` was using verbatim as the on-disk `.bc` stem — yielding `.tmp.Foo.bc` instead of `Foo.bc`.

Use the declared `module Foo where` name (already in `session.parsed_modules`) when computing the `.bc` filename, falling back to the existing key when the parsed module isn't in the map. The map key itself is unchanged so the parse cache and the topological sort continue to work unmodified.

## Scope
Only deliverable **(1)** of the issue is addressed here. The two follow-ons:
- **(2)** Writing `.bc` artifacts to a per-build cache directory rather than CWD, and
- **(3)** Cleanup on partial failure,

overlap with the recompilation work already tracked by #371 / #456 and remain out of scope for this PR. Keeping them with #453 risks duplicating that direction.

## Verification
`rhc build /home/alfredo/programming/zig/rusholme/tmp/Foo453.hs -o foo453_out` (where the source declares `module Foo453 where`) now emits `Foo453.bc` plus the existing `Prelude.bc`, instead of the previous path-mangled stem.

## Testing
- `nix develop --command zig build test --summary all`: `1013/1013 tests passed`.
