### PR TITLE
#496: TyEnv deep-frees HType allocations (arena-per-TyEnv)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -421,7 +421,7 @@ fn cmdCheck(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     // during renaming.
     var mv_supply = htype_mod.MetaVarSupply{};
     var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
-    try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply, no_implicit_prelude);
+    try rusholme.tc.env.initBuiltins(&ty_env, &u_supply, no_implicit_prelude);
 
     // Respect the NoImplicitPrelude language extension: only load Prelude
     // when the user has NOT enabled NoImplicitPrelude.
@@ -525,7 +525,7 @@ fn cmdCore(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     // ── Load Prelude before user rename ───────────────────────────────
     var mv_supply = htype_mod.MetaVarSupply{};
     var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
-    try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply, no_implicit_prelude);
+    try rusholme.tc.env.initBuiltins(&ty_env, &u_supply, no_implicit_prelude);
 
     // Respect the NoImplicitPrelude language extension: only load Prelude
     // when the user has NOT enabled NoImplicitPrelude.
@@ -627,7 +627,7 @@ fn cmdGrin(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     // ── Load Prelude before user rename ───────────────────────────────
     var mv_supply = htype_mod.MetaVarSupply{};
     var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
-    try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply, no_implicit_prelude);
+    try rusholme.tc.env.initBuiltins(&ty_env, &u_supply, no_implicit_prelude);
 
     // Respect the NoImplicitPrelude language extension: only load Prelude
     // when the user has NOT enabled NoImplicitPrelude.
@@ -746,7 +746,7 @@ fn cmdLl(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     // ── Load Prelude before user rename ───────────────────────────────
     var mv_supply = htype_mod.MetaVarSupply{};
     var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
-    try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply, no_implicit_prelude);
+    try rusholme.tc.env.initBuiltins(&ty_env, &u_supply, no_implicit_prelude);
 
     // Respect the NoImplicitPrelude language extension: only load Prelude
     // when the user has NOT enabled NoImplicitPrelude.

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -484,7 +484,7 @@ pub const CompileEnv = struct {
 
         // ── Typecheck ────────────────────────────────────────────────────
         var ty_env = try env_mod.TyEnv.init(self.alloc);
-        try env_mod.initBuiltins(&ty_env, self.alloc, &self.u_supply, no_implicit_prelude);
+        try env_mod.initBuiltins(&ty_env, &self.u_supply, no_implicit_prelude);
         // Seed with types from imported modules only.
         try self.seedTyEnvFromImports(&ty_env, module.imports);
 

--- a/src/repl/cli.zig
+++ b/src/repl/cli.zig
@@ -73,9 +73,10 @@ pub fn runServer(allocator: Allocator, io: Io) !void {
 /// inline hints, syntax highlighting, and persistent history.
 /// Falls back to `runSimple` when not on a TTY or replxx fails to init.
 pub fn run(allocator: Allocator, io: Io) !void {
-    // Use an arena allocator for the session lifetime. The typechecker's
-    // initBuiltins allocates type structures that outlive the session's
-    // deinit — an arena ensures bulk cleanup on exit.
+    // Use an arena allocator for the session lifetime. The TyEnv now owns its
+    // own type arena and frees its built-in HType trees on deinit (#496), but
+    // other Session-wide state still leaks under a checked allocator (tracked
+    // separately) — an arena ensures bulk cleanup on exit regardless.
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const alloc = arena.allocator();

--- a/src/repl/pipeline.zig
+++ b/src/repl/pipeline.zig
@@ -645,7 +645,7 @@ test "pipeline: compile simple literal expression" {
     var rename_env = try RenameEnv.init(alloc, &u_supply, &diags, false);
     defer rename_env.deinit();
     var ty_env = try env_mod.TyEnv.init(alloc);
-    try env_mod.initBuiltins(&ty_env, alloc, &u_supply, false);
+    try env_mod.initBuiltins(&ty_env, &u_supply, false);
     var mv_supply = htype_mod.MetaVarSupply{};
 
     const result = try pipeline.compileInput(
@@ -681,7 +681,7 @@ test "pipeline: compile data declaration" {
     var rename_env = try RenameEnv.init(alloc, &u_supply, &diags, false);
     defer rename_env.deinit();
     var ty_env = try env_mod.TyEnv.init(alloc);
-    try env_mod.initBuiltins(&ty_env, alloc, &u_supply, false);
+    try env_mod.initBuiltins(&ty_env, &u_supply, false);
     var mv_supply = htype_mod.MetaVarSupply{};
 
     const result = try pipeline.compileInput(
@@ -717,7 +717,7 @@ test "pipeline: compile function declaration" {
     var rename_env = try RenameEnv.init(alloc, &u_supply, &diags, false);
     defer rename_env.deinit();
     var ty_env = try env_mod.TyEnv.init(alloc);
-    try env_mod.initBuiltins(&ty_env, alloc, &u_supply, false);
+    try env_mod.initBuiltins(&ty_env, &u_supply, false);
     var mv_supply = htype_mod.MetaVarSupply{};
 
     // Use a simple function that doesn't require typeclasses
@@ -839,7 +839,7 @@ test "pipeline: handle let prefix in declarations" {
     var rename_env = try RenameEnv.init(alloc, &u_supply, &diags, false);
     defer rename_env.deinit();
     var ty_env = try env_mod.TyEnv.init(alloc);
-    try env_mod.initBuiltins(&ty_env, alloc, &u_supply, false);
+    try env_mod.initBuiltins(&ty_env, &u_supply, false);
     var mv_supply = htype_mod.MetaVarSupply{};
 
     // The "let " prefix should be stripped for module-level declarations

--- a/src/repl/session.zig
+++ b/src/repl/session.zig
@@ -189,7 +189,7 @@ pub const Session = struct {
         };
         errdefer ty_env.deinit();
 
-        env_mod.initBuiltins(&ty_env, allocator, &u_supply, false) catch {
+        env_mod.initBuiltins(&ty_env, &u_supply, false) catch {
             return SessionError.OutOfMemory;
         };
 

--- a/src/typechecker/env.zig
+++ b/src/typechecker/env.zig
@@ -36,10 +36,24 @@
 //!
 //! ## Memory
 //!
-//! `TyEnv` does not own the `HType` values stored in schemes — they must be
-//! allocated on the typechecker's arena, which outlives any individual env
-//! frame.  The env itself (frame nodes and hash maps) is allocated on the
-//! provided allocator, which should also be the typechecker's arena.
+//! `TyEnv` owns a private `std.heap.ArenaAllocator` (the *type arena*) that
+//! backs every `HType` tree the env itself allocates — notably the built-in
+//! schemes created by `initBuiltins`.  `deinit` tears the arena down in one
+//! shot, so there is never any per-node ownership tracking or recursive
+//! free of `*const HType` pointers (those pointers may be shared, stack-, or
+//! caller-arena-allocated, which is precisely what made an earlier recursive
+//! `freeHTypeWithTracking` attempt crash with use-after-free; see #496).
+//!
+//! Code that mints `HType` nodes destined to be stored in this env (e.g. the
+//! built-in initialiser) must allocate them on `typeAllocator()`.  The frame
+//! nodes and hash maps themselves are allocated on the *backing* allocator
+//! passed to `init`.
+//!
+//! The typechecker may also `bind` schemes whose bodies it allocated on its
+//! own pass arena (not the env's type arena).  Those are not owned by the
+//! env: the env never frees individual scheme bodies, only the type arena and
+//! the frame/map bookkeeping.  This keeps the ownership boundary crisp — the
+//! env owns exactly what it allocated through `typeAllocator()`.
 
 const std = @import("std");
 const htype_mod = @import("htype.zig");
@@ -289,20 +303,44 @@ const Frame = struct {
 /// Call `push` / `pop` around each syntactic scope.  Prefer `enterScope` /
 /// `Scope.exit` for RAII-style management.
 pub const TyEnv = struct {
+    /// Backing allocator for frame nodes and hash maps.
     alloc: std.mem.Allocator,
+    /// Private arena that owns every `HType` tree allocated *by this env*
+    /// (e.g. the built-in schemes from `initBuiltins`).  Tearing it down in
+    /// `deinit` frees those trees in one shot, with no per-node ownership
+    /// tracking — see the module-level "Memory" note.  Heap-boxed so the
+    /// `TyEnv` value stays trivially movable (`init` returns by value).
+    type_arena: *std.heap.ArenaAllocator,
     /// The current (innermost) frame.  Never null after `init`.
     current: *Frame,
 
     // ── Lifecycle ──────────────────────────────────────────────────────
 
     /// Create an empty environment with one (global) frame.
+    ///
+    /// `alloc` backs the frame/map bookkeeping and the private type arena.
     pub fn init(alloc: std.mem.Allocator) std.mem.Allocator.Error!TyEnv {
+        const type_arena = try alloc.create(std.heap.ArenaAllocator);
+        errdefer alloc.destroy(type_arena);
+        type_arena.* = std.heap.ArenaAllocator.init(alloc);
+        errdefer type_arena.deinit();
+
         const frame = try alloc.create(Frame);
         frame.* = .{ .bindings = .{}, .outer = null };
-        return .{ .alloc = alloc, .current = frame };
+        return .{ .alloc = alloc, .type_arena = type_arena, .current = frame };
     }
 
-    /// Free all frames and their binding maps.
+    /// The allocator for `HType` nodes owned by this env.
+    ///
+    /// Any `HType` tree that will be stored in this env's bindings via the
+    /// env's own initialisers (`initBuiltins`) must be allocated here so that
+    /// `deinit` reclaims it.  Lookups/instantiations that produce *transient*
+    /// types not stored in the env should keep using the caller's allocator.
+    pub fn typeAllocator(self: *const TyEnv) std.mem.Allocator {
+        return self.type_arena.allocator();
+    }
+
+    /// Free all frames, their binding maps, and the private type arena.
     pub fn deinit(self: *TyEnv) void {
         var frame: ?*Frame = self.current;
         while (frame) |f| {
@@ -311,6 +349,8 @@ pub const TyEnv = struct {
             self.alloc.destroy(f);
             frame = outer;
         }
+        self.type_arena.deinit();
+        self.alloc.destroy(self.type_arena);
     }
 
     // ── Binding ────────────────────────────────────────────────────────
@@ -512,8 +552,16 @@ fn collectHTypeFreeMetas(
 ///
 /// `supply` is the typechecker's `UniqueSupply` — used to mint fresh
 /// `Name` values for the rigid type variables in polymorphic schemes.
-pub fn initBuiltins(env: *TyEnv, alloc: std.mem.Allocator, supply: *UniqueSupply, no_implicit_prelude: bool) std.mem.Allocator.Error!void {
+///
+/// All `HType` trees built here are allocated on the env's private type
+/// arena (`env.typeAllocator()`), so `env.deinit()` reclaims them with no
+/// per-node tracking.  This is what lets `TyEnv.init → initBuiltins →
+/// deinit` run leak-free under `std.testing.allocator` (#496).
+pub fn initBuiltins(env: *TyEnv, supply: *UniqueSupply, no_implicit_prelude: bool) std.mem.Allocator.Error!void {
     _ = supply; // reserved for future use if we need to mint fresh IDs for other built-ins
+
+    // Every HType allocated below is owned by the env's type arena.
+    const alloc = env.typeAllocator();
 
     // ── Type constructor helpers ───────────────────────────────────────
     // These are HType values for common base types.
@@ -871,7 +919,7 @@ test "initBuiltins: putStrLn is in scope" {
     var u_supply = UniqueSupply{}; // Starts at 1000
 
     // Since initBuiltins now uses stable IDs (0-999), it doesn't move the supply.
-    try initBuiltins(&env, alloc, &u_supply, false);
+    try initBuiltins(&env, &u_supply, false);
 
     try testing.expect(u_supply.next == 1000);
 
@@ -889,7 +937,7 @@ test "initBuiltins: True and False are bound" {
     var env = try TyEnv.init(alloc);
     defer env.deinit();
     var u_supply = UniqueSupply{};
-    try initBuiltins(&env, alloc, &u_supply, false);
+    try initBuiltins(&env, &u_supply, false);
 
     var mv_supply = MetaVarSupply{};
     const true_ty = try env.lookup(Known.Con.True.unique, alloc, &mv_supply);
@@ -910,7 +958,7 @@ test "initBuiltins: bindings are polymorphic where expected" {
     var env = try TyEnv.init(alloc);
     defer env.deinit();
     var u_supply = UniqueSupply{};
-    try initBuiltins(&env, alloc, &u_supply, false);
+    try initBuiltins(&env, &u_supply, false);
 
     // We'll just verify that some bindings in the map are polymorphic.
     var it = env.current.bindings.iterator();
@@ -932,7 +980,62 @@ test "initBuiltins: at least one binder exists" {
     var env = try TyEnv.init(alloc);
     defer env.deinit();
     var u_supply = UniqueSupply{};
-    try initBuiltins(&env, alloc, &u_supply, false);
+    try initBuiltins(&env, &u_supply, false);
 
     try testing.expect(env.current.bindings.count() > 0);
+}
+
+// ── Leak regression (#496) ─────────────────────────────────────────────
+
+test "TyEnv: init -> initBuiltins -> deinit is leak-free under testing.allocator" {
+    // Acceptance test for #496.  No arena wrapper here: the built-in HType
+    // trees are owned by the env's private type arena, so `deinit` must
+    // reclaim every allocation.  Any leak is reported by the leak-detecting
+    // testing allocator.  This also proves there is no use-after-free: the
+    // arena teardown never recursively walks shared `*const HType` pointers.
+    var env = try TyEnv.init(testing.allocator);
+    defer env.deinit();
+
+    var u_supply = UniqueSupply{};
+    try initBuiltins(&env, &u_supply, false);
+
+    // Sanity: the prelude bindings were actually installed.
+    try testing.expect(env.current.bindings.count() > 0);
+}
+
+test "TyEnv: NoImplicitPrelude init -> initBuiltins -> deinit is leak-free" {
+    // The wired-in-only path (NoImplicitPrelude) allocates a different subset
+    // of HType trees; exercise it too under the leak-detecting allocator.
+    var env = try TyEnv.init(testing.allocator);
+    defer env.deinit();
+
+    var u_supply = UniqueSupply{};
+    try initBuiltins(&env, &u_supply, true);
+
+    try testing.expect(env.current.bindings.count() > 0);
+}
+
+test "TyEnv: push/pop and lookup keep the env arena self-contained (no leak)" {
+    // Lookups instantiate schemes onto a *caller* allocator (here, a scratch
+    // arena), distinct from the env's type arena.  Pushing/popping frames and
+    // binding fresh schemes must not leak when run under testing.allocator.
+    var scratch = std.heap.ArenaAllocator.init(testing.allocator);
+    defer scratch.deinit();
+
+    var env = try TyEnv.init(testing.allocator);
+    defer env.deinit();
+
+    var u_supply = UniqueSupply{};
+    try initBuiltins(&env, &u_supply, false);
+
+    var mv_supply = MetaVarSupply{};
+    // Instantiate a polymorphic built-in (the cons constructor) onto scratch.
+    const cons_ty = try env.lookup(Known.Con.Cons.unique, scratch.allocator(), &mv_supply);
+    try testing.expect(cons_ty != null);
+
+    // Push an inner frame, bind a monomorphic type allocated on the env arena,
+    // then pop it.  The env's bookkeeping (frame + map) is freed by `pop`.
+    try env.push();
+    try env.bindMono(testName("x", 7), conTy(Known.Type.Int));
+    env.pop();
 }

--- a/src/typechecker/env.zig
+++ b/src/typechecker/env.zig
@@ -336,7 +336,12 @@ pub const TyEnv = struct {
     /// env's own initialisers (`initBuiltins`) must be allocated here so that
     /// `deinit` reclaims it.  Lookups/instantiations that produce *transient*
     /// types not stored in the env should keep using the caller's allocator.
-    pub fn typeAllocator(self: *const TyEnv) std.mem.Allocator {
+    ///
+    /// Intentionally non-`pub`: keeping the only writer (`initBuiltins`) inside
+    /// this module is what makes `deinit`'s arena teardown sound.  Allocations
+    /// from this allocator are owned by the `TyEnv` and freed at `deinit`, so
+    /// they must never escape into longer-lived state.
+    fn typeAllocator(self: *const TyEnv) std.mem.Allocator {
         return self.type_arena.allocator();
     }
 
@@ -1001,6 +1006,16 @@ test "TyEnv: init -> initBuiltins -> deinit is leak-free under testing.allocator
 
     // Sanity: the prelude bindings were actually installed.
     try testing.expect(env.current.bindings.count() > 0);
+
+    // Deep-walk an arena-allocated built-in body so this also guards against
+    // use-after-free, not just leaks.  Instantiating `(:) : forall a. a ->
+    // [a] -> [a]` dereferences the `Fun.arg`/`Fun.res` pointers that live in
+    // the env's private type arena.
+    var scratch = std.heap.ArenaAllocator.init(testing.allocator);
+    defer scratch.deinit();
+    var mv_supply = MetaVarSupply{};
+    const cons_ty = (try env.lookup(Known.Con.Cons.unique, scratch.allocator(), &mv_supply)).?;
+    try testing.expect(cons_ty == .Fun);
 }
 
 test "TyEnv: NoImplicitPrelude init -> initBuiltins -> deinit is leak-free" {
@@ -1013,6 +1028,14 @@ test "TyEnv: NoImplicitPrelude init -> initBuiltins -> deinit is leak-free" {
     try initBuiltins(&env, &u_supply, true);
 
     try testing.expect(env.current.bindings.count() > 0);
+
+    // As above, deep-walk an arena-allocated body to guard against
+    // use-after-free.  `(:)` is a wired-in binding present on this path too.
+    var scratch = std.heap.ArenaAllocator.init(testing.allocator);
+    defer scratch.deinit();
+    var mv_supply = MetaVarSupply{};
+    const cons_ty = (try env.lookup(Known.Con.Cons.unique, scratch.allocator(), &mv_supply)).?;
+    try testing.expect(cons_ty == .Fun);
 }
 
 test "TyEnv: push/pop and lookup keep the env arena self-contained (no leak)" {
@@ -1033,8 +1056,10 @@ test "TyEnv: push/pop and lookup keep the env arena self-contained (no leak)" {
     const cons_ty = try env.lookup(Known.Con.Cons.unique, scratch.allocator(), &mv_supply);
     try testing.expect(cons_ty != null);
 
-    // Push an inner frame, bind a monomorphic type allocated on the env arena,
-    // then pop it.  The env's bookkeeping (frame + map) is freed by `pop`.
+    // Push an inner frame, bind a nullary type (a stack-resident `Con` that
+    // allocates nothing), then pop it.  This checks the frame *bookkeeping*
+    // cleanup: `pop` must free the inner frame and its binding map without
+    // touching the env's type arena.
     try env.push();
     try env.bindMono(testName("x", 7), conTy(Known.Type.Int));
     env.pop();

--- a/src/typechecker/infer.zig
+++ b/src/typechecker/infer.zig
@@ -2580,7 +2580,7 @@ test "infer: integer literal has type Int" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -2602,7 +2602,7 @@ test "infer: character literal has type Char" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -2624,7 +2624,7 @@ test "infer: string literal has type [Char]" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -2648,7 +2648,7 @@ test "infer: float literal has type Double" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -2862,7 +2862,7 @@ test "infer: let id = \\x -> x in (id 1, id True) — let-polymorphism" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -2978,7 +2978,7 @@ test "infer: genuine let-polymorphism still works in nested scopes" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -3102,7 +3102,7 @@ test "infer: if True then 1 else 2 has type Int" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -3701,7 +3701,7 @@ test "infer: if branches of different types emits error" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -3788,7 +3788,7 @@ test "infer: (1, True) has type (Int, Bool)" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -3821,7 +3821,7 @@ test "inferModule: main = putStrLn \"Hello\"" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -3921,7 +3921,7 @@ test "inferModule: signature matches inferred type" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -3994,7 +3994,7 @@ test "inferModule: signature mismatch produces error" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -4044,7 +4044,7 @@ test "inferModule: type variables in signature are scoped correctly" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -4146,7 +4146,7 @@ test "inferModule: #304 bad x y = x with sig a -> b -> b produces RigidMismatch"
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -4204,7 +4204,7 @@ test "inferModule: #304 good x y = y with sig a -> b -> b succeeds" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -4556,7 +4556,7 @@ test "inferModule with type application in signature" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     // Bind Just constructor as Int -> Int for testing (simplified)
     const just_name = testName("Just", 9301);
@@ -4635,7 +4635,7 @@ test "infer: let-binding with type signature uses signature" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 
@@ -4713,7 +4713,7 @@ test "infer: let-binding with polymorphic signature works" {
     var us = UniqueSupply{};
     var diags = DiagnosticCollector.init();
     defer diags.deinit(alloc);
-    try env_mod.initBuiltins(&env, alloc, &us, false);
+    try env_mod.initBuiltins(&env, &us, false);
 
     var ctx = makeCtx(&arena, &env, &mv, &us, &diags);
 

--- a/tests/compile_fail_test_runner.zig
+++ b/tests/compile_fail_test_runner.zig
@@ -137,7 +137,7 @@ fn tryCompile(
     // ── Typecheck ────────────────────────────────────────────────────────
     var mv_supply = htype_mod.MetaVarSupply{};
     var ty_env = try rusholme.tc.env.TyEnv.init(aa);
-    try rusholme.tc.env.initBuiltins(&ty_env, aa, &u_supply, no_implicit_prelude);
+    try rusholme.tc.env.initBuiltins(&ty_env, &u_supply, no_implicit_prelude);
     var infer_ctx = infer_mod.InferCtx.init(aa, &ty_env, &mv_supply, &u_supply, &diags);
     var module_types = infer_mod.inferModule(&infer_ctx, renamed, null) catch
         return collectCodes(allocator, &diags, aa);

--- a/tests/golden_test_runner.zig
+++ b/tests/golden_test_runner.zig
@@ -276,7 +276,7 @@ fn pipelineToCore(allocator: std.mem.Allocator, source: []const u8) ![]const u8 
     // ── Typecheck ────────────────────────────────────────────────────────
     var mv_supply = htype_mod.MetaVarSupply{};
     var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
-    try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply, no_implicit_prelude);
+    try rusholme.tc.env.initBuiltins(&ty_env, &u_supply, no_implicit_prelude);
     var infer_ctx = infer_mod.InferCtx.init(arena_alloc, &ty_env, &mv_supply, &u_supply, &diags);
     var module_types = try infer_mod.inferModule(&infer_ctx, renamed, null);
     defer module_types.deinit(arena_alloc);
@@ -356,7 +356,7 @@ fn pipelineToGrin(allocator: std.mem.Allocator, source: []const u8) ![]const u8 
     // ── Typecheck ────────────────────────────────────────────────────────
     var mv_supply = htype_mod.MetaVarSupply{};
     var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
-    try rusholme.tc.env.initBuiltins(&ty_env, arena_alloc, &u_supply, no_implicit_prelude);
+    try rusholme.tc.env.initBuiltins(&ty_env, &u_supply, no_implicit_prelude);
     var infer_ctx = infer_mod.InferCtx.init(arena_alloc, &ty_env, &mv_supply, &u_supply, &diags);
     var module_types = try infer_mod.inferModule(&infer_ctx, renamed, null);
     defer module_types.deinit(arena_alloc);


### PR DESCRIPTION
Closes #496

## Summary

`TyEnv.deinit()` freed only frames and binding maps, leaking the `HType`
trees that `initBuiltins` allocates (via `funTy` / `applyTy` / `dupeIds`).
Invisible under `ArenaAllocator` callers, but ~48 leaks under
`std.testing.allocator`. An earlier recursive `freeHTypeWithTracking`
attempt (#494) crashed with use-after-free because the `*const HType`
pointers in `AppTy` / `Fun` / `ForAll` may be shared, stack-, or
caller-arena-allocated — not individually heap-owned.

**Strategy chosen: arena-per-TyEnv** (the issue's preferred option, and a
textbook "define errors out of existence" move from A Philosophy of Software
Design). `TyEnv` now owns a private `std.heap.ArenaAllocator`; `initBuiltins`
allocates every `HType` on `env.typeAllocator()`, and `deinit` tears the
arena down in one shot. This removes all per-node ownership tracking and
makes the recursive-free use-after-free impossible by construction.

### Audit (deliverable 1)
The env stores `TyScheme` values by value; their `body` / `binders` /
`constraints` point at `HType`/slice memory owned by whoever allocated them.
`initBuiltins` is the only env-internal producer — its pointers are now all
on the env's type arena. The typechecker may also `bind` schemes whose
bodies it allocated on its own pass arena; those are explicitly *not* owned
by the env (it never recursively frees scheme bodies), so there is no
double-free and no dangling. Transient `lookup`/`instantiate` results
continue to use the caller's allocator.

### Interface cleanup
`initBuiltins` no longer takes a redundant `alloc` parameter (it uses the
env's type arena). All 32 call sites across `infer.zig`, `main.zig`,
`pipeline.zig`, `session.zig`, `compile_env.zig`, and the test runners were
updated.

## Deliverables
- [x] Audit HType allocation patterns (always-heap vs. shared/stack/arena)
- [x] Design a safe deep-free strategy (arena-per-TyEnv)
- [x] Implement it
- [x] Zero-leak regression test: `TyEnv.init -> initBuiltins -> deinit` under
      `std.testing.allocator` (plus NoImplicitPrelude and push/pop/lookup
      variants)
- [x] Checked the `src/repl/server.zig` arena: it is **not** redundant — the
      Session leaks ~21k allocations from unrelated state. Filed as #741 and
      updated the `cli.zig run()` comment accordingly.

## Testing
`nix develop --command zig build test --summary all`:
`Build Summary: 47/47 steps succeeded; 1019/1019 tests passed`.
The new leak-regression tests run under the leak-detecting allocator with no
arena and pass with zero leaks / no use-after-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
