### PR TITLE
#713: Add default implementations for Enum class methods

### DIFF
--- a/lib/Prelude.hs
+++ b/lib/Prelude.hs
@@ -285,6 +285,49 @@ class Enum a where
   enumFromThen :: a -> a -> [a]
   enumFromTo :: a -> a -> [a]
   enumFromThenTo :: a -> a -> a -> [a]
+  -- Default implementations per the Haskell 2010 Report (§6.3.4), expressed in
+  -- terms of succ, fromEnum and toEnum so that any instance defining those
+  -- three (plus pred) gets the four ranged enumerations for free.  Three
+  -- deliberate deviations from a naive transcription of the Report:
+  --
+  --  * Range bounds are compared on the Int results of fromEnum using the
+  --    monomorphic primitives (primGtInt / primLtInt / primEqInt) rather than
+  --    the Ord (>)/(<) methods.  Default-method bodies are not yet type-checked,
+  --    so the evidence resolver cannot supply the Ord Int dictionary that Ord
+  --    (>) would require (#629); the primitive comparison is semantically
+  --    identical and needs no dictionary.
+  --
+  --  * The `step` of enumFromThen/enumFromThenTo is written inline rather than
+  --    bound with `let`.  A `let`-bound name inside a (not-yet-type-checked)
+  --    default-method body is mistranslated by the GRIN→LLVM backend (the case
+  --    scrutinee resolves to a garbage value).  Inlining the pure expression
+  --    sidesteps that.
+  --    Tracked in: https://github.com/adinapoli/rusholme/issues/744
+  --    The recompute-the-step formulation also forces `toEnum` one step past
+  --    the limit for finite enums (enumFromThen/enumFromThenTo only).
+  --    Tracked in: https://github.com/adinapoli/rusholme/issues/745
+  --
+  --  * enumFromTo stops with an explicit equality check (primEqInt) so that
+  --    `succ` is never evaluated one step past the last element — otherwise the
+  --    final `succ maxBound` would raise the maxBound error before the bound
+  --    check could terminate the list.
+  enumFrom n = n : enumFrom (succ n)
+  enumFromTo n m =
+    if primGtInt (fromEnum n) (fromEnum m)
+    then []
+    else if primEqInt (fromEnum n) (fromEnum m)
+         then [n]
+         else n : enumFromTo (succ n) m
+  enumFromThen n n2 =
+    n : enumFromThen n2 (toEnum (fromEnum n2 + (fromEnum n2 - fromEnum n)))
+  enumFromThenTo n n2 m =
+    if primGeInt (fromEnum n2 - fromEnum n) 0
+    then if primGtInt (fromEnum n) (fromEnum m)
+         then []
+         else n : enumFromThenTo n2 (toEnum (fromEnum n2 + (fromEnum n2 - fromEnum n))) m
+    else if primLtInt (fromEnum n) (fromEnum m)
+         then []
+         else n : enumFromThenTo n2 (toEnum (fromEnum n2 + (fromEnum n2 - fromEnum n))) m
 
 instance Enum Int where
   succ n = n + 1
@@ -300,25 +343,14 @@ instance Enum Int where
        then if n > m then [] else n : enumFromThenTo n2 (n2 + step) m
        else if n < m then [] else n : enumFromThenTo n2 (n2 + step) m
 
+-- Char, Bool and Ordering need only define succ/pred/toEnum/fromEnum: the
+-- four ranged enumerations (enumFrom, enumFromTo, enumFromThen,
+-- enumFromThenTo) are inherited from the Enum class defaults above.
 instance Enum Char where
   succ c = intToChar (charToInt c + 1)
   pred c = intToChar (charToInt c - 1)
   toEnum n = intToChar n
   fromEnum c = charToInt c
-  enumFrom c = c : enumFrom (intToChar (charToInt c + 1))
-  enumFromTo c end = if charToInt c > charToInt end
-                     then []
-                     else c : enumFromTo (intToChar (charToInt c + 1)) end
-  enumFromThen c c2 = c : enumFromThen c2 (intToChar (charToInt c2 + (charToInt c2 - charToInt c)))
-  enumFromThenTo c c2 end =
-    let step = charToInt c2 - charToInt c
-    in if step >= 0
-       then if charToInt c > charToInt end
-            then []
-            else c : enumFromThenTo c2 (intToChar (charToInt c2 + step)) end
-       else if charToInt c < charToInt end
-            then []
-            else c : enumFromThenTo c2 (intToChar (charToInt c2 + step)) end
 
 instance Enum Bool where
   succ False = True
@@ -330,20 +362,6 @@ instance Enum Bool where
   toEnum _ = error "toEnum: out of range for Bool"
   fromEnum False = 0
   fromEnum True  = 1
-  enumFrom n = n : enumFrom (succ n)
-  enumFromTo n m = if fromEnum n > fromEnum m
-                   then []
-                   else n : enumFromTo (succ n) m
-  enumFromThen n n2 = n : enumFromThen n2 (succ n2)
-  enumFromThenTo n n2 m =
-    let step = fromEnum n2 - fromEnum n
-    in if step >= 0
-       then if fromEnum n > fromEnum m
-            then []
-            else n : enumFromThenTo n2 (succ n2) m
-       else if fromEnum n < fromEnum m
-            then []
-            else n : enumFromThenTo n2 (succ n2) m
 
 instance Enum Ordering where
   succ LT = EQ
@@ -359,20 +377,6 @@ instance Enum Ordering where
   fromEnum LT = 0
   fromEnum EQ = 1
   fromEnum GT = 2
-  enumFrom n = n : enumFrom (succ n)
-  enumFromTo n m = if fromEnum n > fromEnum m
-                   then []
-                   else n : enumFromTo (succ n) m
-  enumFromThen n n2 = n : enumFromThen n2 (succ n2)
-  enumFromThenTo n n2 m =
-    let step = fromEnum n2 - fromEnum n
-    in if step >= 0
-       then if fromEnum n > fromEnum m
-            then []
-            else n : enumFromThenTo n2 (succ n2) m
-       else if fromEnum n < fromEnum m
-            then []
-            else n : enumFromThenTo n2 (succ n2) m
 
 -- ========================================================================
 -- Higher-order combinators

--- a/src/core/desugar.zig
+++ b/src/core/desugar.zig
@@ -30,12 +30,6 @@ pub const DesugarCtx = struct {
     /// when translating `DictEvidence.instance` to a Core variable reference.
     dict_names: DictNameMap = .empty,
 
-    /// Maps `(class_unique, method_unique)` → default method `Name`.
-    /// Populated by `desugarClassDecl` (section 3), queried by
-    /// `desugarInstanceDecl` when a method has no explicit binding and
-    /// the class provides a default implementation.
-    default_method_names: std.AutoHashMapUnmanaged(DefaultMethodKey, Name) = .{},
-
     /// Evidence map built from solved constraints. Keyed by
     /// `(var_unique, class_name_unique)` → list of `DictEvidence` pointers.
     /// Multiple constraints for the same variable can arise from multiple
@@ -63,11 +57,6 @@ pub const DesugarCtx = struct {
         class_unique: u64,
         /// Unique ID of the Rigid type variable.  Zero for non-Rigid or unknown.
         tyvar_unique: u64,
-    };
-
-    pub const DefaultMethodKey = struct {
-        class_unique: u64,
-        method_unique: u64,
     };
 
     pub const DictNameKey = struct {
@@ -736,12 +725,16 @@ fn desugarClassDecl(
             .unique = ctx.u_supply.fresh(),
         };
 
-        // Register the default method name so that desugarInstanceDecl can
-        // reference the same unique when a method is not explicitly provided.
-        try ctx.default_method_names.put(alloc, .{
-            .class_unique = cd.name.unique.value,
-            .method_unique = method.name.unique.value,
-        }, default_name);
+        // Record the default-method name in the ClassEnv so that
+        // desugarInstanceDecl — possibly in a *different* module — can reference
+        // the same unique when a method is not explicitly provided.  Stored in
+        // the (cross-module, serialised) ClassEnv rather than a per-ctx map so
+        // that user instances of a Prelude class can find Prelude defaults.
+        ctx.types.class_env.setDefaultName(
+            cd.name.unique.value,
+            method.name.unique.value,
+            default_name,
+        );
 
         // Compile the default method body using the pattern match compiler.
         // The default body is a slice of RMatch equations (same as FunBind).
@@ -931,14 +924,20 @@ fn desugarInstanceDecl(
             //
             // Then the dictionary constructor uses _inst$... as the field.
             //
-            // Look up the name registered during class desugaring so that
-            // the reference matches the binding's unique (issue #660).
-            const default_method_name = ctx.default_method_names.get(.{
-                .class_unique = id_decl.class_name.unique.value,
-                .method_unique = method.name.unique.value,
-            }) orelse {
-                // Defensive fallback — should not happen if desugarClassDecl ran first.
-                return error.OutOfMemory;
+            // Look up the name recorded in the ClassEnv during class desugaring
+            // so that the reference matches the binding's unique (issue #660).
+            // This is read from `MethodInfo.default_name`, which the ClassEnv
+            // carries across module boundaries (issue #713).
+            const default_method_name = method.default_name orelse {
+                // `has_default` is true but no compiled default-binding name was
+                // recorded.  This is an internal inconsistency: the class was
+                // type-checked with a default but never desugared (or the
+                // ClassEnv was not threaded through).  Crash rather than emit a
+                // dangling reference.
+                std.debug.panic(
+                    "desugarInstanceDecl: missing default-method binding for {s}.{s}",
+                    .{ id_decl.class_name.base, method.name.base },
+                );
             };
 
             // Count the method arity (excluding the dict param which we supply).
@@ -2633,6 +2632,18 @@ fn desugarMatch(
     // because `inferPat` already populated `local_binders`.
     try registerPatBinders(ctx, equations, arg_tys);
 
+    // Also pre-register binders introduced *inside* each equation's body
+    // (let bindings, lambda parameters, case/do pattern variables).  Class
+    // default methods and instance methods are not type-checked, so binders
+    // such as the `step` in `let step = ... in ...` never reach
+    // `local_binders` via inference and would otherwise crash `desugarExpr`
+    // with a "Variable ... not found in type definitions" panic.  As with
+    // `registerPatBinders`, this is a no-op for already-typed bodies thanks
+    // to the `contains` guard in `registerBinder`.
+    for (equations) |eq| {
+        try registerRhsBinders(ctx, eq.rhs);
+    }
+
     var eq_idx: usize = equations.len;
     while (eq_idx > 0) {
         eq_idx -= 1;
@@ -3103,20 +3114,10 @@ fn registerPatBindersRec(
 ) std.mem.Allocator.Error!void {
     const dummy = dummyCoreType();
     switch (pat) {
-        .Var => |v| {
-            // Only register if not already present (the typechecker may have
-            // populated it for top-level FunBinds).
-            if (!ctx.types.local_binders.contains(v.name.unique)) {
-                const hty = try coreTypeToHType(ctx.alloc, ty);
-                try ctx.types.local_binders.put(ctx.alloc, v.name.unique, hty);
-            }
-        },
+        .Var => |v| try registerBinder(ctx, v.name, ty),
         .Paren => |inner| try registerPatBindersRec(ctx, inner.*, ty),
         .AsPat => |as_| {
-            if (!ctx.types.local_binders.contains(as_.name.unique)) {
-                const hty = try coreTypeToHType(ctx.alloc, ty);
-                try ctx.types.local_binders.put(ctx.alloc, as_.name.unique, hty);
-            }
+            try registerBinder(ctx, as_.name, ty);
             try registerPatBindersRec(ctx, as_.pat.*, ty);
         },
         .Con => |c| {
@@ -3139,6 +3140,156 @@ fn registerPatBindersRec(
             }
         },
         .Lit, .Wild => {},
+    }
+}
+
+/// Register a single binder in `local_binders` with the given Core type,
+/// converted to an `HType`.  No-op if the binder is already present, so it
+/// never overwrites a type computed by the typechecker (top-level FunBinds)
+/// or by an earlier registration pass.
+fn registerBinder(
+    ctx: *DesugarCtx,
+    name: Name,
+    ty: ast_mod.CoreType,
+) std.mem.Allocator.Error!void {
+    if (ctx.types.local_binders.contains(name.unique)) return;
+    const hty = try coreTypeToHType(ctx.alloc, ty);
+    try ctx.types.local_binders.put(ctx.alloc, name.unique, hty);
+}
+
+/// Register every binder introduced inside the body of an *untyped* equation
+/// so that `desugarExpr` can resolve them.
+///
+/// Class default methods and instance methods are not type-checked (the
+/// typechecker skips their bodies), so any binder introduced *within* the
+/// body — a `let`-bound name, a lambda parameter, or a `case`/`do` pattern
+/// variable — is absent from `local_binders`.  `desugarExpr` panics when it
+/// cannot resolve such a binder.  `registerPatBinders` already covers the
+/// equation's *argument* patterns; these helpers complete the invariant for
+/// the body so the panic is removed by construction rather than by an ad-hoc
+/// limit.  Each binder is registered with a placeholder type, which is all the
+/// downstream GRIN translator needs (the Core types of these binders are only
+/// used structurally; see `registerPatBindersRec`).
+fn registerRhsBinders(ctx: *DesugarCtx, rhs: renamer_mod.RRhs) std.mem.Allocator.Error!void {
+    switch (rhs) {
+        .UnGuarded => |expr| try registerExprBinders(ctx, expr),
+        .Guarded => |grhs_list| {
+            for (grhs_list) |grhs| {
+                for (grhs.guards) |guard| {
+                    switch (guard) {
+                        .ExprGuard => |e| try registerExprBinders(ctx, e),
+                        .PatGuard => |pg| {
+                            try registerPatBindersRec(ctx, pg.pat, dummyCoreType());
+                            try registerExprBinders(ctx, pg.expr);
+                        },
+                    }
+                }
+                try registerExprBinders(ctx, grhs.rhs);
+            }
+        },
+    }
+}
+
+/// Walk an `RExpr` and register all binders it introduces.  See
+/// `registerRhsBinders` for why this is necessary.
+fn registerExprBinders(ctx: *DesugarCtx, expr: renamer_mod.RExpr) std.mem.Allocator.Error!void {
+    const dummy = dummyCoreType();
+    switch (expr) {
+        .Var, .Lit => {},
+        .App => |a| {
+            try registerExprBinders(ctx, a.fn_expr.*);
+            try registerExprBinders(ctx, a.arg_expr.*);
+        },
+        .InfixApp => |ia| {
+            try registerExprBinders(ctx, ia.left.*);
+            try registerExprBinders(ctx, ia.right.*);
+        },
+        .LeftSection => |ls| try registerExprBinders(ctx, ls.expr.*),
+        .RightSection => |rs| try registerExprBinders(ctx, rs.expr.*),
+        .Lambda => |lam| {
+            for (lam.params) |p| try registerBinder(ctx, p, dummy);
+            try registerExprBinders(ctx, lam.body.*);
+        },
+        .Let => |let_blk| {
+            try registerDeclBinders(ctx, let_blk.binds);
+            try registerExprBinders(ctx, let_blk.body.*);
+        },
+        .Case => |c| {
+            try registerExprBinders(ctx, c.scrutinee.*);
+            for (c.alts) |alt| {
+                try registerPatBindersRec(ctx, alt.pattern, dummy);
+                try registerRhsBinders(ctx, alt.rhs);
+            }
+        },
+        .If => |i| {
+            try registerExprBinders(ctx, i.condition.*);
+            try registerExprBinders(ctx, i.then_expr.*);
+            try registerExprBinders(ctx, i.else_expr.*);
+        },
+        .Do => |stmts| {
+            for (stmts) |stmt| {
+                switch (stmt) {
+                    .Generator => |g| {
+                        try registerPatBindersRec(ctx, g.pat, dummy);
+                        try registerExprBinders(ctx, g.expr);
+                    },
+                    .Qualifier, .Stmt => |e| try registerExprBinders(ctx, e),
+                    .LetStmt => |binds| try registerDeclBinders(ctx, binds),
+                }
+            }
+        },
+        .Tuple, .List => |elems| {
+            for (elems) |e| try registerExprBinders(ctx, e);
+        },
+        .EnumFrom => |e| try registerExprBinders(ctx, e.from.*),
+        .EnumFromThen => |e| {
+            try registerExprBinders(ctx, e.from.*);
+            try registerExprBinders(ctx, e.then.*);
+        },
+        .EnumFromTo => |e| {
+            try registerExprBinders(ctx, e.from.*);
+            try registerExprBinders(ctx, e.to.*);
+        },
+        .EnumFromThenTo => |e| {
+            try registerExprBinders(ctx, e.from.*);
+            try registerExprBinders(ctx, e.then.*);
+            try registerExprBinders(ctx, e.to.*);
+        },
+        .TypeAnn => |ta| try registerExprBinders(ctx, ta.expr.*),
+        .TypeApp => |ta| try registerExprBinders(ctx, ta.fn_expr.*),
+        .Negate => |inner| try registerExprBinders(ctx, inner.*),
+        .Paren => |inner| try registerExprBinders(ctx, inner.*),
+        .RecordCon => |rc| {
+            for (rc.fields) |f| try registerExprBinders(ctx, f.expr);
+        },
+        .RecordUpdate => |ru| {
+            try registerExprBinders(ctx, ru.expr.*);
+            for (ru.fields) |f| try registerExprBinders(ctx, f.expr);
+        },
+        .Field => |f| try registerExprBinders(ctx, f.expr.*),
+    }
+}
+
+/// Register binders for the declarations bound by a `let`/`where` block inside
+/// an untyped body: the names of `FunBind` equations, their argument patterns,
+/// and `PatBind` patterns, descending into each body recursively.
+fn registerDeclBinders(ctx: *DesugarCtx, binds: []const renamer_mod.RDecl) std.mem.Allocator.Error!void {
+    const dummy = dummyCoreType();
+    for (binds) |bd| {
+        switch (bd) {
+            .FunBind => |fb| {
+                try registerBinder(ctx, fb.name, dummy);
+                for (fb.equations) |eq| {
+                    for (eq.patterns) |pat| try registerPatBindersRec(ctx, pat, dummy);
+                    try registerRhsBinders(ctx, eq.rhs);
+                }
+            },
+            .PatBind => |pb| {
+                try registerPatBindersRec(ctx, pb.pattern, dummy);
+                try registerRhsBinders(ctx, pb.rhs);
+            },
+            else => {},
+        }
     }
 }
 
@@ -3822,4 +3973,58 @@ test "desugarRhs: otherwise-only guard is transparent" {
     // `otherwise` is trivially true: no Case wrapper, just the Lit directly.
     try testing.expect(result == .Lit);
     try testing.expectEqual(@as(i64, 42), result.Lit.val.Int);
+}
+
+test "registerRhsBinders: let-bound name in an untyped body is registered (#713)" {
+    // Reproduces the desugarer crash that issue #713 fixed: a default/instance
+    // method body containing `let step = 0 in step` introduces the binder
+    // `step`, which the typechecker never sees (class/instance bodies are not
+    // type-checked).  Before the fix, `desugarExpr` panicked with
+    // "Variable step not found in type definitions".  `registerRhsBinders`
+    // must populate `local_binders` for such interior binders.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var types = infer_mod.ModuleTypes{
+        .schemes = .{},
+        .local_binders = .{},
+        .class_env = infer_mod.ClassEnv.init(alloc),
+    };
+    defer types.deinit(alloc);
+
+    var diags = DiagnosticCollector.init();
+    defer diags.deinit(alloc);
+
+    var u_supply = naming_mod.UniqueSupply{};
+    var ctx = makeCtx(alloc, &types, &diags, &u_supply);
+
+    const step_name = testName("step", 9001);
+
+    // let step = 0 in step
+    const zero_lit = renamer_mod.RExpr{ .Lit = .{ .Int = .{ .value = 0, .span = syntheticSpan() } } };
+    const step_var = try alloc.create(renamer_mod.RExpr);
+    step_var.* = .{ .Var = .{ .name = step_name, .span = syntheticSpan() } };
+    const step_decl = renamer_mod.RDecl{ .PatBind = .{
+        .pattern = .{ .Var = .{ .name = step_name, .span = syntheticSpan() } },
+        .rhs = .{ .UnGuarded = zero_lit },
+        .span = syntheticSpan(),
+    } };
+    const let_expr = renamer_mod.RExpr{ .Let = .{
+        .binds = try alloc.dupe(renamer_mod.RDecl, &.{step_decl}),
+        .body = step_var,
+    } };
+    const rhs = renamer_mod.RRhs{ .UnGuarded = let_expr };
+
+    // Precondition: the binder is unknown to the typechecker.
+    try testing.expect(!types.local_binders.contains(step_name.unique));
+
+    try registerRhsBinders(&ctx, rhs);
+
+    // The interior `step` binder is now registered, so `desugarExpr` will not
+    // panic when it reaches the let binding.
+    try testing.expect(types.local_binders.contains(step_name.unique));
+
+    const result = try desugarExpr(&ctx, let_expr);
+    try testing.expect(result.* == .Let);
 }

--- a/src/deriving/enum_class.zig
+++ b/src/deriving/enum_class.zig
@@ -1,18 +1,13 @@
 //! Synthesise an `Enum` instance.  Only legal for enumeration types (all
 //! constructors nullary).
 //!
-//! Generates all 8 Enum methods: `fromEnum`, `toEnum`, `succ`, `pred`,
-//! `enumFrom`, `enumFromTo`, `enumFromThen`, `enumFromThenTo`.
-//!
-//! The four arithmetic-sequence methods use explicit case-matching
-//! over all constructor combinations rather than recursive self-calls.
-//! This avoids GRIN thunk-naming collisions (see issue #714) and keeps
-//! the generated code self-contained within the instance.  The trade-off
-//! is O(n²) and O(n³) code size for `enumFromThen` and `enumFromThenTo`
-//! respectively, which is acceptable for enumeration types (few constructors).
-//!
-//! A more compact recursive approach (e.g. `enumFrom x = x : enumFrom (succ x)`)
-//! is deferred to issue #714 due to the thunk-naming collision it triggers.
+//! Generates only the four *primitive* Enum methods: `fromEnum`, `toEnum`,
+//! `succ` and `pred`.  The four ranged enumerations — `enumFrom`,
+//! `enumFromTo`, `enumFromThen`, `enumFromThenTo` — are inherited from the
+//! `Enum` class defaults, which are expressed in terms of `succ`, `fromEnum`
+//! and `toEnum` (issue #713).  Relying on the defaults removes the previous
+//! O(n²)/O(n³) explicit case-matching code-size blow-up for `enumFromThen`
+//! and `enumFromThenTo` (the workaround that issue #714 tracked, now obsolete).
 const std = @import("std");
 const ast = @import("../frontend/ast.zig");
 const span_mod = @import("../diagnostics/span.zig");
@@ -142,193 +137,15 @@ pub fn synth(
     );
     const pred_fb = try builder.mkFunBind(arena, "pred", &.{pred_match}, span);
 
-    // enumFrom — explicit case enumeration (no recursive self-calls).
-    // For each constructor Ck: enumFrom Ck = [Ck, C{k+1}, ..., C{n-1}]
-    var ef_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
-    for (decl.constructors, 0..) |c, idx| {
-        const pat = try builder.mkConPat(arena, c.name, &.{}, span);
-        // Build [Ck, C{k+1}, ..., C{n-1}] right-to-left
-        var list_expr: ast.Expr = .{ .List = &.{} };
-        var k: usize = decl.constructors.len;
-        while (k > idx) {
-            k -= 1;
-            const elem = builder.mkVar(decl.constructors[k].name, span);
-            list_expr = try builder.mkInfix(arena, elem, ":", list_expr, span);
-        }
-        try ef_alts.append(arena, builder.mkAlt(pat, list_expr, span));
-    }
-    const ef_body = try builder.mkCase(arena, builder.mkVar("x", span), ef_alts.items);
-    const ef_match = try builder.mkMatch(
-        arena,
-        &.{builder.mkVarPat("x", span)},
-        ef_body,
-        span,
-    );
-    const ef_fb = try builder.mkFunBind(arena, "enumFrom", &.{ef_match}, span);
-
-    // enumFromTo — explicit case enumeration for both arguments.
-    // enumFromTo Ck Cj = [Ck, ..., Cj] if j >= k, else []
-    var eft_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
-    for (decl.constructors, 0..) |c_outer, outer_idx| {
-        const outer_pat = try builder.mkConPat(arena, c_outer.name, &.{}, span);
-        var inner_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
-        for (decl.constructors, 0..) |c_inner, inner_idx| {
-            const inner_pat = try builder.mkConPat(arena, c_inner.name, &.{}, span);
-            if (inner_idx < outer_idx) {
-                // y < x: empty list
-                try inner_alts.append(arena, builder.mkAlt(inner_pat, .{ .List = &.{} }, span));
-            } else {
-                // y >= x: [C{outer_idx}, ..., C{inner_idx}]
-                var list_expr: ast.Expr = .{ .List = &.{} };
-                var k: usize = inner_idx + 1;
-                while (k > outer_idx) {
-                    k -= 1;
-                    const elem = builder.mkVar(decl.constructors[k].name, span);
-                    list_expr = try builder.mkInfix(arena, elem, ":", list_expr, span);
-                }
-                try inner_alts.append(arena, builder.mkAlt(inner_pat, list_expr, span));
-            }
-        }
-        const inner_case = try builder.mkCase(arena, builder.mkVar("y", span), inner_alts.items);
-        try eft_alts.append(arena, builder.mkAlt(outer_pat, inner_case, span));
-    }
-    const eft_body = try builder.mkCase(arena, builder.mkVar("x", span), eft_alts.items);
-    const eft_match = try builder.mkMatch(
-        arena,
-        &.{ builder.mkVarPat("x", span), builder.mkVarPat("y", span) },
-        eft_body,
-        span,
-    );
-    const eft_fb = try builder.mkFunBind(arena, "enumFromTo", &.{eft_match}, span);
-
-    // enumFromThen — explicit case enumeration for both arguments.
-    // For each pair (Ck, Cj), produce the arithmetic sequence
-    //   [Ck, C{k+step}, ...] limited to the constructor range.
-    // Lists are built right-to-left to ensure correct element order.
-    // tracked in: https://github.com/adinapoli/rusholme/issues/708
-    var eftn_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
-    for (decl.constructors, 0..) |c, idx| {
-        const outer_pat = try builder.mkConPat(arena, c.name, &.{}, span);
-        var inner_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
-        for (decl.constructors, 0..) |c2, idx2| {
-            const inner_pat = try builder.mkConPat(arena, c2.name, &.{}, span);
-            const step: isize = @as(isize, @intCast(idx2)) - @as(isize, @intCast(idx));
-            var list_expr: ast.Expr = .{ .List = &.{} };
-            if (step > 0) {
-                // Ascending: [Ck, C{k+step}, C{k+2*step}, ...] up to last in range
-                // Build right-to-left: iterate from last element back to first
-                var pos: usize = decl.constructors.len - 1;
-                while (pos > idx) : (pos -= 1) {
-                    // Only include elements on the step grid
-                    if ((pos - idx) % @as(usize, @intCast(step)) == 0) {
-                        const elem = builder.mkVar(decl.constructors[pos].name, span);
-                        list_expr = try builder.mkInfix(arena, elem, ":", list_expr, span);
-                    }
-                }
-                // Always include the first element
-                const first = builder.mkVar(decl.constructors[idx].name, span);
-                list_expr = try builder.mkInfix(arena, first, ":", list_expr, span);
-            } else if (step < 0) {
-                // Descending: [Ck, C{k+step}, C{k+2*step}, ...] down to first in range
-                // Build right-to-left: iterate from first element forward to k
-                var pos: usize = 0;
-                while (pos < idx) : (pos += 1) {
-                    const abs_step = @as(usize, @intCast(-step));
-                    if ((idx - pos) % abs_step == 0) {
-                        const elem = builder.mkVar(decl.constructors[pos].name, span);
-                        list_expr = try builder.mkInfix(arena, elem, ":", list_expr, span);
-                    }
-                }
-                // Always include the first element
-                const first = builder.mkVar(decl.constructors[idx].name, span);
-                list_expr = try builder.mkInfix(arena, first, ":", list_expr, span);
-            } else {
-                // step == 0: infinite repeat, just return [Ck]
-                const elem = builder.mkVar(c.name, span);
-                list_expr = try builder.mkInfix(arena, elem, ":", .{ .List = &.{} }, span);
-            }
-            try inner_alts.append(arena, builder.mkAlt(inner_pat, list_expr, span));
-        }
-        const inner_case = try builder.mkCase(arena, builder.mkVar("y", span), inner_alts.items);
-        try eftn_alts.append(arena, builder.mkAlt(outer_pat, inner_case, span));
-    }
-    const eftn_body = try builder.mkCase(arena, builder.mkVar("x", span), eftn_alts.items);
-    const eftn_match = try builder.mkMatch(
-        arena,
-        &.{ builder.mkVarPat("x", span), builder.mkVarPat("y", span) },
-        eftn_body,
-        span,
-    );
-    const eftn_fb = try builder.mkFunBind(arena, "enumFromThen", &.{eftn_match}, span);
-
-    // enumFromThenTo — explicit case enumeration for all three arguments.
-    // Produces the arithmetic sequence [Ck, C{k+step}, ...] up to Cm.
-    // Lists are built right-to-left to ensure correct element order.
-    var eftt_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
-    for (decl.constructors, 0..) |cx, x_idx| {
-        const outer_pat = try builder.mkConPat(arena, cx.name, &.{}, span);
-        var mid_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
-        for (decl.constructors, 0..) |cy, y_idx| {
-            const mid_pat = try builder.mkConPat(arena, cy.name, &.{}, span);
-            var inner_alts: std.ArrayListUnmanaged(ast.Alt) = .empty;
-            for (decl.constructors, 0..) |cz, z_idx| {
-                const inner_pat = try builder.mkConPat(arena, cz.name, &.{}, span);
-                const step: isize = @as(isize, @intCast(y_idx)) - @as(isize, @intCast(x_idx));
-                var list_expr: ast.Expr = .{ .List = &.{} };
-                if (step > 0) {
-                    // Ascending: build [Ck, C{k+step}, ...] right-to-left up to Cm
-                    var pos: usize = z_idx + 1;
-                    while (pos > x_idx) : (pos -= 1) {
-                        if ((pos - 1 - x_idx) % @as(usize, @intCast(step)) == 0) {
-                            const elem = builder.mkVar(decl.constructors[pos - 1].name, span);
-                            list_expr = try builder.mkInfix(arena, elem, ":", list_expr, span);
-                        }
-                    }
-                    // Always include the first element Ck
-                    const first = builder.mkVar(decl.constructors[x_idx].name, span);
-                    list_expr = try builder.mkInfix(arena, first, ":", list_expr, span);
-                } else if (step < 0) {
-                    // Descending: build [Ck, C{k+step}, ...] right-to-left down to Cm
-                    const abs_step = @as(usize, @intCast(-step));
-                    var pos: usize = 0;
-                    while (pos < x_idx) : (pos += 1) {
-                        if ((x_idx - pos) % abs_step == 0) {
-                            const elem = builder.mkVar(decl.constructors[pos].name, span);
-                            list_expr = try builder.mkInfix(arena, elem, ":", list_expr, span);
-                        }
-                    }
-                    // Always include the first element Ck
-                    const first = builder.mkVar(decl.constructors[x_idx].name, span);
-                    list_expr = try builder.mkInfix(arena, first, ":", list_expr, span);
-                } else {
-                    // step == 0: [x] (infinite repeat, cap at single element)
-                    const elem = builder.mkVar(cx.name, span);
-                    list_expr = try builder.mkInfix(arena, elem, ":", .{ .List = &.{} }, span);
-                }
-                try inner_alts.append(arena, builder.mkAlt(inner_pat, list_expr, span));
-            }
-            const inner_case = try builder.mkCase(arena, builder.mkVar("z", span), inner_alts.items);
-            try mid_alts.append(arena, builder.mkAlt(mid_pat, inner_case, span));
-        }
-        const mid_case = try builder.mkCase(arena, builder.mkVar("y", span), mid_alts.items);
-        try eftt_alts.append(arena, builder.mkAlt(outer_pat, mid_case, span));
-    }
-    const eftt_body = try builder.mkCase(arena, builder.mkVar("x", span), eftt_alts.items);
-    const eftt_match = try builder.mkMatch(
-        arena,
-        &.{ builder.mkVarPat("x", span), builder.mkVarPat("y", span), builder.mkVarPat("z", span) },
-        eftt_body,
-        span,
-    );
-    const eftt_fb = try builder.mkFunBind(arena, "enumFromThenTo", &.{eftt_match}, span);
-
     const applied = try builder.mkAppliedTypeCon(arena, decl.name, decl.tyvars, span);
     const head = try builder.mkInstanceHead(arena, "Enum", applied, span);
     const instance = try builder.mkInstance(
         arena,
         null,
         head,
-        &.{ from_fb, to_fb, succ_fb, pred_fb, ef_fb, eft_fb, eftn_fb, eftt_fb },
+        // Only the primitive methods; the four ranged enumerations are
+        // inherited from the Enum class defaults (issue #713).
+        &.{ from_fb, to_fb, succ_fb, pred_fb },
         span,
     );
     return .{ .helpers = &.{}, .instance = instance };

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -1195,6 +1195,10 @@ fn serialiseClassEnvIntoIface(
                 .name = .{ .base = m.name.base, .unique = m.name.unique.value },
                 .ty = s_ty,
                 .has_default = m.has_default,
+                .default_name = if (m.default_name) |dn|
+                    .{ .base = dn.base, .unique = dn.unique.value }
+                else
+                    null,
             };
         }
 
@@ -1279,6 +1283,10 @@ fn deserialiseClassEnvFromIface(
                 .name = .{ .base = sm.name.base, .unique = .{ .value = sm.name.unique } },
                 .ty = hty,
                 .has_default = sm.has_default,
+                .default_name = if (sm.default_name) |dn|
+                    .{ .base = dn.base, .unique = .{ .value = dn.unique } }
+                else
+                    null,
             };
         }
 

--- a/src/modules/mod_iface.zig
+++ b/src/modules/mod_iface.zig
@@ -234,6 +234,10 @@ pub const SerialisedMethodInfo = struct {
     name: SerialisedNameRef,
     ty: SerialisedCoreType,
     has_default: bool,
+    /// Compiled default-method binding name (mirrors `MethodInfo.default_name`).
+    /// `null` when the method has no default.  Carried across modules so a
+    /// downstream instance can reference the upstream default (issue #713).
+    default_name: ?SerialisedNameRef = null,
 };
 
 /// A JSON-serialisable class declaration (mirrors `class_env.ClassInfo`).
@@ -746,6 +750,10 @@ fn deepCopySerialisedMethodInfo(alloc: std.mem.Allocator, src: SerialisedMethodI
         .name = try deepCopySerialisedNameRef(alloc, src.name),
         .ty = try deepCopySerialisedCoreType(alloc, src.ty),
         .has_default = src.has_default,
+        .default_name = if (src.default_name) |dn|
+            try deepCopySerialisedNameRef(alloc, dn)
+        else
+            null,
     };
 }
 

--- a/src/typechecker/class_env.zig
+++ b/src/typechecker/class_env.zig
@@ -86,6 +86,17 @@ pub const MethodInfo = struct {
     ty: HType,
     /// Whether a default implementation exists.
     has_default: bool,
+    /// Name of the compiled default-method binding (e.g.
+    /// `default$Enum$enumFromTo`), or `null` if the method has no default.
+    ///
+    /// Populated during desugaring (`desugarClassDecl`) via
+    /// `ClassEnv.setDefaultName`, mirroring `ClassInfo.dict_con_name`.  Stored
+    /// here — rather than in a per-module map — so that an instance declared in
+    /// a *different* module from the class (e.g. a user `instance Enum Color`
+    /// against the Prelude's `Enum`) can still find the shared default binding's
+    /// unique.  The `ClassEnv` is serialised into the `.rhi` interface, so this
+    /// survives the module boundary.
+    default_name: ?Name = null,
 };
 
 // ── InstanceInfo ──────────────────────────────────────────────────────
@@ -165,6 +176,26 @@ pub const ClassEnv = struct {
             std.debug.panic("setDictConName: class {d} not found in ClassEnv", .{class_unique});
         };
         entry.dict_con_name = dict_con_name;
+    }
+
+    /// Record the compiled default-method binding name for one method of an
+    /// existing class.  Called by the desugarer after compiling the default
+    /// body, mirroring `setDictConName`.  Asserts that both the class and the
+    /// method exist.
+    pub fn setDefaultName(self: *ClassEnv, class_unique: u64, method_unique: u64, default_name: Name) void {
+        const entry = self.classes.getPtr(class_unique) orelse {
+            std.debug.panic("setDefaultName: class {d} not found in ClassEnv", .{class_unique});
+        };
+        for (entry.methods) |*m| {
+            if (m.name.unique.value == method_unique) {
+                // `methods` is stored as `[]const` but the backing slice is
+                // mutable (allocated during type inference); mutate in place to
+                // attach the default name, just as `dict_con_name` is set.
+                @constCast(m).default_name = default_name;
+                return;
+            }
+        }
+        std.debug.panic("setDefaultName: method {d} not found in class {d}", .{ method_unique, class_unique });
     }
 
     /// Register an instance declaration.

--- a/tests/e2e/e2e_713_enum_defaults.hs
+++ b/tests/e2e/e2e_713_enum_defaults.hs
@@ -1,0 +1,47 @@
+module Main where
+
+-- Test: Enum class default methods (issue #713).
+--
+-- The Enum class provides default implementations of enumFrom, enumFromTo,
+-- enumFromThen and enumFromThenTo in terms of succ, fromEnum and toEnum.
+--
+-- `Suit` defines ONLY the four primitive methods (succ, pred, toEnum,
+-- fromEnum) and gets the ranged enumerations for free from the defaults.
+data Suit = Clubs | Diamonds | Hearts | Spades
+
+instance Show Suit where
+  show Clubs    = "Clubs"
+  show Diamonds = "Diamonds"
+  show Hearts   = "Hearts"
+  show Spades   = "Spades"
+
+instance Enum Suit where
+  succ Clubs    = Diamonds
+  succ Diamonds = Hearts
+  succ Hearts   = Spades
+  succ Spades   = error "succ: Spades is maxBound for Suit"
+  pred Diamonds = Clubs
+  pred Hearts   = Diamonds
+  pred Spades   = Hearts
+  pred Clubs    = error "pred: Clubs is minBound for Suit"
+  toEnum 0 = Clubs
+  toEnum 1 = Diamonds
+  toEnum 2 = Hearts
+  toEnum 3 = Spades
+  toEnum _ = error "toEnum: out of range for Suit"
+  fromEnum Clubs    = 0
+  fromEnum Diamonds = 1
+  fromEnum Hearts   = 2
+  fromEnum Spades   = 3
+
+main :: IO ()
+main = do
+  -- enumFromTo from the class default, on the user instance.
+  putStrLn (show (enumFromTo Clubs Spades))
+  putStrLn (show (enumFromTo Diamonds Hearts))
+  putStrLn (show (enumFromTo Spades Clubs))
+  -- enumFromTo on the built-in Prelude instances, which now also rely on the
+  -- shared class defaults rather than per-instance copies.
+  putStrLn (show (enumFromTo False True))
+  putStrLn (show (enumFromTo LT GT))
+  putStrLn (show (enumFromTo 'a' 'e'))

--- a/tests/e2e/e2e_713_enum_defaults.stdout
+++ b/tests/e2e/e2e_713_enum_defaults.stdout
@@ -1,0 +1,6 @@
+[Clubs,Diamonds,Hearts,Spades]
+[Diamonds,Hearts]
+[]
+[False,True]
+[LT,EQ,GT]
+['a','b','c','d','e']

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -462,3 +462,7 @@ test "e2e: e2e_605_zero_field_thunk (#605)" {
 test "e2e: e2e_708_bounded_enum (#708)" {
     try testE2e(std.testing.allocator, "e2e_708_bounded_enum");
 }
+
+test "e2e: e2e_713_enum_defaults (#713)" {
+    try testE2e(std.testing.allocator, "e2e_713_enum_defaults");
+}


### PR DESCRIPTION
Closes #713

## Summary

Adds Haskell-2010 default implementations of `enumFrom`, `enumFromTo`,
`enumFromThen` and `enumFromThenTo` to the `Enum` class (`lib/Prelude.hs`),
expressed in terms of `succ`, `fromEnum` and `toEnum`. The `Char`/`Bool`/
`Ordering` Prelude instances now define only the four primitive methods and
inherit the ranged enumerations from the defaults. The `deriving` synthesiser
likewise emits only the four primitives, removing its previous O(n²)/O(n³)
explicit case-match code blow-up (the workaround #714 tracked).

## Root-cause analysis & fixes

The issue described an "OutOfMemory / infinite expansion". The actual failures
were two distinct, non-OOM bugs:

1. **Desugarer panic** `Variable step not found in type definitions`. Default
   and instance method bodies are not type-checked (`infer.zig` Pass 0a records
   only signatures), so binders introduced *inside* the body — `let` names like
   `step`, lambda params, `case`/`do` pattern vars — never reach
   `local_binders`. `registerPatBinders` already handled the equation's
   *argument* patterns; this PR adds `registerRhsBinders`/`registerExprBinders`
   to complete the same invariant over the body. The panic is removed by
   construction, not by a limit.

2. **Cross-module default lookup** (surfaced as a misleading `error.OutOfMemory`
   defensive fallback). The default-binding name lived in a per-`DesugarCtx`
   map, so a user `instance Enum Color` against the Prelude's `Enum` could not
   find the Prelude default. Moved it into `ClassEnv.MethodInfo.default_name`
   (mirroring the existing `dict_con_name`), which is serialised into the `.rhi`
   interface and therefore survives the module boundary. The per-ctx map is
   removed entirely.

## Deliverables

- [x] Haskell-2010 default impls for the four ranged `Enum` methods
- [x] Desugarer fix (root cause: missing binder registration for untyped
      bodies — not a depth limit)
- [x] Deriving synthesiser omits the four methods (now inherited from defaults)
- [x] e2e test with an `instance Enum` relying on the defaults
      (`tests/e2e/e2e_713_enum_defaults.hs`) + a desugarer unit test
- [x] Follow-up issues filed: #744, #745

## Testing

`nix develop --command zig build test --summary all`

```
Build Summary: 47/47 steps succeeded; 1018/1018 tests passed
+- run test e2e-tests 50 pass (50 total)
```

New `tests/e2e/e2e_713_enum_defaults.hs` exercises `enumFromTo` on a custom
4-constructor type that defines only `succ`/`pred`/`toEnum`/`fromEnum`, plus the
built-in `Bool`/`Ordering`/`Char` instances, all driven by the class defaults.

## Known limitations (follow-ups)

- #744 — GRIN→LLVM mistranslates `let`-bound names in untyped default/instance
  bodies (the `case` scrutinee resolves to garbage). Worked around by writing
  the `step` inline in the defaults.
- #745 — `enumFromThen`/`enumFromThenTo` defaults force `toEnum` one step past
  the limit for finite enums (the list values are correct). `enumFromTo` is
  unaffected (explicit equality stop).

#714 (switch derived `enumFromThen`/`enumFromThenTo` away from explicit
case-match) is effectively resolved by this PR, since the derived instance no
longer synthesises those methods at all.
