### PR TITLE
#737: Remove dead LeftSection/RightSection/Negate arms

### DIFF
--- a/src/core/desugar.zig
+++ b/src/core/desugar.zig
@@ -2403,12 +2403,6 @@ pub fn desugarExpr(ctx: *DesugarCtx, expr: renamer_mod.RExpr) std.mem.Allocator.
 
             node.* = app2.*;
         },
-        .LeftSection, .RightSection, .Negate => {
-            // The renamer rewrites operator sections to `Lambda + InfixApp`
-            // and `Negate` to `App(negate, e)` (Haskell 2010 §3.4 / §3.5),
-            // so these variants must never reach the Core desugarer.
-            std.debug.panic("desugar: unexpected RExpr variant {s} (renamer desugaring failed)", .{@tagName(expr)});
-        },
         .Tuple => {
             // Tuple expressions
             // tracked in: https://github.com/adinapoli/rusholme/issues/361

--- a/src/renamer/renamer.zig
+++ b/src/renamer/renamer.zig
@@ -330,8 +330,6 @@ pub const RExpr = union(enum) {
     Lit: ast.Literal,
     App: struct { fn_expr: *const RExpr, arg_expr: *const RExpr },
     InfixApp: struct { left: *const RExpr, op: Name, op_span: SourceSpan, right: *const RExpr },
-    LeftSection: struct { expr: *const RExpr, op: Name, op_span: SourceSpan },
-    RightSection: struct { op: Name, op_span: SourceSpan, expr: *const RExpr },
     Lambda: struct { params: []const Name, param_spans: []const SourceSpan, body: *const RExpr },
     Let: struct { binds: []const RDecl, body: *const RExpr },
     Case: struct { scrutinee: *const RExpr, alts: []const RAlt },
@@ -350,7 +348,6 @@ pub const RExpr = union(enum) {
     TypeAnn: struct { expr: *const RExpr, type: ast.Type },
     /// Type application: f @Int (GHC TypeApplications extension)
     TypeApp: struct { fn_expr: *const RExpr, type: ast.Type, span: SourceSpan },
-    Negate: *const RExpr,
     Paren: *const RExpr,
     /// Record construction: Point { x = 1, y = 2 }
     RecordCon: struct { con: Name, fields: []const RFieldUpdate },

--- a/src/typechecker/decl_groups.zig
+++ b/src/typechecker/decl_groups.zig
@@ -58,18 +58,6 @@ fn collectExprVarRefs(
             }
             try collectExprVarRefs(ia.right.*, top_level, refs, alloc);
         },
-        .LeftSection => |ls| {
-            try collectExprVarRefs(ls.expr.*, top_level, refs, alloc);
-            if (top_level.contains(ls.op.unique.value)) {
-                try refs.append(alloc, ls.op.unique.value);
-            }
-        },
-        .RightSection => |rs| {
-            if (top_level.contains(rs.op.unique.value)) {
-                try refs.append(alloc, rs.op.unique.value);
-            }
-            try collectExprVarRefs(rs.expr.*, top_level, refs, alloc);
-        },
         .Lambda => |lam| {
             try collectExprVarRefs(lam.body.*, top_level, refs, alloc);
         },
@@ -126,7 +114,6 @@ fn collectExprVarRefs(
         },
         .TypeAnn => |ta| try collectExprVarRefs(ta.expr.*, top_level, refs, alloc),
         .TypeApp => |ta| try collectExprVarRefs(ta.fn_expr.*, top_level, refs, alloc),
-        .Negate => |e| try collectExprVarRefs(e.*, top_level, refs, alloc),
         .Paren => |e| try collectExprVarRefs(e.*, top_level, refs, alloc),
         .RecordCon => |rc| {
             for (rc.fields) |f| try collectExprVarRefs(f.expr, top_level, refs, alloc);

--- a/src/typechecker/infer.zig
+++ b/src/typechecker/infer.zig
@@ -865,8 +865,6 @@ fn getExprSpan(expr: RExpr) SourceSpan {
         .EnumFromThenTo => |e| e.span,
         .TypeApp => |tapp| tapp.span,
         .InfixApp => |ia| ia.op_span,
-        .LeftSection => |ls| ls.op_span,
-        .RightSection => |rs| rs.op_span,
         else => syntheticSpan(),
     };
 }
@@ -1458,59 +1456,6 @@ pub fn infer(ctx: *InferCtx, expr: RExpr) std.mem.Allocator.Error!*HType {
             break :blk res_ty;
         },
 
-        // ── Sections ─────────────────────────────────────────────────
-        .LeftSection => |ls| blk: {
-            const op_scheme = ctx.env.lookupScheme(ls.op.unique);
-            const op_ty = if (op_scheme) |s| blk2: {
-                const inst = try s.instantiate(ctx.alloc, ctx.mv_supply);
-                for (inst.wanted) |wc| {
-                    try ctx.wanted_constraints.append(ctx.alloc, .{ .Class = .{
-                        .class_name = wc.class_name,
-                        .ty = wc.ty,
-                        .span = ls.op_span,
-                        .var_unique = ls.op.unique,
-                    } });
-                }
-                break :blk2 try ctx.alloc_ty(inst.ty);
-            } else
-                try ctx.freshMeta();
-
-            const expr_ty = try infer(ctx, ls.expr.*);
-            const right_ty = try ctx.freshMeta();
-            const res_ty = try ctx.freshMeta();
-
-            const inner = try ctx.alloc_ty(HType{ .Fun = .{ .arg = right_ty, .res = res_ty } });
-            const expected = try ctx.alloc_ty(HType{ .Fun = .{ .arg = expr_ty, .res = inner } });
-            try ctx.unifyNow(op_ty, expected, ls.op_span);
-            break :blk ctx.alloc_ty(HType{ .Fun = .{ .arg = right_ty, .res = res_ty } });
-        },
-
-        .RightSection => |rs| blk: {
-            const op_scheme = ctx.env.lookupScheme(rs.op.unique);
-            const op_ty = if (op_scheme) |s| blk2: {
-                const inst = try s.instantiate(ctx.alloc, ctx.mv_supply);
-                for (inst.wanted) |wc| {
-                    try ctx.wanted_constraints.append(ctx.alloc, .{ .Class = .{
-                        .class_name = wc.class_name,
-                        .ty = wc.ty,
-                        .span = rs.op_span,
-                        .var_unique = rs.op.unique,
-                    } });
-                }
-                break :blk2 try ctx.alloc_ty(inst.ty);
-            } else
-                try ctx.freshMeta();
-
-            const expr_ty = try infer(ctx, rs.expr.*);
-            const left_ty = try ctx.freshMeta();
-            const res_ty = try ctx.freshMeta();
-
-            const inner = try ctx.alloc_ty(HType{ .Fun = .{ .arg = expr_ty, .res = res_ty } });
-            const expected = try ctx.alloc_ty(HType{ .Fun = .{ .arg = left_ty, .res = inner } });
-            try ctx.unifyNow(op_ty, expected, rs.op_span);
-            break :blk ctx.alloc_ty(HType{ .Fun = .{ .arg = left_ty, .res = res_ty } });
-        },
-
         // ── TypeAnn ───────────────────────────────────────────────────
         //
         // Γ ⊢ e : τ'    τ' ~ τ_ann
@@ -1544,25 +1489,6 @@ pub fn infer(ctx: *InferCtx, expr: RExpr) std.mem.Allocator.Error!*HType {
             _ = try astTypeToHType(ta.type, ctx); // Convert but ignore for now
             const fn_ty = try infer(ctx, ta.fn_expr.*);
             break :blk fn_ty;
-        },
-
-        // ── Negate ────────────────────────────────────────────────────
-        .Negate => |inner| blk: {
-            const inner_ty = try infer(ctx, inner.*);
-            const int_node = try ctx.alloc_ty(intTy());
-            // Use span from inner expression for better error messages
-            const neg_span = switch (inner.*) {
-                .Var => |v| v.span,
-                .Lit => |l| l.getSpan(),
-                .EnumFrom => |e| e.span,
-                .EnumFromThen => |e| e.span,
-                .EnumFromTo => |e| e.span,
-                .EnumFromThenTo => |e| e.span,
-                .TypeApp => |ta| ta.span,
-                else => syntheticSpan(),
-            };
-            try ctx.unifyNow(inner_ty, int_node, neg_span);
-            break :blk int_node;
         },
 
         // ── Arithmetic sequences (Haskell 2010 §3.10) ────────────────


### PR DESCRIPTION
Closes #737

## Summary
After #736 the renamer rewrites surface-AST operator sections into `Lambda + InfixApp` and unary negation into `App(negate, e)` (Haskell 2010 §3.4/§3.5) *before* it constructs the renamer `RExpr`. As a result the renamer never builds `RExpr.LeftSection`, `RExpr.RightSection`, or `RExpr.Negate`, so those three variants — and every downstream arm that consumed them — are dead code.

This PR takes the aggressive cleanup (issue option 2): it deletes the three `RExpr` variants outright together with their now-unreachable consumer arms. Removing the variants lets Zig's exhaustiveness checking enforce the invariant directly, so no `unreachable` placeholders are required.

Net effect: 96 lines deleted, 0 added. No behaviour change.

## How each arm was verified unreachable
- The renamer's `renameExpr` switches on the **surface** `ast.Expr`. Its `.LeftSection`/`.RightSection`/`.Negate` arms `return try renameExpr(<rewritten>, env)` — they construct lambdas/`InfixApp`/`App(negate,…)` and never produce the `RExpr` equivalents.
- `grep` confirms the only construction sites of `LeftSection`/`RightSection` are in `parser.zig` (surface AST) and one renamer test (surface AST). Nothing constructs the renamer `RExpr` variants.
- `RPat.Negate` (negative-literal patterns) is a **distinct** variant, still produced by the renamer and consumed by `inferPat`/`applyPat`/etc. It is reachable and was deliberately left untouched.

## Deliverables
- [x] Remove dead `.LeftSection`/`.RightSection` arms in `src/typechecker/infer.zig` (`infer` + `getExprSpan`)
- [x] Remove dead `.Negate` arm in `src/typechecker/infer.zig` (`infer`)
- [x] Remove dead section arms in `src/typechecker/decl_groups.zig` (`collectExprVarRefs`)
- [x] Remove the now-redundant `desugarExpr` panic guard in `src/core/desugar.zig`
- [x] Remove the three `RExpr` variants from `src/renamer/renamer.zig`
- [x] Confirm sections/negate still work end-to-end

## Testing
- `nix develop --command zig build` — clean.
- `nix develop --command zig build test --summary all` — green (839 unit tests; golden 26; parser 76; compile-fail 2; runtime 15; e2e 49; pkg-cmd 8; repl-tests pass). Overall exit code 0.
- End-to-end coverage already exists in `tests/e2e/ghc_010_sections_negate.hs`: left section `(+ 1)`, right section `(10 -)`, `negate`, bare negation `-5`, parenthesised `(- 9)`, and `map (+ 10) [1,2,3]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
