### PR TITLE
#734: cross-reference follow-up issue for multi-binding let-qualifier crash

### DIFF
--- a/src/renamer/renamer.zig
+++ b/src/renamer/renamer.zig
@@ -1458,6 +1458,11 @@ fn desugarListComp(
             } };
         },
         .LetQualifier => |decls| {
+            // NOTE: a `let` qualifier that binds MULTIPLE bindings currently
+            // miscompiles downstream and segfaults at runtime (the layout/parse
+            // here is correct; the bug is in the multi-binding Rec lowering path,
+            // same family as #664). Tracked in:
+            //   https://github.com/adinapoli/rusholme/issues/747
             const rest_expr = try desugarListComp(env, body, rest, lc_span);
             const body_p = try env.alloc.create(ast.Expr);
             body_p.* = rest_expr;


### PR DESCRIPTION
Follow-up to the merged PR #743 (issue #734) — process fixes requested in the "with fixes" review verdict.

PR #743 was merged before these review-process fixes landed, so this small follow-up carries them in.

## Summary
- Filed #747 for the latent runtime crash the layout fix exposed: a single `let` qualifier that
  binds MULTIPLE bindings (e.g. `let a = x; b = x + 1`) compiles but segfaults at runtime (exit 139),
  while GHC prints `[5,7]`. The crash is downstream of layout (layout/parse is correct, asserted by
  the #734 unit test); it lives in the multi-binding Rec lowering path, same family as #664 and the
  Rec-codegen single-binding-NonRec workaround.
- Added a cross-reference code comment near the `.LetQualifier` arm of `desugarListComp`
  (`src/renamer/renamer.zig`) pointing at #747.

## Testing
- `nix develop --command zig build` — clean.
- `nix develop --command zig build test --summary all` — all suites pass (comment-only change).
- Confirmed the repro: single-binding let-qualifier prints `[12,13]`; multi-binding segfaults (exit 139).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
