### PR TITLE
#72: Implement Immix mark-and-sweep collection

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -508,7 +508,10 @@ Previous issues #58–#61 (hardcoded Prelude stubs) are closed as superseded —
 | [#71](https://github.com/adinapoli/rusholme/issues/71) | Implement Immix block and line allocator | [#70](https://github.com/adinapoli/rusholme/issues/70) | :yellow_circle: |
 | [#776](https://github.com/adinapoli/rusholme/issues/776) | rts: wire ImmixGc behind --rts=arena\|immix backend selector | [#71](https://github.com/adinapoli/rusholme/issues/71) | :white_circle: |
 | [#777](https://github.com/adinapoli/rusholme/issues/777) | rts: split Immix allocator into small + overflow cursors | [#71](https://github.com/adinapoli/rusholme/issues/71) | :white_circle: |
-| [#72](https://github.com/adinapoli/rusholme/issues/72) | Implement Immix mark-and-sweep collection | [#71](https://github.com/adinapoli/rusholme/issues/71) | :white_circle: |
+| [#72](https://github.com/adinapoli/rusholme/issues/72) | Implement Immix mark-and-sweep collection | [#71](https://github.com/adinapoli/rusholme/issues/71) | :yellow_circle: |
+| [#779](https://github.com/adinapoli/rusholme/issues/779) | rts: per-constructor pointer-mask tables for precise GC tracing | [#72](https://github.com/adinapoli/rusholme/issues/72) | :white_circle: |
+| [#780](https://github.com/adinapoli/rusholme/issues/780) | backend: shadow-stack ABI for precise GC roots | [#72](https://github.com/adinapoli/rusholme/issues/72) | :white_circle: |
+| [#781](https://github.com/adinapoli/rusholme/issues/781) | rts: auto-trigger collection from the allocator based on a heap budget | [#72](https://github.com/adinapoli/rusholme/issues/72) | :white_circle: |
 | [#73](https://github.com/adinapoli/rusholme/issues/73) | Implement Immix opportunistic defragmentation | [#72](https://github.com/adinapoli/rusholme/issues/72) | :white_circle: |
 | [#74](https://github.com/adinapoli/rusholme/issues/74) | Research: ASAP-style static deallocation via GRIN analysis | [#44](https://github.com/adinapoli/rusholme/issues/44) | :white_circle: |
 

--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -8,9 +8,9 @@
 //! Every constructor node is allocated via `rts_alloc(tag, n_fields)` and
 //! uses the Zig RTS `Node` layout:
 //!
-//!   ┌─────────────┬──────────────┬────────────┬────────────────────────┐
-//!   │  tag (u64)  │ n_fields(u32)│  _pad(u32) │ field[0] … field[N-1] │
-//!   └─────────────┴──────────────┴────────────┴────────────────────────┘
+//!   ┌─────────────┬──────────────┬─────────────────┬────────────────────────┐
+//!   │  tag (u64)  │ n_fields(u32)│  gc_flags (u32) │ field[0] … field[N-1] │
+//!   └─────────────┴──────────────┴─────────────────┴────────────────────────┘
 //!
 //! The header is 16 bytes; each field slot is 8 bytes (u64).  Field values
 //! are stored as raw u64 — either a pointer cast to uintptr (for *Node
@@ -353,16 +353,18 @@ fn untagInt(builder: llvm.Builder, val: llvm.Value) llvm.Value {
 }
 
 /// Return the LLVM struct type for the unified node header:
-///   { i64 tag, i32 n_fields, i32 _pad }   (16 bytes)
+///   { i64 tag, i32 n_fields, i32 gc_flags }   (16 bytes)
 ///
 /// Used only for GEP into the tag word when loading the discriminant
 /// in Case expressions.  Field I/O uses the rts_load_field / rts_store_field
-/// RTS helpers instead of direct GEP.
+/// RTS helpers instead of direct GEP. The third word stores Immix
+/// collector metadata (see `src/rts/node.zig::Node.gc_flags`) and is
+/// never read by generated code.
 fn nodeHeaderType() llvm.Type {
     var members = [_]llvm.Type{
         llvm.i64Type(), // tag
         llvm.i32Type(), // n_fields
-        llvm.i32Type(), // _pad
+        llvm.i32Type(), // gc_flags
     };
     return c.LLVMStructType(@ptrCast(&members), 3, 0);
 }

--- a/src/rts/immix.zig
+++ b/src/rts/immix.zig
@@ -31,9 +31,53 @@
 //! that `block_of(ptr) = ptr & ~(BLOCK_SIZE-1)`. The in-block header
 //! occupies an integer number of lines at the start of the block; those
 //! lines are pre-marked `used` and skipped during allocation.
+//!
+//! ## Mark-and-sweep collection (#72)
+//!
+//! `collect()` runs a classic Cheney-style trace from a set of roots,
+//! marks every reachable `Node` (object granularity) and the lines it
+//! occupies (line granularity), then re-files every block based on its
+//! resulting line-mark count. Dead lines become free; dead large
+//! objects are released to the child allocator.
+//!
+//! Object marks live in `Node.gc_flags` and store the *cycle id* at
+//! which the node was last marked — `node.gc_flags == self.mark_id`
+//! means "alive in this cycle". This avoids a separate reset pass: each
+//! collection bumps `mark_id`, and stale ids automatically read as
+//! unmarked.
+//!
+//! Roots are pulled from two sources:
+//!
+//!   * Explicitly-registered slots via `addRoot`/`removeRoot` — precise.
+//!     This is the long-term root mechanism (LLVM backend will spill
+//!     live `*Node` values into shadow-stack frames; the GC walks them
+//!     exactly).
+//!   * Optional **conservative stack scan** between `stack_base` (set
+//!     once via `setStackBase`) and the current frame address — every
+//!     aligned word in that range that *looks* like a heap pointer is
+//!     treated as a root. This is the zig-gc-style bring-up path so
+//!     the collector works before the backend emits precise roots.
+//!     If `stack_base` is `null` the scan is skipped entirely (the
+//!     mode unit tests use, since their roots are explicit). The
+//!     conservative scan does **not** cover register-resident values,
+//!     so production use will need a `setjmp`-style register spill or
+//!     precise shadow-stack roots before it can be trusted.
+//!
+//! Object-body tracing is **precise** for built-in tags whose layout
+//! the RTS knows (`Unit`/`Int`/`Char`/`String` carry no pointers;
+//! `Ind` has exactly one pointer at `field[0]`), and **conservative**
+//! within the remaining tag classes (`Thunk`, `Closure`, `Data`,
+//! user-defined constructors) where the RTS does not yet have a
+//! per-tag pointer mask. Each field slot in those classes is treated
+//! as a candidate pointer; only words that pass `isHeapPointer`
+//! (alignment, falls inside an Immix block's payload region or an LOS
+//! slab) are followed. Precise per-constructor masks are tracked
+//! separately as a backend deliverable.
 
 const std = @import("std");
 const heap = @import("heap.zig");
+const nodemod = @import("node.zig");
+const Node = nodemod.Node;
 
 // ═══════════════════════════════════════════════════════════════════════
 // Geometry
@@ -173,13 +217,14 @@ const LargeObject = struct {
 // ImmixGc
 // ═══════════════════════════════════════════════════════════════════════
 
-/// Phase-2 Immix heap: block/line bump allocator over a child allocator.
+/// Phase-2 Immix heap: block/line bump allocator + mark-region collector
+/// over a child allocator.
 ///
-/// The collector half lands in #72; until then, `free`/`collect`/roots
-/// are no-ops and the heap grows monotonically. Even so, the on-disk
-/// layout already carries every piece of metadata the collector will
-/// need (per-line marks, per-block classification, intrusive lists),
-/// so #72 is a logic-only addition.
+/// `#71` landed the allocation half; `#72` adds collection: `collect()`
+/// runs a mark phase from explicit + (optionally) conservative roots,
+/// then sweeps blocks at line granularity and releases unreachable
+/// large objects. Defragmentation (#73) is still out of scope — the
+/// collector is strictly non-moving.
 pub const ImmixGc = struct {
     /// Source of 32 KB blocks and LOS slabs.
     child: std.mem.Allocator,
@@ -188,13 +233,12 @@ pub const ImmixGc = struct {
     /// Blocks with no live lines, immediately ready for cold bumping.
     free_blocks: ?*BlockHeader = null,
     /// Blocks with at least one free line and at least one used line.
-    /// In Phase 2 these only appear as the current bump block moves on
-    /// (no collection yet recycles full blocks down).
     recyclable_blocks: ?*BlockHeader = null,
     /// Blocks with no free lines remaining.
     full_blocks: ?*BlockHeader = null,
-    /// Singly-linked list of every block this heap owns, used solely by
-    /// `deinit` to return them to the child allocator.
+    /// Singly-linked list of every block this heap owns, used by
+    /// `deinit` to return them to the child allocator and by `collect`
+    /// to iterate the heap regardless of current classification.
     all_blocks: ?*BlockHeader = null,
 
     // ── Current bump region ───────────────────────────────────────────
@@ -209,6 +253,23 @@ pub const ImmixGc = struct {
     // ── Large object space ────────────────────────────────────────────
     large_objects: ?*LargeObject = null,
 
+    // ── Collector state ───────────────────────────────────────────────
+    /// Cycle id stamped onto `Node.gc_flags` to indicate liveness in
+    /// the current collection. `0` means "no collection has run yet";
+    /// freshly-allocated nodes carry this value and are treated as
+    /// dead by a collection that hasn't traced them yet — callers are
+    /// expected to root them via `addRoot` (or place them somewhere
+    /// reachable from a registered root) before invoking `collect`.
+    mark_id: u32 = 0,
+    /// Roots registered via `addRoot`. Each entry is a pointer to a
+    /// slot that holds a `*Node` encoded as `u64` (`@intFromPtr`).
+    /// `collect` walks this list precisely; any non-null slot is
+    /// followed unconditionally regardless of `isHeapPointer`.
+    roots: std.ArrayList(*u64) = .empty,
+    /// Optional high-water frame address for the conservative stack
+    /// scan. If `null`, only explicit roots are used.
+    stack_base: ?usize = null,
+
     // ── Stats ─────────────────────────────────────────────────────────
     stats_data: heap.AllocStats = .{},
     /// Number of blocks owned by this heap (small + LOS counts are
@@ -219,6 +280,15 @@ pub const ImmixGc = struct {
 
     pub fn init(child: std.mem.Allocator) ImmixGc {
         return .{ .child = child };
+    }
+
+    /// Record the calling frame as the boundary for the conservative
+    /// stack scanner. Call this once, as high in the program's
+    /// lifetime as possible (typically from `main`). Until called, the
+    /// conservative scan is disabled and the collector only sees
+    /// explicit roots registered via `addRoot`.
+    pub fn setStackBase(self: *ImmixGc, frame_address: usize) void {
+        self.stack_base = frame_address;
     }
 
     pub fn deinit(self: *ImmixGc) void {
@@ -252,6 +322,8 @@ pub const ImmixGc = struct {
             l = next;
         }
         self.large_objects = null;
+
+        self.roots.deinit(self.child);
     }
 
     /// View this heap through the GC-swappable interface (see
@@ -300,9 +372,8 @@ pub const ImmixGc = struct {
     }
 
     fn collectImpl(ctx: *anyopaque) void {
-        // Collection lands in #72. Until then this is a no-op so the
-        // surrounding RTS can call it unconditionally.
-        _ = ctx;
+        const self: *ImmixGc = @ptrCast(@alignCast(ctx));
+        self.collect();
     }
 
     fn statsImpl(ctx: *anyopaque) heap.AllocStats {
@@ -311,17 +382,26 @@ pub const ImmixGc = struct {
     }
 
     fn addRootImpl(ctx: *anyopaque, slot: *u64) void {
-        // Roots are needed by tracing (#72) and required to be precise
-        // by evacuation (#73). Recorded as no-op here so the interface
-        // is callable from day one — replaced with a real root set in
-        // #72.
-        _ = ctx;
-        _ = slot;
+        const self: *ImmixGc = @ptrCast(@alignCast(ctx));
+        // Append is allocator-fallible; in practice the root set is
+        // tiny and the child allocator is the same one the heap uses,
+        // so OOM here is a hard error.
+        self.roots.append(self.child, slot) catch @panic("Immix: out of memory while registering root");
     }
 
     fn removeRootImpl(ctx: *anyopaque, slot: *u64) void {
-        _ = ctx;
-        _ = slot;
+        const self: *ImmixGc = @ptrCast(@alignCast(ctx));
+        // Linear scan: roots are removed in roughly LIFO order during
+        // normal execution (stack frames unwind), so the matching slot
+        // is usually near the end of the list.
+        var i: usize = self.roots.items.len;
+        while (i > 0) {
+            i -= 1;
+            if (self.roots.items[i] == slot) {
+                _ = self.roots.swapRemove(i);
+                return;
+            }
+        }
     }
 
     // ── std.mem.Allocator adapter ─────────────────────────────────────
@@ -351,38 +431,38 @@ pub const ImmixGc = struct {
                 self.stats_data.bytes_allocated += len;
                 return p;
             }
-        }
-
-        // Slow path: current hole is too small. Advance to the next hole
-        // in the current block, or move to a different block.
-        if (self.advanceToHole(len, alignment)) {
-            if (self.bumpInCurrentHole(len, alignment)) |p| {
-                self.stats_data.bytes_allocated += len;
-                return p;
+            // Walk forward through any remaining holes in the current
+            // block — after a collection these can appear between live
+            // lines, not just at the tail.
+            while (self.advanceToHole(len, alignment)) {
+                if (self.bumpInCurrentHole(len, alignment)) |p| {
+                    self.stats_data.bytes_allocated += len;
+                    return p;
+                }
             }
         }
 
-        // The freshly-attached hole still didn't fit. This can only
-        // happen if every hole we can reach is smaller than `len + α`
-        // where α is the alignment padding — i.e. the block is too
-        // fragmented to satisfy this medium-sized request. Allocate a
-        // fresh block as overflow.
+        // Current block exhausted (or no current block yet). Pull
+        // blocks one at a time from recyclable/free lists or the child
+        // allocator until one offers a hole big enough.
         //
         // Note: the Immix paper distinguishes a dedicated *overflow
         // cursor* (medium objects skip small holes and go to fresh
         // blocks to avoid wasting them). We use the simpler single-
-        // cursor design here; a dedicated overflow path can be added
-        // when fragmentation measurements (#72) show it pays off.
-        const fresh = self.allocBlock() orelse return null;
-        self.attachBlockAsCurrent(fresh);
-        if (self.bumpInCurrentHole(len, alignment)) |p| {
-            self.stats_data.bytes_allocated += len;
-            return p;
+        // cursor design here; a dedicated overflow path is tracked
+        // separately.
+        while (self.allocBlock()) |fresh| {
+            self.attachBlockAsCurrent(fresh);
+            while (self.advanceToHole(len, alignment)) {
+                if (self.bumpInCurrentHole(len, alignment)) |p| {
+                    self.stats_data.bytes_allocated += len;
+                    return p;
+                }
+            }
+            // Block is too fragmented for this request — its lists are
+            // restored on the next loop iteration's attachBlockAsCurrent.
         }
-        // A fresh block whose entire payload couldn't satisfy `len`
-        // would mean `len > PAYLOAD_BYTES`, which we already routed to
-        // the LOS above.
-        unreachable;
+        return null;
     }
 
     /// Try to allocate `len` bytes from the current hole. Returns the
@@ -441,9 +521,13 @@ pub const ImmixGc = struct {
     }
 
     /// Detach the current block (moving it to a classification list)
-    /// and attach a fresh block as the new bump target. Used both when
-    /// the current block is exhausted and when we need to bring in the
-    /// first block.
+    /// and attach a fresh block as the new bump target. The cursor is
+    /// positioned at the payload boundary with an empty hole; the
+    /// surrounding `alloc` loop calls `advanceToHole` to locate the
+    /// first actually-free hole. This unifies the fresh-block and
+    /// recyclable-block paths: a fresh block's first hole spans the
+    /// whole payload, and a recyclable block's first hole sits between
+    /// existing live lines.
     fn attachBlockAsCurrent(self: *ImmixGc, block: *BlockHeader) void {
         if (self.current_block) |old| {
             // Reclassify the previous block based on whether any free
@@ -453,7 +537,7 @@ pub const ImmixGc = struct {
         self.current_block = block;
         const base = @intFromPtr(block);
         self.cursor = base + HEADER_BYTES;
-        self.limit = base + BLOCK_SIZE;
+        self.limit = base + HEADER_BYTES;
     }
 
     fn classifyAndFile(self: *ImmixGc, block: *BlockHeader) void {
@@ -560,13 +644,317 @@ pub const ImmixGc = struct {
         return lo.payload;
     }
 
+    // ── Collection ────────────────────────────────────────────────────
+
+    /// Run a single mark-and-sweep cycle.
+    ///
+    /// Sequence:
+    ///   1. Bump `mark_id` so stale per-node marks read as unmarked.
+    ///   2. Reset every block's payload line marks to free; header
+    ///      lines stay used.
+    ///   3. Trace from every registered root (precise) and, if a
+    ///      `stack_base` was set, every aligned word in the
+    ///      conservative stack range. Each reachable node has its
+    ///      `gc_flags` set to `mark_id` and the lines it spans set to
+    ///      used.
+    ///   4. Re-classify every block based on the freshly-computed
+    ///      line counts and rebuild the free/recyclable/full lists.
+    ///   5. Drop large objects whose payload node was not marked.
+    ///   6. Reset the bump cursor so the next allocation picks a hole
+    ///      from a recyclable block (if any).
+    pub fn collect(self: *ImmixGc) void {
+        const new_id = std.math.add(u32, self.mark_id, 1) catch blk: {
+            // u32 wrap. Reset every node's mark on the heap and start
+            // over at 1. Practically unreachable for any realistic
+            // workload (4 billion cycles), but covered for completeness.
+            self.clearAllMarks();
+            break :blk 1;
+        };
+        self.mark_id = new_id;
+
+        // Step 2: clear payload line marks.
+        var b = self.all_blocks;
+        while (b) |block| : (b = block.all_next) {
+            for (block.line_marks[HEADER_LINES..]) |*m| m.* = 0;
+        }
+
+        // Step 3: mark.
+        self.markFromRoots();
+        // Pass the current frame as the low-water mark for the
+        // conservative scan. Capture it here so the scan covers every
+        // frame younger than `stack_base`.
+        if (self.stack_base) |sb| {
+            self.markFromStackRange(@frameAddress(), sb);
+        }
+
+        // Step 4: re-classify blocks. We rebuild the lists from
+        // scratch to avoid double-filing.
+        self.free_blocks = null;
+        self.recyclable_blocks = null;
+        self.full_blocks = null;
+        b = self.all_blocks;
+        while (b) |block| : (b = block.all_next) {
+            block.next = null;
+            self.classifyAndFile(block);
+        }
+
+        // Step 5: sweep LOS.
+        self.sweepLargeObjects();
+
+        // Step 6: drop the current bump region so the next allocation
+        // picks a (possibly freshly-recycled) block from
+        // `recyclable_blocks`/`free_blocks`.
+        self.current_block = null;
+        self.cursor = 0;
+        self.limit = 0;
+
+        // Update accounting: the bytes we freed are exactly the lines
+        // that were just reclaimed. Re-scan the heap to count free
+        // lines (cheap; this is per-cycle bookkeeping, not per-alloc).
+        var free_payload_lines: u64 = 0;
+        b = self.all_blocks;
+        while (b) |block| : (b = block.all_next) {
+            for (block.line_marks[HEADER_LINES..]) |m| {
+                if (m == 0) free_payload_lines += 1;
+            }
+        }
+        const total_payload_lines: u64 = @as(u64, @intCast(PAYLOAD_LINES)) * self.blocks_allocated;
+        const used_payload_lines = total_payload_lines - free_payload_lines;
+        const used_payload_bytes = used_payload_lines * LINE_SIZE;
+        // bytes_freed is a monotonic counter that tracks lifetime
+        // reclamation; we add the delta between bytes-allocated and
+        // bytes-still-resident-in-blocks. Plus LOS reclaim accounted
+        // for separately in `sweepLargeObjects`.
+        const block_freed = if (self.stats_data.bytes_allocated >= used_payload_bytes + self.losBytesLive())
+            self.stats_data.bytes_allocated - used_payload_bytes - self.losBytesLive()
+        else
+            self.stats_data.bytes_freed; // keep monotonic on heuristic mismatch
+        self.stats_data.bytes_freed = block_freed;
+
+        self.stats_data.collections += 1;
+    }
+
+    /// Sum live LOS payload bytes.
+    fn losBytesLive(self: *const ImmixGc) u64 {
+        var total: u64 = 0;
+        var p = self.large_objects;
+        while (p) |lo| : (p = lo.next) total += lo.payload_len;
+        return total;
+    }
+
+    /// Walk every Node in every block and LOS slab, zeroing its
+    /// `gc_flags`. Called only on `mark_id` overflow.
+    fn clearAllMarks(self: *ImmixGc) void {
+        // Conservative pass: the block's bump cursor doesn't tell us
+        // where individual nodes live, so walk linearly from
+        // HEADER_BYTES reading {tag, n_fields, gc_flags} and stepping
+        // forward by the encoded size. Stops when n_fields would push
+        // past the block end (which marks the boundary between live
+        // bumped data and unused tail bytes).
+        var b = self.all_blocks;
+        while (b) |block| : (b = block.all_next) {
+            const base = @intFromPtr(block);
+            var p = base + HEADER_BYTES;
+            const end = base + BLOCK_SIZE;
+            while (p + @sizeOf(Node) <= end) {
+                const n: *Node = @ptrFromInt(p);
+                const size = @sizeOf(Node) + @as(usize, n.n_fields) * @sizeOf(u64);
+                if (p + size > end) break; // ragged tail
+                n.gc_flags = 0;
+                p += std.mem.alignForward(usize, size, @alignOf(Node));
+            }
+        }
+        var l = self.large_objects;
+        while (l) |lo| : (l = lo.next) {
+            const n: *Node = @ptrCast(@alignCast(lo.payload));
+            n.gc_flags = 0;
+        }
+    }
+
+    /// Mark phase entry point: queues every explicit root and runs the
+    /// transitive trace.
+    fn markFromRoots(self: *ImmixGc) void {
+        var work: std.ArrayList(*Node) = .empty;
+        defer work.deinit(self.child);
+        for (self.roots.items) |slot| {
+            const w = slot.*;
+            if (self.isHeapPointer(w)) {
+                work.append(self.child, @ptrFromInt(w)) catch @panic("Immix: out of memory during mark");
+            }
+        }
+        self.drainMarkWorklist(&work);
+    }
+
+    fn markFromStackRange(self: *ImmixGc, lo_addr: usize, hi_addr: usize) void {
+        var work: std.ArrayList(*Node) = .empty;
+        defer work.deinit(self.child);
+        var start: usize = undefined;
+        var end: usize = undefined;
+        if (lo_addr < hi_addr) {
+            start = lo_addr;
+            end = hi_addr;
+        } else {
+            start = hi_addr;
+            end = lo_addr;
+        }
+        const word_size = @sizeOf(usize);
+        var p = std.mem.alignForward(usize, start, word_size);
+        while (p + word_size <= end) : (p += word_size) {
+            const w = @as(*const usize, @ptrFromInt(p)).*;
+            if (self.isHeapPointer(w)) {
+                work.append(self.child, @ptrFromInt(w)) catch @panic("Immix: out of memory during mark");
+            }
+        }
+        self.drainMarkWorklist(&work);
+    }
+
+    fn drainMarkWorklist(self: *ImmixGc, work: *std.ArrayList(*Node)) void {
+        while (work.pop()) |node| {
+            if (node.gc_flags == self.mark_id) continue;
+            // Sanity-clamp `n_fields` against the block payload bound
+            // before recursing. A conservative-scan false positive may
+            // point at the middle of a node (or at non-node memory
+            // that just happens to live inside the heap) where
+            // `n_fields` is garbage. Without this clamp we'd walk off
+            // the end of the block during pointer recursion.
+            if (!self.nodeLooksValid(node)) continue;
+            node.gc_flags = self.mark_id;
+            self.markNodeLines(node);
+
+            const tag_raw = @intFromEnum(node.tag);
+            switch (tag_raw) {
+                @intFromEnum(nodemod.Tag.Unit),
+                @intFromEnum(nodemod.Tag.Int),
+                @intFromEnum(nodemod.Tag.Char),
+                @intFromEnum(nodemod.Tag.String),
+                => {
+                    // No Node-pointer fields.
+                },
+                @intFromEnum(nodemod.Tag.Ind) => {
+                    // Indirection: field[0] is the *Node target.
+                    if (node.n_fields >= 1) {
+                        const w = nodemod.fieldsConst(node)[0];
+                        if (self.isHeapPointer(w)) {
+                            work.append(self.child, @ptrFromInt(w)) catch @panic("Immix: out of memory during mark");
+                        }
+                    }
+                },
+                else => {
+                    // Thunks, closures, Data constructors, user-defined
+                    // tags: conservatively scan every field slot. A
+                    // tag→pointer-mask table from the backend would
+                    // make this precise; tracked separately.
+                    for (nodemod.fieldsConst(node)) |w| {
+                        if (self.isHeapPointer(w)) {
+                            work.append(self.child, @ptrFromInt(w)) catch @panic("Immix: out of memory during mark");
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    /// Bound-check a node candidate before treating it as live.
+    ///
+    /// A conservative-scan pointer may point into the middle of a real
+    /// node, or into otherwise-valid heap memory whose contents are not
+    /// a node header. In both cases reading `n_fields` returns garbage,
+    /// so we cap the resulting object size against the remaining bytes
+    /// of the containing block (or LOS slab) before recursing.
+    fn nodeLooksValid(self: *const ImmixGc, node: *Node) bool {
+        const size = @sizeOf(Node) + @as(usize, node.n_fields) * @sizeOf(u64);
+        const addr = @intFromPtr(node);
+        if (self.blockOf(node)) |block| {
+            const block_end = @intFromPtr(block) + BLOCK_SIZE;
+            return addr + size <= block_end;
+        }
+        // LOS object — payload size known from the slab header.
+        var l = self.large_objects;
+        while (l) |lo| : (l = lo.next) {
+            const start = @intFromPtr(lo.payload);
+            if (addr == start) {
+                return size <= lo.payload_len;
+            }
+        }
+        return false;
+    }
+
+    /// Mark every line the given node occupies. Marks the line
+    /// containing the header byte and the lines containing payload
+    /// bytes; the last line is the one holding `addr + size - 1`.
+    fn markNodeLines(self: *ImmixGc, node: *Node) void {
+        const addr = @intFromPtr(node);
+        const size = @sizeOf(Node) + @as(usize, node.n_fields) * @sizeOf(u64);
+        // Small object inside a block?
+        if (self.blockOf(node)) |block| {
+            const first = block.lineIndexOf(addr);
+            const last = block.lineIndexOf(addr + size - 1);
+            for (first..last + 1) |i| block.line_marks[i] = 1;
+        }
+        // LOS objects have no line marks (their whole slab is live or
+        // dead in one shot).
+    }
+
+    /// Test whether `word` looks like a pointer into our heap.
+    ///
+    /// Strict: must be non-null, 8-byte-aligned, and either point into
+    /// the payload region of an Immix block (i.e. past the in-block
+    /// header) or into an LOS payload.
+    pub fn isHeapPointer(self: *const ImmixGc, word: u64) bool {
+        if (word == 0) return false;
+        // `Node` requires 8-byte alignment.
+        if (word % @alignOf(Node) != 0) return false;
+        // Search block list. The block base is the word masked to
+        // BLOCK_SIZE; check whether that base appears in `all_blocks`.
+        const candidate_base = word & ~@as(u64, BLOCK_SIZE - 1);
+        var b = self.all_blocks;
+        while (b) |block| : (b = block.all_next) {
+            if (@intFromPtr(block) == candidate_base) {
+                const offset = word - candidate_base;
+                return offset >= HEADER_BYTES and offset < BLOCK_SIZE;
+            }
+        }
+        // Check LOS.
+        var l = self.large_objects;
+        while (l) |lo| : (l = lo.next) {
+            const payload_start = @intFromPtr(lo.payload);
+            if (word >= payload_start and word < payload_start + lo.payload_len) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// LOS sweep: drop slabs whose payload `Node` wasn't marked in
+    /// this cycle. Assumes LOS payloads start with a `Node` header
+    /// (the only thing the RTS allocates through this allocator).
+    fn sweepLargeObjects(self: *ImmixGc) void {
+        var pp: *?*LargeObject = &self.large_objects;
+        while (pp.*) |lo| {
+            const n: *const Node = @ptrCast(@alignCast(lo.payload));
+            if (n.gc_flags == self.mark_id) {
+                pp = &lo.next;
+                continue;
+            }
+            // Unlink and free.
+            pp.* = lo.next;
+            const raw: [*]align(@alignOf(LargeObject)) u8 = @ptrCast(@alignCast(lo.slab_base));
+            const slice: []align(@alignOf(LargeObject)) u8 = raw[0..lo.slab_len];
+            self.child.free(slice);
+            self.large_objects_allocated -= 1;
+            // bytes_freed includes the payload (not the slab overhead).
+            // We avoid touching stats here because `collect()` recomputes
+            // it consistently at the end.
+        }
+    }
+
     // ── Introspection helpers (test-only) ─────────────────────────────
 
     /// Address of the block that owns `ptr`, or `null` if `ptr` does
     /// not live in any of this heap's blocks. Pointer-only: large
     /// objects return `null`. Useful for tests asserting that small
     /// objects end up clustered as expected.
-    pub fn blockOf(self: *ImmixGc, ptr: *const anyopaque) ?*BlockHeader {
+    pub fn blockOf(self: *const ImmixGc, ptr: *const anyopaque) ?*BlockHeader {
         const addr = @intFromPtr(ptr);
         const candidate_base = addr & ~(@as(usize, BLOCK_SIZE) - 1);
         // Confirm the candidate is one of ours; ptr arithmetic alone
@@ -579,7 +967,7 @@ pub const ImmixGc = struct {
     }
 
     /// True if `ptr` lives in the large-object space.
-    pub fn isLarge(self: *ImmixGc, ptr: *const anyopaque) bool {
+    pub fn isLarge(self: *const ImmixGc, ptr: *const anyopaque) bool {
         const addr = @intFromPtr(ptr);
         var l = self.large_objects;
         while (l) |lo| : (l = lo.next) {
@@ -770,21 +1158,46 @@ test "Immix: blocks remain on the master list after classification" {
     try testing.expectEqual(@as(usize, @intCast(gc.blocks_allocated)), count);
 }
 
-test "Immix: GcAllocator.free/collect/addRoot are callable no-ops" {
+test "Immix: GcAllocator.free is still a bulk-reclaim no-op" {
+    // Per-object free is reclaimed by collection (#72), not by the
+    // mutator. Verifies the vtable hook is callable and does not
+    // accidentally update accounting.
     var gc = ImmixGc.init(testing.allocator);
     defer gc.deinit();
 
     const a = gc.gcAllocator();
     const p = try a.alloc(64, .of(u64));
     a.free(p[0..64], .of(u64));
-    a.collect();
-
-    var slot: u64 = 0;
-    a.addRoot(&slot);
-    a.removeRoot(&slot);
-
     try testing.expectEqual(@as(u64, 0), a.stats().bytes_freed);
+}
+
+test "Immix: collect() bumps the cycle counter" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+
+    const a = gc.gcAllocator();
     try testing.expectEqual(@as(u64, 0), a.stats().collections);
+    a.collect();
+    try testing.expectEqual(@as(u64, 1), a.stats().collections);
+    a.collect();
+    try testing.expectEqual(@as(u64, 2), a.stats().collections);
+}
+
+test "Immix: addRoot / removeRoot maintain the root list" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+
+    var slot_a: u64 = 0;
+    var slot_b: u64 = 0;
+    const a = gc.gcAllocator();
+    a.addRoot(&slot_a);
+    a.addRoot(&slot_b);
+    try testing.expectEqual(@as(usize, 2), gc.roots.items.len);
+    a.removeRoot(&slot_a);
+    try testing.expectEqual(@as(usize, 1), gc.roots.items.len);
+    try testing.expectEqual(&slot_b, gc.roots.items[0]);
+    a.removeRoot(&slot_b);
+    try testing.expectEqual(@as(usize, 0), gc.roots.items.len);
 }
 
 test "Immix: std.mem.Allocator adapter routes through the same heap" {
@@ -818,4 +1231,219 @@ test "Immix: classifyAndFile records a filled block as full" {
     var b = gc.full_blocks;
     while (b) |bl| : (b = bl.next) fullc += 1;
     try testing.expect(fullc >= 1);
+}
+
+// ── Collection (#72) ─────────────────────────────────────────────────
+
+/// Helper for the collector tests: allocate a header + N payload slots
+/// from `gc` and initialise the resulting Node in place.
+fn newNode(gc: *ImmixGc, tag: nodemod.Tag, n_fields: u32) !*Node {
+    const size = @sizeOf(Node) + @as(usize, n_fields) * @sizeOf(u64);
+    const raw = try gc.gcAllocator().alloc(size, .of(Node));
+    const n: *Node = @ptrCast(@alignCast(raw));
+    n.* = .{ .tag = tag, .n_fields = n_fields };
+    if (n_fields > 0) @memset(nodemod.fields(n), 0);
+    return n;
+}
+
+test "Immix: collect with no roots clears every payload line" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    _ = try newNode(&gc, .Int, 1);
+    _ = try newNode(&gc, .Int, 1);
+    _ = try newNode(&gc, .Data, 2);
+    gc.collect();
+    // Every payload line of every block should now read as free.
+    var b = gc.all_blocks;
+    while (b) |block| : (b = block.all_next) {
+        for (block.line_marks[HEADER_LINES..]) |m| {
+            try testing.expectEqual(@as(u8, 0), m);
+        }
+    }
+}
+
+test "Immix: collect keeps a rooted Int, drops an unrooted one" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    const live = try newNode(&gc, .Int, 1);
+    nodemod.fields(live)[0] = 42;
+    const dead = try newNode(&gc, .Int, 1);
+    nodemod.fields(dead)[0] = 99;
+
+    var slot: u64 = @intFromPtr(live);
+    gc.gcAllocator().addRoot(&slot);
+    defer gc.gcAllocator().removeRoot(&slot);
+
+    gc.collect();
+    try testing.expectEqual(gc.mark_id, live.gc_flags);
+    try testing.expect(dead.gc_flags != gc.mark_id);
+}
+
+test "Immix: collect follows Ind indirection" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    const target = try newNode(&gc, .Int, 1);
+    nodemod.fields(target)[0] = 7;
+    const ind = try newNode(&gc, .Ind, 1);
+    nodemod.fields(ind)[0] = @intFromPtr(target);
+
+    var slot: u64 = @intFromPtr(ind);
+    gc.gcAllocator().addRoot(&slot);
+    defer gc.gcAllocator().removeRoot(&slot);
+
+    gc.collect();
+    try testing.expectEqual(gc.mark_id, ind.gc_flags);
+    try testing.expectEqual(gc.mark_id, target.gc_flags);
+}
+
+test "Immix: collect terminates on heap cycles" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    // A and B point at each other through Data field[0].
+    const a = try newNode(&gc, .Data, 1);
+    const b = try newNode(&gc, .Data, 1);
+    nodemod.fields(a)[0] = @intFromPtr(b);
+    nodemod.fields(b)[0] = @intFromPtr(a);
+
+    var slot: u64 = @intFromPtr(a);
+    gc.gcAllocator().addRoot(&slot);
+    defer gc.gcAllocator().removeRoot(&slot);
+
+    gc.collect();
+    try testing.expectEqual(gc.mark_id, a.gc_flags);
+    try testing.expectEqual(gc.mark_id, b.gc_flags);
+}
+
+test "Immix: collect reclaims an unrooted LOS allocation" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    const big = try gc.gcAllocator().alloc(PAYLOAD_BYTES + 64, .of(Node));
+    const n: *Node = @ptrCast(@alignCast(big));
+    n.* = .{ .tag = .Data, .n_fields = 0 };
+    try testing.expectEqual(@as(u64, 1), gc.large_objects_allocated);
+
+    gc.collect();
+    try testing.expectEqual(@as(u64, 0), gc.large_objects_allocated);
+}
+
+test "Immix: collect preserves a rooted LOS allocation" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    const big = try gc.gcAllocator().alloc(PAYLOAD_BYTES + 64, .of(Node));
+    const n: *Node = @ptrCast(@alignCast(big));
+    n.* = .{ .tag = .Data, .n_fields = 0 };
+
+    var slot: u64 = @intFromPtr(n);
+    gc.gcAllocator().addRoot(&slot);
+    defer gc.gcAllocator().removeRoot(&slot);
+
+    gc.collect();
+    try testing.expectEqual(@as(u64, 1), gc.large_objects_allocated);
+    try testing.expectEqual(gc.mark_id, n.gc_flags);
+}
+
+test "Immix: collect re-files blocks based on surviving lines" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    // Allocate a single rooted Int — at most a handful of lines used.
+    const live = try newNode(&gc, .Int, 1);
+    var slot: u64 = @intFromPtr(live);
+    gc.gcAllocator().addRoot(&slot);
+    defer gc.gcAllocator().removeRoot(&slot);
+
+    // And several unrooted Data nodes to dirty more lines.
+    var i: usize = 0;
+    while (i < 32) : (i += 1) _ = try newNode(&gc, .Data, 1);
+
+    gc.collect();
+
+    // After collect, the single block should be recyclable (live lines
+    // remain) — not free (something is still live) and not full (most
+    // lines were reclaimed).
+    const block = gc.all_blocks orelse return error.TestUnexpectedNullBlock;
+    try testing.expectEqual(BlockState.recyclable, block.state);
+    try testing.expect(block.free_lines > 0);
+    try testing.expect(block.free_lines < PAYLOAD_LINES);
+}
+
+test "Immix: allocation after collect reuses reclaimed lines" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    // Fill some lines, drop them all, collect.
+    var i: usize = 0;
+    while (i < 32) : (i += 1) _ = try newNode(&gc, .Int, 1);
+    const blocks_before = gc.blocks_allocated;
+    gc.collect();
+    // The next allocation should NOT need a new block — there should be
+    // plenty of reclaimed lines available.
+    _ = try newNode(&gc, .Int, 1);
+    try testing.expectEqual(blocks_before, gc.blocks_allocated);
+}
+
+test "Immix: stress — repeated alloc/collect leaves no LOS leak" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    const cycles: usize = 16;
+    var i: usize = 0;
+    while (i < cycles) : (i += 1) {
+        // Each iteration: alloc one LOS object, no root, collect.
+        const big = try gc.gcAllocator().alloc(PAYLOAD_BYTES + 32, .of(Node));
+        const n: *Node = @ptrCast(@alignCast(big));
+        n.* = .{ .tag = .Data, .n_fields = 0 };
+        gc.collect();
+    }
+    try testing.expectEqual(@as(u64, 0), gc.large_objects_allocated);
+}
+
+test "Immix: collect monotonically increments mark_id" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    const before = gc.mark_id;
+    gc.collect();
+    try testing.expect(gc.mark_id > before);
+    const mid = gc.mark_id;
+    gc.collect();
+    try testing.expect(gc.mark_id > mid);
+}
+
+test "Immix: markFromStackRange follows pointers in a synthetic buffer" {
+    // Bypasses the real stack so the test doesn't depend on compiler
+    // frame-pointer choices. Exercises the conservative scan logic
+    // directly against a known byte range.
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    const live = try newNode(&gc, .Int, 1);
+
+    // Pretend this buffer is a stack window: one entry is the heap
+    // pointer to `live`; the others are noise. The scan should pick
+    // out the heap pointer and mark its target.
+    var buf: [4]usize align(@alignOf(usize)) = .{
+        0xdead,
+        @intFromPtr(live),
+        0,
+        0xbeef,
+    };
+
+    // Set up collector state as if collect() had just bumped mark_id
+    // and cleared payload line marks.
+    gc.mark_id = 1;
+    var b = gc.all_blocks;
+    while (b) |block| : (b = block.all_next) {
+        for (block.line_marks[HEADER_LINES..]) |*m| m.* = 0;
+    }
+    gc.markFromStackRange(
+        @intFromPtr(&buf),
+        @intFromPtr(&buf) + @sizeOf(@TypeOf(buf)),
+    );
+
+    try testing.expectEqual(@as(u32, 1), live.gc_flags);
+}
+
+test "Immix: isHeapPointer rejects non-pointer words" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    _ = try newNode(&gc, .Int, 1);
+    try testing.expect(!gc.isHeapPointer(0));
+    try testing.expect(!gc.isHeapPointer(7)); // misaligned
+    try testing.expect(!gc.isHeapPointer(0xdeadbeef_00000000));
 }

--- a/src/rts/node.zig
+++ b/src/rts/node.zig
@@ -18,11 +18,19 @@
 //!
 //! ## Layout
 //!
-//!   ┌──────────────┬────────────────┬───────────────────────────────────────┐
-//!   │  tag (u64)   │ n_fields (u32) │ _pad (u32) │ field[0] … field[N-1]   │
-//!   └──────────────┴────────────────┴───────────────────────────────────────┘
+//!   ┌──────────────┬────────────────┬─────────────────┬───────────────────────┐
+//!   │  tag (u64)   │ n_fields (u32) │ gc_flags (u32)  │ field[0] … field[N-1] │
+//!   └──────────────┴────────────────┴─────────────────┴───────────────────────┘
 //!
 //! The header is 16 bytes; each field is 8 bytes (u64).
+//!
+//! `gc_flags` holds garbage-collector metadata. For the Immix collector
+//! (#72) it stores the *cycle id* at which this node was last marked
+//! live — comparing it against the heap's current cycle id distinguishes
+//! marked from unmarked objects without a separate reset pass. The
+//! LLVM-generated allocation path leaves this field zero; the value is
+//! only meaningful once collection runs (until then it is read as
+//! "never marked", which is exactly what we want for a phase-1 arena).
 //! Nodes are allocated via `rts_alloc(tag, n_fields)` which uses the heap
 //! arena to allocate exactly `@sizeOf(Node) + n_fields * 8` bytes.
 //!
@@ -112,8 +120,15 @@ pub const Node = extern struct {
     /// Number of field slots that follow the header in memory.
     n_fields: u32,
 
-    /// Explicit padding to make the header 16 bytes on all targets.
-    _pad: u32 = 0,
+    /// Garbage-collector flags. Repurposes what used to be padding into
+    /// metadata: the Immix collector stores the cycle id at which this
+    /// node was last marked live. Zero means "never marked" — which is
+    /// the value freshly-allocated nodes carry, and which is treated
+    /// as dead by `collect`. Newly-allocated objects that must survive
+    /// the next collection should be reachable from a root by the time
+    /// `collect` runs, so the field can stay zero until the collector
+    /// touches it. Backend layout (`{i64, i32, i32}`) is unchanged.
+    gc_flags: u32 = 0,
 };
 
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #72

## Summary

Lands the collection half of the Immix heap on top of #71's allocation
geometry. The RTS now has a working stop-the-world mark-and-sweep
collector that frees dead lines and dead LOS slabs without any backend
changes.

This PR is built on top of [#778](https://github.com/adinapoli/rusholme/pull/778)
(unmerged). Branched from `llm-agent/issue-71` so the diff is reviewable
in isolation; depend-and-merge or rebase onto main once #778 lands.

## What lands

**Mark.** Each `collect()` bumps a `u32` cycle counter
(`Node.gc_flags`); a node is alive in this cycle iff its `gc_flags`
equals `mark_id`. No reset pass is needed because stale ids simply
read as unmarked. Tracing is precise for built-in tags (`Unit`/`Int`/
`Char`/`String` have no pointer fields; `Ind` has exactly one at
`field[0]`) and conservative for the remaining classes (`Thunk`,
`Closure`, `Data`, user constructors) until the backend emits per-tag
pointer-mask tables (filed as **#779**).

**Sweep.** Block payload line marks are zeroed before tracing; each
live object's lines get re-marked as the tracer walks it. Blocks are
re-filed across the `free` / `recyclable` / `full` lists from scratch
and the bump cursor is dropped, so the next allocation picks a
(possibly freshly-recycled) block. Unmarked LOS slabs are returned to
the child allocator.

**Roots.** Two mechanisms:

  * Explicit `addRoot` / `removeRoot` — precise, used by unit tests.
  * Optional conservative `@frameAddress()` stack scan, enabled by
    `setStackBase`. Disabled by default; bring-up only — register-
    resident pointers are invisible and the scan pins everything it
    finds, blocking evacuation. Shadow-stack ABI work filed as
    **#780**.

**Allocation tweaks.** `attachBlockAsCurrent` now positions at the
payload boundary with an empty hole, and the main `alloc` loop walks
forward through every hole in the current block before reaching for a
new one. This unifies the fresh-block and recyclable-block paths — a
fresh block's first hole spans the whole payload, a recyclable block's
first hole sits between live lines.

**Safety guard.** `nodeLooksValid` bound-checks `n_fields` against the
containing block's payload before recursing. Without this a
conservative-scan false positive could walk off the end of the heap.

## What is filed for later

- **#779** — emit per-constructor pointer-mask tables for precise
  tracing (prerequisite for #73 defragmentation).
- **#780** — shadow-stack ABI for precise GC roots (the single biggest
  blocker between this PR and "the collector is safe in production").
- **#781** — auto-trigger collection from the allocator based on a
  heap budget.

## Deliverables

- [x] Root scanning (explicit precise + conservative bring-up scan)
- [x] Mark phase: trace from roots, mark live objects and the lines
  they occupy
- [x] Sweep phase: reclaim blocks/lines containing no live objects
- [x] Line-granularity reclamation
- [x] Allocator reuses reclaimed lines (verified by the
  "allocation after collect reuses reclaimed lines" unit test)
- [ ] GC triggering heuristic — filed as **#781**; collect() is
  currently called only by tests until the backend wiring (#776) lands
- [x] Unit tests: allocate, drop references, collect, verify the
  marked / dead distinction holds at object, line, and LOS granularity
- [x] Stress test: repeated alloc/collect cycles with LOS objects
  leak nothing (`testing.allocator` catches any child-allocator leak)

## Testing

```
nix develop --command zig build test --summary all
# Build Summary: 51/51 steps succeeded; 1129/1129 tests passed
# +- run test rts-unit-tests 57 pass (57 total)
```

14 new collector tests cover: clearing line marks of unrooted
objects, keeping rooted Ints alive, following `Ind` indirections,
cycle termination, LOS reclaim & retention, block reclassification,
allocation reusing reclaimed lines, repeated alloc/collect stress,
`mark_id` monotonicity, conservative scan over a synthetic stack
buffer, and `isHeapPointer` rejecting non-pointer words.

## References

- Blackburn & McKinley, *"Immix: A Mark-Region Garbage Collector"*, PLDI 2008
- `docs/references/immix-gc.md`
- `docs/decisions/284-zig-gc-immix-reference.md` §4.1 (precise vs. conservative)
