### PR TITLE
#536: Implement foreign import ccall for RTS function calls

### DIFF
--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -152,6 +152,53 @@ const PrimOpMapping = struct {
             };
         }
 
+        // ── Direct RTS symbols via `foreign import ccall` (#536) ─────
+        //
+        // The desugarer passes ccall symbol names through unchanged, so
+        // they arrive here as the literal RTS symbol. This set must stay
+        // in sync with `PrimOp.isSupportedCCallSymbol` (src/grin/primop.zig),
+        // which gates what the desugarer accepts.
+        if (std.mem.eql(u8, name.base, "rts_putStrLn")) {
+            return .{
+                .libcall = .{
+                    .name = "rts_putStrLn",
+                    .return_kind = .i32,
+                    .param_kinds = &.{.ptr},
+                    .arg_strategy = .string_to_global_ptr,
+                },
+            };
+        }
+        if (std.mem.eql(u8, name.base, "rts_putStr")) {
+            return .{
+                .libcall = .{
+                    .name = "rts_putStr",
+                    .return_kind = .i32,
+                    .param_kinds = &.{.ptr},
+                    .arg_strategy = .string_to_global_ptr,
+                },
+            };
+        }
+        if (std.mem.eql(u8, name.base, "rts_putChar")) {
+            return .{
+                .libcall = .{
+                    .name = "rts_putChar",
+                    .return_kind = .i32,
+                    .param_kinds = &.{.i64},
+                    .arg_strategy = .value_passthrough,
+                },
+            };
+        }
+        if (std.mem.eql(u8, name.base, "rts_error")) {
+            return .{
+                .libcall = .{
+                    .name = "rts_error",
+                    .return_kind = .i32,
+                    .param_kinds = &.{.ptr},
+                    .arg_strategy = .string_to_global_ptr,
+                },
+            };
+        }
+
         // Arithmetic PrimOp mappings
         if (std.mem.eql(u8, name.base, "add_Int")) return .{ .instruction = .{ .add = {} } };
         if (std.mem.eql(u8, name.base, "sub_Int")) return .{ .instruction = .{ .sub = {} } };
@@ -3426,6 +3473,26 @@ test "PrimOpMapping: error maps to rts_error" {
     });
     try std.testing.expect(result != null);
     try std.testing.expectEqualStrings("rts_error", std.mem.span(result.?.libcall.name));
+}
+
+test "PrimOpMapping: ccall rts_ symbols map directly (#536)" {
+    // ccall names pass through desugar unchanged, so the mapping must
+    // match the literal RTS symbol regardless of unique.
+    const cases = [_]struct { sym: []const u8, param: ParamKind }{
+        .{ .sym = "rts_putStrLn", .param = .ptr },
+        .{ .sym = "rts_putStr", .param = .ptr },
+        .{ .sym = "rts_putChar", .param = .i64 },
+        .{ .sym = "rts_error", .param = .ptr },
+    };
+    for (cases) |case| {
+        const result = PrimOpMapping.lookup(.{
+            .base = case.sym,
+            .unique = .{ .value = 4242 },
+        });
+        try std.testing.expect(result != null);
+        try std.testing.expectEqualStrings(case.sym, std.mem.span(result.?.libcall.name));
+        try std.testing.expectEqual(case.param, result.?.libcall.param_kinds[0]);
+    }
 }
 
 test "PrimOpMapping: unknown function returns null" {

--- a/src/core/desugar.zig
+++ b/src/core/desugar.zig
@@ -368,22 +368,36 @@ pub fn desugarModule(
                 });
             },
             .ForeignPrim => |fp| {
-                // Validate the PrimOp name at compile time.
-                // Accept:
+                // Validate the imported name at compile time.
+                //
+                // `prim` convention accepts:
                 //   1. raw PrimOp enum names (e.g. "add_Int") via fromString
                 //   2. Prelude-level aliases (e.g. "putStrLn" → putStrLn_)
                 //   3. backend-only names recognised directly by the LLVM
                 //      backend's `PrimOpMapping` but with no PrimOp enum
                 //      variant (e.g. ">>=", "div#"). See #534.
-                const is_known = primop_mod.PrimOp.fromString(fp.primop_name) != null or
-                    primop_mod.PrimOp.fromPreludeName(fp.primop_name) != null or
-                    primop_mod.PrimOp.isBackendOnlyName(fp.primop_name);
+                //
+                // `ccall` convention (#536) accepts the RTS symbols the
+                // LLVM backend has signature descriptors for.
+                const is_known = switch (fp.convention) {
+                    .prim => primop_mod.PrimOp.fromString(fp.primop_name) != null or
+                        primop_mod.PrimOp.fromPreludeName(fp.primop_name) != null or
+                        primop_mod.PrimOp.isBackendOnlyName(fp.primop_name),
+                    .ccall => primop_mod.PrimOp.isSupportedCCallSymbol(fp.primop_name),
+                };
                 if (!is_known) {
-                    const msg = try std.fmt.allocPrint(
-                        alloc,
-                        "unknown primitive operation: `{s}`",
-                        .{fp.primop_name},
-                    );
+                    const msg = switch (fp.convention) {
+                        .prim => try std.fmt.allocPrint(
+                            alloc,
+                            "unknown primitive operation: `{s}`",
+                            .{fp.primop_name},
+                        ),
+                        .ccall => try std.fmt.allocPrint(
+                            alloc,
+                            "unsupported ccall symbol: `{s}` (supported RTS symbols: rts_putStrLn, rts_putStr, rts_putChar, rts_error)",
+                            .{fp.primop_name},
+                        ),
+                    };
                     try diags.emit(alloc, .{
                         .severity = .@"error",
                         .code = .unknown_primop,
@@ -406,7 +420,12 @@ pub fn desugarModule(
                 // so the LLVM backend's PrimOpMapping only needs to match
                 // canonical names.  Raw enum names (e.g. "add_Int") pass
                 // through unchanged via fromString.
-                const canonical_base = if (primop_mod.PrimOp.fromString(fp.primop_name)) |_|
+                //
+                // ccall symbols (#536) pass through unchanged: the backend
+                // matches the RTS symbol name directly.
+                const canonical_base = if (fp.convention == .ccall)
+                    fp.primop_name
+                else if (primop_mod.PrimOp.fromString(fp.primop_name)) |_|
                     fp.primop_name
                 else if (primop_mod.PrimOp.fromPreludeName(fp.primop_name)) |op|
                     op.name()

--- a/src/grin/primop.zig
+++ b/src/grin/primop.zig
@@ -378,6 +378,21 @@ pub const PrimOp = enum(u16) {
             std.mem.eql(u8, str, "quot#") or
             std.mem.eql(u8, str, "rem#");
     }
+
+    /// RTS symbols reachable via `foreign import ccall` (#536).
+    ///
+    /// The LLVM backend holds a signature descriptor for each of these
+    /// (grin_to_llvm.zig `PrimOpMapping.lookup`, direct-symbol matches),
+    /// so this set must stay in sync with the backend. Symbols outside
+    /// the set are rejected at desugar time with a structured
+    /// diagnostic; generic signature plumbing for arbitrary C symbols
+    /// is follow-up work alongside the ccall PrimOp bridge (#344).
+    pub fn isSupportedCCallSymbol(str: []const u8) bool {
+        return std.mem.eql(u8, str, "rts_putStrLn") or
+            std.mem.eql(u8, str, "rts_putStr") or
+            std.mem.eql(u8, str, "rts_putChar") or
+            std.mem.eql(u8, str, "rts_error");
+    }
 };
 
 /// Categories of PrimOps for documentation and organization.

--- a/src/renamer/renamer.zig
+++ b/src/renamer/renamer.zig
@@ -446,16 +446,30 @@ pub const RDecl = union(enum) {
     InstanceDecl: RInstanceDecl,
     /// Data declaration (algebraic data type).
     DataDecl: RDataDecl,
-    /// Foreign primitive import: `foreign import prim "op_name" binding :: Type`.
+    /// Foreign import: `foreign import <conv> "name" binding :: Type`,
+    /// where `<conv>` is `prim` (GRIN PrimOp) or `ccall` (C call to an
+    /// RTS function, #536).
     ForeignPrim: struct {
         /// The renamed Haskell binding name (with unique ID).
         name: Name,
-        /// The raw PrimOp string name (e.g., "add_Int").
+        /// The raw imported name: a PrimOp string (e.g., "add_Int") for
+        /// `prim`, or a C symbol (e.g., "rts_putStrLn") for `ccall`.
         primop_name: []const u8,
         /// The declared type signature (AST-level, not yet elaborated).
         type: ast.Type,
+        /// Which foreign calling convention the declaration used.
+        convention: ForeignConvention,
         span: SourceSpan,
     },
+};
+
+/// Foreign import calling conventions accepted by the renamer (#536).
+pub const ForeignConvention = enum {
+    /// GRIN PrimOp — lowered to LLVM instructions or RTS libcalls via
+    /// PrimOp alias normalisation.
+    prim,
+    /// Direct C-calling-convention call to an RTS symbol.
+    ccall,
 };
 
 /// A renamed data constructor declaration.
@@ -915,11 +929,16 @@ fn renameDecl(
             } };
         },
         .Foreign => |fd| blk: {
-            // Only `prim` calling convention is supported; others are deferred.
-            if (!std.mem.eql(u8, fd.calling_convention, "prim")) {
+            // `prim` (GRIN PrimOps) and `ccall` (RTS C calls, #536) are
+            // supported; other conventions (capi, stdcall, …) are deferred.
+            const convention: ForeignConvention = if (std.mem.eql(u8, fd.calling_convention, "prim"))
+                .prim
+            else if (std.mem.eql(u8, fd.calling_convention, "ccall"))
+                .ccall
+            else {
                 const msg = try std.fmt.allocPrint(
                     env.alloc,
-                    "unsupported foreign calling convention: `{s}` (only `prim` is supported)",
+                    "unsupported foreign calling convention: `{s}` (only `prim` and `ccall` are supported)",
                     .{fd.calling_convention},
                 );
                 try env.diags.emit(env.alloc, .{
@@ -929,12 +948,13 @@ fn renameDecl(
                     .message = msg,
                 });
                 break :blk null;
-            }
+            };
             const name = env.scope.lookup(fd.binding_name) orelse env.freshName(fd.binding_name);
             break :blk RDecl{ .ForeignPrim = .{
                 .name = name,
                 .primop_name = fd.foreign_name,
                 .type = fd.type,
+                .convention = convention,
                 .span = fd.span,
             } };
         },

--- a/tests/compile_fail_test_runner.zig
+++ b/tests/compile_fail_test_runner.zig
@@ -222,3 +222,7 @@ test "should_fail_compile: sfc001_unknown_primop" {
 test "should_fail_compile: sfc002_unbound_variable" {
     try testShouldFailCompile(std.testing.allocator, "sfc002_unbound_variable");
 }
+
+test "should_fail_compile: sfc003_unsupported_ccall_symbol (#536)" {
+    try testShouldFailCompile(std.testing.allocator, "sfc003_unsupported_ccall_symbol");
+}

--- a/tests/e2e/e2e_536_foreign_ccall.hs
+++ b/tests/e2e/e2e_536_foreign_ccall.hs
@@ -1,0 +1,20 @@
+-- foreign import ccall to RTS functions (#536).
+--
+-- `foreign import ccall` binds a Haskell name directly to a C-calling-
+-- convention RTS symbol. This is layer 2 of the FFI architecture:
+--   1. foreign import prim   — GRIN PrimOps → LLVM instructions
+--   2. foreign import ccall  — RTS functions → C calls (this test)
+--   3. Haskell wrappers in Prelude.hs over either
+{-# LANGUAGE NoImplicitPrelude #-}
+
+foreign import ccall "rts_putStrLn" cPutStrLn :: String -> IO ()
+foreign import ccall "rts_putStr" cPutStr :: String -> IO ()
+foreign import ccall "rts_putChar" cPutChar :: Char -> IO ()
+
+main :: IO ()
+main = do
+    cPutStrLn "hello from ccall"
+    cPutStr "no newline, "
+    cPutStrLn "then one"
+    cPutChar 'x'
+    cPutChar '\n'

--- a/tests/e2e/e2e_536_foreign_ccall.stdout
+++ b/tests/e2e/e2e_536_foreign_ccall.stdout
@@ -1,0 +1,3 @@
+hello from ccall
+no newline, then one
+x

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -513,6 +513,10 @@ test "e2e: ghc_744_let_in_default_body (#744)" {
     try testE2e(std.testing.allocator, "ghc_744_let_in_default_body");
 }
 
+test "e2e: e2e_536_foreign_ccall (#536)" {
+    try testE2e(std.testing.allocator, "e2e_536_foreign_ccall");
+}
+
 // ── Optimisation-level smoke tests (#755) ────────────────────────────────────
 //
 // These verify that the `-O<level>` flag actually flows through `rhc build`

--- a/tests/should_fail_compile/sfc003_unsupported_ccall_symbol.hs
+++ b/tests/should_fail_compile/sfc003_unsupported_ccall_symbol.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Sfc003UnsupportedCcallSymbol where
+
+-- This should fail during desugaring (#536): `rts_bogus` is not one of
+-- the RTS symbols the backend has a ccall signature descriptor for.
+
+foreign import ccall "rts_bogus" cBogus :: Int -> IO ()
+
+main :: IO ()
+main = cBogus 42

--- a/tests/should_fail_compile/sfc003_unsupported_ccall_symbol.properties
+++ b/tests/should_fail_compile/sfc003_unsupported_ccall_symbol.properties
@@ -1,0 +1,1 @@
+expected_code: E010


### PR DESCRIPTION
Closes #536

## Summary

Implements `foreign import ccall` for RTS function calls — layer 2 of the FFI architecture (`prim` = GRIN PrimOps → LLVM instructions; `ccall` = RTS functions → C-calling-convention calls):

- **Renamer**: accepts `ccall` alongside `prim`, recording the convention on the `ForeignPrim` RDecl (other conventions still rejected with a structured diagnostic).
- **Desugarer**: validates ccall symbols against `PrimOp.isSupportedCCallSymbol` (the RTS symbols the backend has signature descriptors for: `rts_putStrLn`, `rts_putStr`, `rts_putChar`, `rts_error`); passes the symbol through unchanged. Unknown symbols → E010 listing the supported set.
- **LLVM backend**: `PrimOpMapping` matches the literal `rts_*` symbol and emits the call via the existing libcall machinery.

## Deliverables

- [x] Parse `foreign import ccall "rts_putStrLn" putStrLn :: String -> IO ()` (parser already accepted any convention)
- [x] Renamer extends the calling-convention check to accept `ccall`
- [x] Desugarer generates a Core binding producing a GRIN App dispatching to a C call
- [x] LLVM backend emits a `call` to the named C function
- [x] E2e test demonstrating ccall to RTS functions

## Follow-ups filed

- #767 — derive C signatures from declared Haskell types (drop the RTS symbol allowlist)
- #768 — dispatch ccall symbols on the interpreter/JIT path

## Testing

`nix develop --command zig build test --summary all` → 47/47 steps, 1039/1039 tests pass. New coverage: `e2e_536_foreign_ccall` (native run prints via ccall imports), `sfc003_unsupported_ccall_symbol` (E010), PrimOpMapping unit test for the four direct symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
