### PR TITLE
#755: rhc build -O<level> + LLVM mid-level optimiser

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -55,6 +55,33 @@ zig build run -- ll     FILE.hs   # emit LLVM IR
 zig build run -- build  FILE.hs   # compile to native executable
 ```
 
+### Optimisation Levels
+
+`rhc build` accepts an `-O <level>` flag with the same syntax as Clang:
+
+| Flag   | Mid-level pipeline | Back-end (`LLVMCodeGenOptLevel`) | Notes |
+|--------|--------------------|----------------------------------|-------|
+| `-O0`  | (skipped)          | `None`                           | Fast compile, no optimisation. |
+| `-O1`  | `default<O1>`      | `Less`                           | Light optimisation. |
+| `-O2`  | `default<O2>`      | `Default`                        | **Default for `rhc build`.** Good speed/size balance. |
+| `-O3`  | `default<O3>`      | `Aggressive`                     | Aggressive inlining + vectorisation. |
+| `-Os`  | `default<Os>`      | `Default`                        | Optimise for size. |
+| `-Oz`  | `default<Oz>`      | `Default`                        | Optimise for size, even more aggressively. |
+
+The mid-level optimiser is invoked via LLVM's new pass manager
+(`LLVMRunPasses` from `llvm-c/Transforms/PassBuilder.h`). At `-O0` the
+optimiser is skipped entirely so debug builds stay fast.
+
+```bash
+rhc build -O2 prog.hs            # native, -O2 (default)
+rhc build -O0 prog.hs            # native, no optimisation
+rhc build -O3 prog.hs -o fast    # native, aggressive
+rhc build -Os prog.hs            # native, size-optimised
+```
+
+The REPL JIT engine keeps `-O0` for fast iteration; this flag affects
+`rhc build` only.
+
 ## WASM REPL (Browser-based Demo)
 
 Rusholme includes a browser-based REPL built with WebAssembly for live Haskell

--- a/src/backend/llvm.zig
+++ b/src/backend/llvm.zig
@@ -17,6 +17,8 @@ const llvm_c = @cImport({
     @cInclude("llvm-c/Orc.h");
     @cInclude("llvm-c/LLJIT.h");
     @cInclude("llvm-c/OrcEE.h");
+    @cInclude("llvm-c/Error.h");
+    @cInclude("llvm-c/Transforms/PassBuilder.h");
 });
 
 // Import C stdio for file I/O
@@ -323,12 +325,89 @@ pub const TargetError = error{
     TargetLookupFailed,
     TargetMachineCreationFailed,
     EmitFailed,
+    PassPipelineFailed,
 };
 
-/// Create a target machine for the native (host) architecture.
-/// Returns both the machine and the target triple string (caller must
-/// dispose both via `disposeTargetMachine` and `LLVMDisposeMessage`).
-pub fn createNativeTargetMachine() TargetError!TargetMachine {
+/// Optimisation level selected by the user (`-O<level>` on `rhc build`).
+///
+/// Mirrors Clang's familiar syntax. The mapping to LLVM is:
+///
+/// | Level | Code-gen (`LLVMCodeGenOptLevel`) | Mid-level pipeline string |
+/// |-------|----------------------------------|---------------------------|
+/// | `O0`  | `None`                           | `default<O0>`             |
+/// | `O1`  | `Less`                           | `default<O1>`             |
+/// | `O2`  | `Default`                        | `default<O2>`             |
+/// | `O3`  | `Aggressive`                     | `default<O3>`             |
+/// | `Os`  | `Default`                        | `default<Os>`             |
+/// | `Oz`  | `Default`                        | `default<Oz>`             |
+///
+/// The mid-level pipeline is run via `runOptimizationPasses` before object
+/// emission (see `LLVMRunPasses` from `llvm-c/Transforms/PassBuilder.h`).
+pub const OptLevel = enum {
+    O0,
+    O1,
+    O2,
+    O3,
+    Os,
+    Oz,
+
+    /// Parse the textual form of an `-O` flag.  Accepts `0|1|2|3|s|z`,
+    /// matching Clang. Returns `null` on unknown input.
+    pub fn parse(text: []const u8) ?OptLevel {
+        if (text.len != 1) return null;
+        return switch (text[0]) {
+            '0' => .O0,
+            '1' => .O1,
+            '2' => .O2,
+            '3' => .O3,
+            's' => .Os,
+            'z' => .Oz,
+            else => null,
+        };
+    }
+
+    /// Short textual form (e.g. `"2"`, `"s"`). Used in `-O<level>` echoes.
+    pub fn shortName(self: OptLevel) []const u8 {
+        return switch (self) {
+            .O0 => "0",
+            .O1 => "1",
+            .O2 => "2",
+            .O3 => "3",
+            .Os => "s",
+            .Oz => "z",
+        };
+    }
+
+    /// Map to LLVM's `LLVMCodeGenOptLevel` enum for target-machine creation.
+    /// `Os`/`Oz` map to `Default` because the size-optimisation lives in the
+    /// mid-level pipeline (`default<Os>`/`default<Oz>`), not the back-end.
+    fn codeGenLevel(self: OptLevel) llvm_c.LLVMCodeGenOptLevel {
+        return switch (self) {
+            .O0 => llvm_c.LLVMCodeGenLevelNone,
+            .O1 => llvm_c.LLVMCodeGenLevelLess,
+            .O2, .Os, .Oz => llvm_c.LLVMCodeGenLevelDefault,
+            .O3 => llvm_c.LLVMCodeGenLevelAggressive,
+        };
+    }
+
+    /// `opt`-style pipeline string accepted by `LLVMRunPasses`.
+    fn pipelineString(self: OptLevel) [:0]const u8 {
+        return switch (self) {
+            .O0 => "default<O0>",
+            .O1 => "default<O1>",
+            .O2 => "default<O2>",
+            .O3 => "default<O3>",
+            .Os => "default<Os>",
+            .Oz => "default<Oz>",
+        };
+    }
+};
+
+/// Create a target machine for the native (host) architecture at the
+/// given optimisation level.
+///
+/// Caller must dispose with `disposeTargetMachine`.
+pub fn createNativeTargetMachine(opt: OptLevel) TargetError!TargetMachine {
     const triple = llvm_c.LLVMGetDefaultTargetTriple();
     defer llvm_c.LLVMDisposeMessage(triple);
 
@@ -345,7 +424,7 @@ pub fn createNativeTargetMachine() TargetError!TargetMachine {
         triple,
         "generic", // CPU
         "", // features
-        llvm_c.LLVMCodeGenLevelDefault,
+        opt.codeGenLevel(),
         llvm_c.LLVMRelocPIC,
         llvm_c.LLVMCodeModelDefault,
     );
@@ -355,9 +434,10 @@ pub fn createNativeTargetMachine() TargetError!TargetMachine {
     return machine;
 }
 
-/// Create a target machine for WebAssembly (wasm32-wasi).
-/// Used by the WASM backend to compile Haskell to .wasm binaries.
-pub fn createWasmTargetMachine() TargetError!TargetMachine {
+/// Create a target machine for WebAssembly (wasm32-wasi) at the given
+/// optimisation level.  Used by the WASM backend to compile Haskell to
+/// `.wasm` binaries.
+pub fn createWasmTargetMachine(opt: OptLevel) TargetError!TargetMachine {
     // Use wasm32-wasi for WASI-compliant WebAssembly
     const triple = "wasm32-wasi";
 
@@ -374,7 +454,7 @@ pub fn createWasmTargetMachine() TargetError!TargetMachine {
         triple.ptr,
         "generic", // CPU
         "", // features (could add "+bulk-memory,+sign-ext" for optimization)
-        llvm_c.LLVMCodeGenLevelDefault,
+        opt.codeGenLevel(),
         llvm_c.LLVMRelocStatic, // Static relocation for WASM
         llvm_c.LLVMCodeModelDefault,
     );
@@ -382,6 +462,35 @@ pub fn createWasmTargetMachine() TargetError!TargetMachine {
     if (machine == null) return error.TargetMachineCreationFailed;
 
     return machine;
+}
+
+/// Run the LLVM mid-level optimiser on `module` at the requested level.
+///
+/// Uses the new pass manager via `LLVMRunPasses` (LLVM ≥ 13), invoking
+/// the canonical `default<O...>` pipeline.  For `-O0` this is a no-op:
+/// we skip the call entirely so we don't pay for pass-builder setup.
+///
+/// Errors from the pass pipeline are surfaced as `PassPipelineFailed`
+/// with a stderr message; this is appropriate because a failing
+/// optimisation pipeline indicates a compiler bug, not user error.
+pub fn runOptimizationPasses(
+    module: Module,
+    machine: TargetMachine,
+    opt: OptLevel,
+) TargetError!void {
+    if (opt == .O0) return;
+
+    const options = llvm_c.LLVMCreatePassBuilderOptions();
+    defer llvm_c.LLVMDisposePassBuilderOptions(options);
+
+    const pipeline = opt.pipelineString();
+    const err = llvm_c.LLVMRunPasses(module, pipeline.ptr, machine, options);
+    if (err != null) {
+        const msg = llvm_c.LLVMGetErrorMessage(err);
+        defer llvm_c.LLVMDisposeErrorMessage(msg);
+        std.log.err("LLVM pass pipeline '{s}' failed: {s}", .{ pipeline, msg });
+        return error.PassPipelineFailed;
+    }
 }
 
 /// Set a custom target triple on a module (for cross-compilation).
@@ -540,6 +649,38 @@ pub fn linkModules(dest: Module, src: Module) TargetError!void {
     if (llvm_c.LLVMLinkModules2(dest, src) != 0) {
         return error.EmitFailed;
     }
+}
+
+test "OptLevel.parse: accepts the six Clang-style levels" {
+    try std.testing.expectEqual(OptLevel.O0, OptLevel.parse("0").?);
+    try std.testing.expectEqual(OptLevel.O1, OptLevel.parse("1").?);
+    try std.testing.expectEqual(OptLevel.O2, OptLevel.parse("2").?);
+    try std.testing.expectEqual(OptLevel.O3, OptLevel.parse("3").?);
+    try std.testing.expectEqual(OptLevel.Os, OptLevel.parse("s").?);
+    try std.testing.expectEqual(OptLevel.Oz, OptLevel.parse("z").?);
+}
+
+test "OptLevel.parse: rejects malformed and unknown levels" {
+    try std.testing.expect(OptLevel.parse("") == null);
+    try std.testing.expect(OptLevel.parse("4") == null);
+    try std.testing.expect(OptLevel.parse("S") == null); // case-sensitive: only lowercase
+    try std.testing.expect(OptLevel.parse("O2") == null); // user supplies just "2"
+    try std.testing.expect(OptLevel.parse("fast") == null);
+}
+
+test "OptLevel.shortName: round-trips parse" {
+    inline for ([_]OptLevel{ .O0, .O1, .O2, .O3, .Os, .Oz }) |lvl| {
+        try std.testing.expectEqual(lvl, OptLevel.parse(lvl.shortName()).?);
+    }
+}
+
+test "OptLevel.pipelineString: well-formed for every level" {
+    try std.testing.expectEqualStrings("default<O0>", OptLevel.O0.pipelineString());
+    try std.testing.expectEqualStrings("default<O1>", OptLevel.O1.pipelineString());
+    try std.testing.expectEqualStrings("default<O2>", OptLevel.O2.pipelineString());
+    try std.testing.expectEqualStrings("default<O3>", OptLevel.O3.pipelineString());
+    try std.testing.expectEqualStrings("default<Os>", OptLevel.Os.pipelineString());
+    try std.testing.expectEqualStrings("default<Oz>", OptLevel.Oz.pipelineString());
 }
 
 // Note: LLVM tests require C headers and libc, which are not available

--- a/src/backend/native.zig
+++ b/src/backend/native.zig
@@ -26,8 +26,13 @@ const emit = struct {
 
         const llvm_module = try translator.translateProgramToModule(context.grin_program.*);
 
-        // Emit object file using LLVM target machine
-        const machine = llvm.createNativeTargetMachine() catch |err| {
+        // Emit object file using LLVM target machine.
+        //
+        // This Backend-interface path is not used by `rhc build` today —
+        // that goes through `emitNative` in main.zig, which threads an
+        // explicit `-O<level>` flag.  Keep the legacy behaviour (no
+        // mid-level passes) here by selecting `.O0`.
+        const machine = llvm.createNativeTargetMachine(.O0) catch |err| {
             std.log.err("Failed to create target machine: {}", .{err});
             return error.TargetMachineFailed;
         };

--- a/src/backend/wasm.zig
+++ b/src/backend/wasm.zig
@@ -35,8 +35,12 @@ const emit = struct {
 
         const llvm_module = try translator.translateProgramToModule(context.grin_program.*);
 
-        // Create target machine for WebAssembly (wasm32-wasi)
-        const machine = llvm.createWasmTargetMachine() catch |err| {
+        // Create target machine for WebAssembly (wasm32-wasi).
+        //
+        // This Backend-interface path is not used by `rhc build` today —
+        // that goes through `emitWasm` in main.zig, which threads an
+        // explicit `-O<level>` flag.  Keep the legacy behaviour here.
+        const machine = llvm.createWasmTargetMachine(.O0) catch |err| {
             std.log.err("Failed to create WebAssembly target machine: {}", .{err});
             return error.TargetMachineFailed;
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -224,6 +224,7 @@ pub fn main(init: std.process.Init) !void {
             const build_params = comptime clap.parseParamsComptime(
                 \\-h, --help                   Display this help and exit.
                 \\-o, --output <str>           Output file name (default: stem of first input).
+                \\-O, --opt-level <str>        Optimisation level: 0|1|2|3|s|z (default: 2 for native, 0 otherwise).
                 \\    --backend <str>          Backend: native (default), jit, wasm, c.
                 \\    --package-db <str>...    Package database path (may be repeated).
                 \\    --repl                   Compile for REPL use (internal).
@@ -237,6 +238,7 @@ pub fn main(init: std.process.Init) !void {
             const build_params_help = comptime clap.parseParamsComptime(
                 \\-h, --help                   Display this help and exit.
                 \\-o, --output <str>           Output file name (default: stem of first input).
+                \\-O, --opt-level <str>        Optimisation level: 0|1|2|3|s|z (default: 2 for native, 0 otherwise).
                 \\    --backend <str>          Backend: native (default), jit, wasm, c.
                 \\    --package-db <str>...    Package database path (may be repeated).
                 \\<str>...
@@ -283,6 +285,27 @@ pub fn main(init: std.process.Init) !void {
             const out = build_res.args.output orelse
                 std.fs.path.stem(std.fs.path.basename(file_paths[0]));
 
+            // Parse `-O <level>` if supplied; otherwise pick the per-backend
+            // default. Native binaries default to `-O2` so that compute-bound
+            // microbenchmarks aren't sandbagged by the unoptimised mid-level
+            // pipeline (epic #754, Track A1).  Other backends keep `-O0` for
+            // fast iteration / debug builds.
+            const opt_level: rusholme.backend.llvm.OptLevel = if (build_res.args.@"opt-level") |level_str|
+                rusholme.backend.llvm.OptLevel.parse(level_str) orelse {
+                    var buf: [512]u8 = undefined;
+                    var fw: File.Writer = .init(.stderr(), io, &buf);
+                    try fw.interface.print(
+                        "rhc build: invalid optimisation level '{s}'\nValid levels: 0, 1, 2, 3, s, z\n",
+                        .{level_str},
+                    );
+                    try fw.interface.flush();
+                    std.process.exit(1);
+                }
+            else switch (backend_kind) {
+                .native => rusholme.backend.llvm.OptLevel.O2,
+                .jit, .wasm, .c => rusholme.backend.llvm.OptLevel.O0,
+            };
+
             return cmdBuild(
                 allocator,
                 io,
@@ -291,6 +314,7 @@ pub fn main(init: std.process.Init) !void {
                 backend_kind,
                 build_res.args.repl != 0,
                 build_res.args.@"package-db",
+                opt_level,
             );
         },
 
@@ -920,7 +944,7 @@ fn loadPrelude(
 /// - native: compiles to native executable via LLVM
 /// - wasm: compiles to WebAssembly binary (.wasm)
 /// - jit, c: not yet implemented
-fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8, output_name: []const u8, backend_kind: rusholme.backend.backend_mod.BackendKind, is_repl: bool, package_dbs: []const []const u8) !void {
+fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8, output_name: []const u8, backend_kind: rusholme.backend.backend_mod.BackendKind, is_repl: bool, package_dbs: []const []const u8, opt_level: rusholme.backend.llvm.OptLevel) !void {
     // REPL mode placeholder - for WASM backend compiles stateful REPL
     _ = is_repl;
 
@@ -1078,9 +1102,9 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
 
     // ── Dispatch to backend-specific emission ─────────────────────────────
     switch (backend_kind) {
-        .native => try emitNative(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name),
-        .jit => try emitJit(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name),
-        .wasm => try emitWasm(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name),
+        .native => try emitNative(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level),
+        .jit => try emitJit(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level),
+        .wasm => try emitWasm(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level),
         .c => {
             var stderr_buf: [4096]u8 = undefined;
             var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
@@ -1103,6 +1127,7 @@ fn emitNative(
     per_module_grin: []const rusholme.grin.ast.Program,
     all_grin: rusholme.grin.ast.Program,
     output_name: []const u8,
+    opt_level: rusholme.backend.llvm.OptLevel,
 ) !void {
     const llvm = rusholme.backend.llvm;
     var arena = std.heap.ArenaAllocator.init(allocator);
@@ -1200,8 +1225,8 @@ fn emitNative(
         break :blk dest;
     };
 
-    // ── Emit object file ───────────────────────────────────────────────
-    const machine = llvm.createNativeTargetMachine() catch |err| {
+    // ── Create target machine at the requested optimisation level ──────
+    const machine = llvm.createNativeTargetMachine(opt_level) catch |err| {
         var stderr_buf: [4096]u8 = undefined;
         var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
         const stderr = &stderr_fw.interface;
@@ -1213,6 +1238,21 @@ fn emitNative(
 
     llvm.setModuleDataLayout(linked_mod, machine);
     llvm.setModuleTriple(linked_mod);
+
+    // ── Run the LLVM mid-level optimiser (no-op at -O0) ────────────────
+    // Without this, the back-end's `LLVMCodeGenOptLevel` setting alone
+    // produces essentially unoptimised code, because the front-end IR
+    // emitted by `grin_to_llvm` is highly redundant (every Bind becomes
+    // a fresh alloca + load/store). Running the new pass manager here
+    // is the difference between O0 and O2 output (epic #754, Track A1).
+    llvm.runOptimizationPasses(linked_mod, machine, opt_level) catch |err| {
+        var stderr_buf: [4096]u8 = undefined;
+        var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
+        const stderr = &stderr_fw.interface;
+        try stderr.print("rhc: LLVM optimisation pipeline failed: {}\n", .{err});
+        try stderr.flush();
+        std.process.exit(1);
+    };
 
     const obj_path = try std.fmt.allocPrint(arena_alloc, "{s}.o", .{output_name});
 
@@ -1270,6 +1310,7 @@ fn emitJit(
     per_module_grin: []const rusholme.grin.ast.Program,
     all_grin: rusholme.grin.ast.Program,
     output_name: []const u8,
+    opt_level: rusholme.backend.llvm.OptLevel,
 ) !void {
     _ = session;
     const llvm = rusholme.backend.llvm;
@@ -1345,7 +1386,7 @@ fn emitJit(
 
     // ── Set native target layout ────────────────────────────────────────
     // lli accepts bitcode/IR compiled for the host architecture.
-    const machine = llvm.createNativeTargetMachine() catch |err| {
+    const machine = llvm.createNativeTargetMachine(opt_level) catch |err| {
         var stderr_buf: [4096]u8 = undefined;
         var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
         const stderr = &stderr_fw.interface;
@@ -1409,6 +1450,18 @@ fn emitJit(
     // attributes are unnecessary — strip them before emitting the IR.
     llvm.stripTargetAttributes(linked_mod);
 
+    // ── Run the LLVM mid-level optimiser (no-op at -O0) ────────────────
+    // The default for the JIT backend is `-O0` so this is normally a
+    // no-op, but if the user passed `-O<n>` we honour it.
+    llvm.runOptimizationPasses(linked_mod, machine, opt_level) catch |err| {
+        var stderr_buf: [4096]u8 = undefined;
+        var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
+        const stderr = &stderr_fw.interface;
+        try stderr.print("rhc: LLVM optimisation pipeline failed: {}\n", .{err});
+        try stderr.flush();
+        std.process.exit(1);
+    };
+
     // ── Write final LLVM IR ────────────────────────────────────────────
     // We emit textual IR (.ll) rather than bitcode (.bc) because Zig
     // embeds its own LLVM build whose bitcode format may be incompatible
@@ -1434,6 +1487,7 @@ fn emitWasm(
     per_module_grin: []const rusholme.grin.ast.Program,
     all_grin: rusholme.grin.ast.Program,
     output_name: []const u8,
+    opt_level: rusholme.backend.llvm.OptLevel,
 ) !void {
     _ = session; // Unused for WASM backend
     const llvm = rusholme.backend.llvm;
@@ -1511,7 +1565,7 @@ fn emitWasm(
     };
 
     // ── Create target machine for WebAssembly ───────────────────────────
-    const machine = llvm.createWasmTargetMachine() catch |err| {
+    const machine = llvm.createWasmTargetMachine(opt_level) catch |err| {
         var stderr_buf: [4096]u8 = undefined;
         var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
         const stderr = &stderr_fw.interface;
@@ -1524,6 +1578,16 @@ fn emitWasm(
     // Set module target triple and data layout for WASM
     llvm.setModuleTargetTriple(linked_mod, "wasm32-wasi");
     llvm.setModuleDataLayout(linked_mod, machine);
+
+    // ── Run the LLVM mid-level optimiser (no-op at -O0) ────────────────
+    llvm.runOptimizationPasses(linked_mod, machine, opt_level) catch |err| {
+        var stderr_buf: [4096]u8 = undefined;
+        var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
+        const stderr = &stderr_fw.interface;
+        try stderr.print("rhc: LLVM optimisation pipeline failed: {}\n", .{err});
+        try stderr.flush();
+        std.process.exit(1);
+    };
 
     // ── Emit bitcode and link with wasm-ld ─────────────────────────────────
     // We use wasm-ld instead of direct emission to get proper WASI-compliant

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -130,6 +130,9 @@ fn printIndented(text: []const u8) void {
 /// optionally stderr). Returns true on success, false on any testable
 /// failure (wrong output, wrong exit code, compile error). Infrastructure
 /// errors (spawn failure, OOM) are propagated as errors.
+///
+/// `opt_flag` is an optional `-O<level>` to pass to `rhc build`. Passing
+/// `null` exercises the CLI default (which is currently `-O2` for native).
 fn runTest(
     allocator: std.mem.Allocator,
     comptime hs_path: []const u8,
@@ -137,6 +140,7 @@ fn runTest(
     expected_exit: u8,
     expected_stderr: ?[]const u8,
     quiet: bool,
+    opt_flag: ?[]const u8,
 ) !bool {
     const io = std.testing.io;
     const rhc_path = e2e_options.rhc_path;
@@ -154,9 +158,27 @@ fn runTest(
     defer allocator.free(binary_path);
 
     // ── Step 1: Compile ───────────────────────────────────────────────────────
-    const compile_argv = [_][]const u8{ rhc_path, "build", hs_path, "-o", binary_path };
+    // Build argv with an optional `-O<level>` flag.  The flag must come
+    // before the positional source path so clap parses it correctly.
+    var argv_buf: [6][]const u8 = undefined;
+    var argv_len: usize = 0;
+    argv_buf[argv_len] = rhc_path;
+    argv_len += 1;
+    argv_buf[argv_len] = "build";
+    argv_len += 1;
+    if (opt_flag) |flag| {
+        argv_buf[argv_len] = flag;
+        argv_len += 1;
+    }
+    argv_buf[argv_len] = hs_path;
+    argv_len += 1;
+    argv_buf[argv_len] = "-o";
+    argv_len += 1;
+    argv_buf[argv_len] = binary_path;
+    argv_len += 1;
+    const compile_argv = argv_buf[0..argv_len];
     const compile_result = try process.run(allocator, io, .{
-        .argv = &compile_argv,
+        .argv = compile_argv,
     });
     defer allocator.free(compile_result.stdout);
     defer allocator.free(compile_result.stderr);
@@ -234,6 +256,17 @@ fn runTest(
 // ── Public test helper ────────────────────────────────────────────────────────
 
 fn testE2e(allocator: std.mem.Allocator, comptime basename: []const u8) !void {
+    return testE2eOpt(allocator, basename, null);
+}
+
+/// Like `testE2e` but additionally passes `-O<level>` to `rhc build`.
+/// Used by the `-O2` smoke test below to verify the LLVM mid-level
+/// optimiser is invoked without crashing.
+fn testE2eOpt(
+    allocator: std.mem.Allocator,
+    comptime basename: []const u8,
+    opt_flag: ?[]const u8,
+) !void {
     const props = try readProperties(allocator, basename);
     defer props.deinit(allocator);
     if (props.skip) return;
@@ -248,6 +281,7 @@ fn testE2e(allocator: std.mem.Allocator, comptime basename: []const u8) !void {
         props.exit_code,
         props.expected_stderr,
         props.xfail,
+        opt_flag,
     );
 
     if (props.xfail) {
@@ -477,4 +511,40 @@ test "e2e: e2e_713_enum_defaults (#713)" {
 
 test "e2e: ghc_744_let_in_default_body (#744)" {
     try testE2e(std.testing.allocator, "ghc_744_let_in_default_body");
+}
+
+// ── Optimisation-level smoke tests (#755) ────────────────────────────────────
+//
+// These verify that the `-O<level>` flag actually flows through `rhc build`
+// to LLVM's mid-level optimiser without crashing.  They are a smoke check —
+// not a performance assertion — and reuse the simplest e2e program so we
+// can be sure any failure is in the optimisation path, not user code.
+
+test "e2e: -O2 invokes LLVM mid-level optimiser without crashing (#755)" {
+    try testE2eOpt(std.testing.allocator, "e2e_001_hello", "-O2");
+}
+
+test "e2e: -O0 disables LLVM mid-level optimiser (#755)" {
+    try testE2eOpt(std.testing.allocator, "e2e_001_hello", "-O0");
+}
+
+test "e2e: -O3 invokes LLVM aggressive pipeline without crashing (#755)" {
+    try testE2eOpt(std.testing.allocator, "e2e_001_hello", "-O3");
+}
+
+test "e2e: rhc build rejects unknown -O level (#755)" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    const rhc_path = e2e_options.rhc_path;
+
+    const argv = [_][]const u8{ rhc_path, "build", "-O", "fast", "tests/e2e/e2e_001_hello.hs" };
+    const result = try process.run(allocator, io, .{ .argv = &argv });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .exited => |code| try std.testing.expect(code != 0),
+        else => return error.UnexpectedTermination,
+    }
+    try std.testing.expect(std.mem.indexOf(u8, result.stderr, "invalid optimisation level") != null);
 }


### PR DESCRIPTION
Closes #755 (sub-issue of epic #754, Track A1).

## Summary

`rhc build` now accepts `-O <level>` (Clang syntax: `0|1|2|3|s|z`) and
actually invokes LLVM's mid-level optimiser. Previously the back-end's
`LLVMCodeGenLevelDefault` was set on the TargetMachine but the mid-level
optimiser was never invoked at all (no `LLVMRunPasses` / pass-manager
call existed in the codegen path). So every `rhc build` was effectively
producing unoptimised IR + unoptimised native code.

The native backend defaults to **`-O2`**. The REPL JIT engine keeps its
current default (`-O0`) for fast iteration; the JIT and WASM emit paths
honour `-O<n>` if explicitly passed.

## Implementation

- Added `OptLevel` enum to `src/backend/llvm.zig` mapping to both
  `LLVMCodeGenOptLevel` (back-end) and the `default<O...>` pass-pipeline
  string (mid-level).
- Added bindings for `llvm-c/Transforms/PassBuilder.h` (`LLVMRunPasses`,
  `LLVMCreatePassBuilderOptions`, `LLVMDisposePassBuilderOptions`) plus
  `llvm-c/Error.h` for error-message extraction. These are exposed via
  `@cImport` since LLVM 19 (vendored from Nix) ships them.
- New `runOptimizationPasses(module, target_machine, opt)` runs the
  canonical `default<O{n}>` pipeline and is a no-op at `-O0` (skips
  pass-builder setup entirely).
- `createNativeTargetMachine` / `createWasmTargetMachine` now take an
  `OptLevel` and map to the matching `LLVMCodeGenOptLevel` for back-end
  codegen.
- Threaded `opt_level` through `cmdBuild` → `emitNative` / `emitJit` /
  `emitWasm`. The new pass-manager invocation runs immediately after
  all linker passes and before object emission so RTS + program code
  optimise together.
- `--help` documents the flag; invalid levels error with a clear message.

## Deliverables

- [x] `-O <level>` flag accepting `0|1|2|3|s|z` with `-O2` default for native.
- [x] LLVM mid-level optimiser invoked via `LLVMRunPasses` from the new pass manager.
- [x] Matching `LLVMCodeGenOptLevel` passed to TargetMachine creation.
- [x] Unit tests for `OptLevel.parse` / `pipelineString` / `shortName`.
- [x] E2E smoke tests for `-O0`, `-O2`, `-O3` (+ rejection of `-O fast`).
- [x] CLI help text + `BUILDING.md` section documenting the flag.

## Testing

```bash
nix develop --command zig build test --summary all
```

Result: **Build Summary: 47/47 steps succeeded; 1033/1033 tests passed**.

## Smoke / benchmark eyeball

Compiled `tests/e2e/ghc_004_length.hs` at all three levels:

| Level | text section | exit / output |
|-------|--------------|---------------|
| `-O0` | 5.4 MB       | `9`           |
| `-O2` | 3.5 MB       | `9`           |
| `-O3` | 3.5 MB       | `9`           |

The 35 % text-size reduction at `-O2` vs `-O0` confirms the new pass
manager is actually running. Outputs match byte-for-byte across levels.

## LLVM-C API path taken

Used the **new pass manager** via `LLVMRunPasses` (available since LLVM
13, project links LLVM 19). The bindings live behind a tiny `@cImport`
addition (two extra `#include` lines) — no manual `extern fn`
declarations needed. The legacy pass manager was not touched.

## Caveats

- `-Os` / `-Oz` map their back-end code-gen level to `Default` (clang
  behaviour) — the size-optimisation lives in the mid-level pipeline.
- The two Backend-interface implementations (`src/backend/native.zig`,
  `src/backend/wasm.zig`) are not used by `rhc build` today; they were
  updated to take `.O0` to preserve their legacy "no mid-level passes"
  behaviour.
- The JIT backend default stays `-O0` because lli will JIT-optimise
  anyway and a slow `rhc build --backend jit` defeats the iteration
  loop. Pass `-O2 --backend jit` explicitly if you need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
