### PR TITLE
#776: Wire ImmixGc behind --rts=arena|immix backend selector

### DIFF
--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -378,6 +378,18 @@ fn declareRtsAlloc(module: llvm.Module) llvm.Value {
     return c.LLVMAddFunction(module, name, fn_ty);
 }
 
+/// Declare `rts_set_backend(value: i32) -> void`. The RTS reads this
+/// once on the first allocation to choose between `ArenaGc` and
+/// `ImmixGc`; subsequent calls with the same value are no-ops. See
+/// `src/rts/heap.zig`.
+fn declareRtsSetBackend(module: llvm.Module) llvm.Value {
+    const name = "rts_set_backend";
+    if (c.LLVMGetNamedFunction(module, name)) |existing| return existing;
+    var params = [_]llvm.Type{llvm.i32Type()};
+    const fn_ty = c.LLVMFunctionType(llvm.voidType(), &params, 1, 0);
+    return c.LLVMAddFunction(module, name, fn_ty);
+}
+
 /// Declare `rts_store_field(node: ptr, index: i32, value: i64) -> void`.
 fn declareRtsStoreField(module: llvm.Module) llvm.Value {
     const name = "rts_store_field";
@@ -475,6 +487,20 @@ const TypeEnv = struct {
     }
 };
 
+/// Selects which RTS heap backend the generated `main` initialises
+/// before user code runs. Mirrors `RtsBackend` in `src/rts/heap.zig`
+/// — keep the numeric values in sync (they cross the C ABI).
+pub const RtsBackend = enum(u32) {
+    arena = 0,
+    immix = 1,
+
+    pub fn parse(s: []const u8) ?RtsBackend {
+        if (std.mem.eql(u8, s, "arena")) return .arena;
+        if (std.mem.eql(u8, s, "immix")) return .immix;
+        return null;
+    }
+};
+
 pub const GrinTranslator = struct {
     ctx: llvm.Context,
     module: llvm.Module,
@@ -512,6 +538,14 @@ pub const GrinTranslator = struct {
     /// Function arity map for correct forward declarations (issue #595).
     /// Maps function unique IDs to their parameter counts.
     arity_map: ?*const std.AutoHashMapUnmanaged(u64, u32) = null,
+
+    /// RTS backend selected by `rhc build --rts=…`. When non-`.arena`
+    /// the translator emits a `call void @rts_set_backend(i32 N)` at
+    /// the very start of `main`'s entry block, before any other
+    /// instruction. `.arena` matches the default lazy-init behaviour
+    /// in `src/rts/heap.zig` and is therefore a no-op for codegen.
+    /// See issue #776.
+    rts_backend: RtsBackend = .arena,
 
     pub fn init(allocator: std.mem.Allocator, registry: *TagRegistry) GrinTranslator {
         llvm.initialize();
@@ -565,6 +599,22 @@ pub const GrinTranslator = struct {
     /// Used by entry-point functions that need to return a
     /// distinguishable "no value" result (as opposed to integer 0,
     /// which is boolean False).
+    /// Emit `rts_set_backend(value)` at the current builder position.
+    /// Generated as the first instruction of native `main` whenever
+    /// the user picks a non-default backend (see #776).
+    fn emitSetRtsBackendCall(self: *GrinTranslator, value: u32) void {
+        const fn_val = declareRtsSetBackend(self.module);
+        var args = [_]llvm.Value{c.LLVMConstInt(llvm.i32Type(), value, 0)};
+        _ = c.LLVMBuildCall2(
+            self.builder,
+            llvm.getFunctionType(fn_val),
+            fn_val,
+            &args,
+            1,
+            "",
+        );
+    }
+
     fn buildUnitNode(self: *GrinTranslator) llvm.Value {
         const rts_alloc_fn = declareRtsAlloc(self.module);
         const unit_tag = @intFromEnum(rts_node.Tag.Unit);
@@ -796,6 +846,15 @@ pub const GrinTranslator = struct {
         self.current_func = func;
         const entry_bb = llvm.appendBasicBlock(func, "entry");
         llvm.positionBuilderAtEnd(self.builder, entry_bb);
+
+        // For native `main`, if the user selected a non-default RTS
+        // backend (#776), emit `call void @rts_set_backend(i32 N)` as
+        // the very first instruction so the heap picks up the
+        // selection before any allocation. Arena is the default, so
+        // codegen omits the call (it matches lazy init).
+        if (is_entry and !is_repl_entry and self.rts_backend != .arena) {
+            self.emitSetRtsBackendCall(@intFromEnum(self.rts_backend));
+        }
 
         // Clear previous function's parameter mapping and set up current one.
         self.params.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -226,6 +226,7 @@ pub fn main(init: std.process.Init) !void {
                 \\-o, --output <str>           Output file name (default: stem of first input).
                 \\-O, --opt-level <str>        Optimisation level: 0|1|2|3|s|z (default: 2 for native, 0 otherwise).
                 \\    --backend <str>          Backend: native (default), jit, wasm, c.
+                \\    --rts <str>              RTS heap backend: arena (default) or immix.
                 \\    --package-db <str>...    Package database path (may be repeated).
                 \\    --repl                   Compile for REPL use (internal).
                 \\<str>...
@@ -240,6 +241,7 @@ pub fn main(init: std.process.Init) !void {
                 \\-o, --output <str>           Output file name (default: stem of first input).
                 \\-O, --opt-level <str>        Optimisation level: 0|1|2|3|s|z (default: 2 for native, 0 otherwise).
                 \\    --backend <str>          Backend: native (default), jit, wasm, c.
+                \\    --rts <str>              RTS heap backend: arena (default) or immix.
                 \\    --package-db <str>...    Package database path (may be repeated).
                 \\<str>...
                 \\
@@ -306,6 +308,20 @@ pub fn main(init: std.process.Init) !void {
                 .jit, .wasm, .c => rusholme.backend.llvm.OptLevel.O0,
             };
 
+            const rts_backend: rusholme.backend.grin_to_llvm.RtsBackend = if (build_res.args.rts) |rts_str|
+                rusholme.backend.grin_to_llvm.RtsBackend.parse(rts_str) orelse {
+                    var buf: [512]u8 = undefined;
+                    var fw: File.Writer = .init(.stderr(), io, &buf);
+                    try fw.interface.print(
+                        "rhc build: unknown RTS backend '{s}'\nValid backends: arena, immix\n",
+                        .{rts_str},
+                    );
+                    try fw.interface.flush();
+                    std.process.exit(1);
+                }
+            else
+                rusholme.backend.grin_to_llvm.RtsBackend.arena;
+
             return cmdBuild(
                 allocator,
                 io,
@@ -315,6 +331,7 @@ pub fn main(init: std.process.Init) !void {
                 build_res.args.repl != 0,
                 build_res.args.@"package-db",
                 opt_level,
+                rts_backend,
             );
         },
 
@@ -944,7 +961,7 @@ fn loadPrelude(
 /// - native: compiles to native executable via LLVM
 /// - wasm: compiles to WebAssembly binary (.wasm)
 /// - jit, c: not yet implemented
-fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8, output_name: []const u8, backend_kind: rusholme.backend.backend_mod.BackendKind, is_repl: bool, package_dbs: []const []const u8, opt_level: rusholme.backend.llvm.OptLevel) !void {
+fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8, output_name: []const u8, backend_kind: rusholme.backend.backend_mod.BackendKind, is_repl: bool, package_dbs: []const []const u8, opt_level: rusholme.backend.llvm.OptLevel, rts_backend: rusholme.backend.grin_to_llvm.RtsBackend) !void {
     // REPL mode placeholder - for WASM backend compiles stateful REPL
     _ = is_repl;
 
@@ -1125,9 +1142,9 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
 
     // ── Dispatch to backend-specific emission ─────────────────────────────
     switch (backend_kind) {
-        .native => try emitNative(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level),
-        .jit => try emitJit(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level),
-        .wasm => try emitWasm(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level),
+        .native => try emitNative(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend),
+        .jit => try emitJit(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend),
+        .wasm => try emitWasm(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend),
         .c => {
             var stderr_buf: [4096]u8 = undefined;
             var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
@@ -1151,6 +1168,7 @@ fn emitNative(
     all_grin: rusholme.grin.ast.Program,
     output_name: []const u8,
     opt_level: rusholme.backend.llvm.OptLevel,
+    rts_backend: rusholme.backend.grin_to_llvm.RtsBackend,
 ) !void {
     const llvm = rusholme.backend.llvm;
     var arena = std.heap.ArenaAllocator.init(allocator);
@@ -1176,6 +1194,7 @@ fn emitNative(
         std.process.exit(1);
     };
     var translator = rusholme.backend.grin_to_llvm.GrinTranslator.init(arena_alloc, &registry);
+    translator.rts_backend = rts_backend;
     defer translator.deinit();
 
     // Translate each module to a separate LLVM module and emit its bitcode.
@@ -1334,6 +1353,7 @@ fn emitJit(
     all_grin: rusholme.grin.ast.Program,
     output_name: []const u8,
     opt_level: rusholme.backend.llvm.OptLevel,
+    rts_backend: rusholme.backend.grin_to_llvm.RtsBackend,
 ) !void {
     _ = session;
     const llvm = rusholme.backend.llvm;
@@ -1360,6 +1380,7 @@ fn emitJit(
         std.process.exit(1);
     };
     var translator = rusholme.backend.grin_to_llvm.GrinTranslator.init(arena_alloc, &registry);
+    translator.rts_backend = rts_backend;
     defer translator.deinit();
 
     // ── Per-module LLVM translation ───────────────────────────────────────
@@ -1511,6 +1532,7 @@ fn emitWasm(
     all_grin: rusholme.grin.ast.Program,
     output_name: []const u8,
     opt_level: rusholme.backend.llvm.OptLevel,
+    rts_backend: rusholme.backend.grin_to_llvm.RtsBackend,
 ) !void {
     _ = session; // Unused for WASM backend
     const llvm = rusholme.backend.llvm;
@@ -1537,6 +1559,7 @@ fn emitWasm(
         std.process.exit(1);
     };
     var translator = rusholme.backend.grin_to_llvm.GrinTranslator.init(arena_alloc, &registry);
+    translator.rts_backend = rts_backend;
     defer translator.deinit();
 
     // ── Per-module LLVM translation ───────────────────────────────────────

--- a/src/rts/heap.zig
+++ b/src/rts/heap.zig
@@ -1,10 +1,10 @@
-//! GC-swappable heap for the Rusholme runtime (issues #56, #70).
+//! GC-swappable heap for the Rusholme runtime (issues #56, #70, #776).
 //!
 //! All runtime heap operations go through the `GcAllocator` interface so
 //! that the GC strategy can be swapped without touching the rest of the
 //! RTS ("Phase 1 → Phase 2 is a swap, not a rewrite" — DESIGN.md):
 //!
-//!   - Phase 1 (current): `ArenaGc` — `std.heap.ArenaAllocator`-backed,
+//!   - Phase 1: `ArenaGc` — `std.heap.ArenaAllocator`-backed,
 //!     `free`/`collect` are no-ops, memory grows until program exit.
 //!   - Phase 2: Immix mark-region GC (#71, #72, #73) implementing the
 //!     same interface.
@@ -14,8 +14,17 @@
 //! additionally exposes `collect`, `stats`, and root registration —
 //! the hooks a tracing collector needs but a plain allocator does not.
 //! See docs/decisions/284-zig-gc-immix-reference.md for the design study.
+//!
+//! ## Backend selection (#776)
+//!
+//! The active backend is selected at startup via `rts_set_backend`,
+//! which generated `main()` calls before any allocation. The call is
+//! emitted by the GRIN→LLVM backend driven by the `rhc build --rts=…`
+//! flag — `arena` is the implicit default (no call emitted), so any
+//! pre-#776 binary continues to use the arena.
 
 const std = @import("std");
+const immix = @import("immix.zig");
 
 // ═══════════════════════════════════════════════════════════════════════
 // Allocation Statistics
@@ -205,45 +214,98 @@ pub const ArenaGc = struct {
 // Global Heap State
 // ═══════════════════════════════════════════════════════════════════════
 
+/// Backend identity. The numeric values are part of the
+/// `rts_set_backend` C ABI — keep them stable; new backends append.
+pub const RtsBackend = enum(u32) {
+    arena = 0,
+    immix = 1,
+};
+
 /// Global heap state for the running program.
 ///
-/// The concrete implementation is selected here at startup; everything
-/// else in the RTS sees only `GcAllocator` / `std.mem.Allocator`.
+/// The concrete backend is selected lazily on first allocation. The
+/// LLVM-generated `main()` calls `rts_set_backend` (when built with a
+/// non-default `--rts`) before any allocation so the desired backend
+/// is recorded before `State.ensureInit` runs.
 const State = struct {
-    var arena_gc: ArenaGc = undefined;
+    var selected: RtsBackend = .arena;
     var initialized: bool = false;
+    var arena_gc: ArenaGc = undefined;
+    var immix_gc: immix.ImmixGc = undefined;
 
-    fn get() *ArenaGc {
-        if (!initialized) {
-            arena_gc = ArenaGc.init(std.heap.page_allocator);
-            initialized = true;
+    fn ensureInit() void {
+        if (initialized) return;
+        switch (selected) {
+            .arena => arena_gc = ArenaGc.init(std.heap.page_allocator),
+            .immix => immix_gc = immix.ImmixGc.init(std.heap.page_allocator),
         }
-        return &arena_gc;
+        initialized = true;
+    }
+
+    fn deinitImpl() void {
+        if (!initialized) return;
+        switch (selected) {
+            .arena => arena_gc.deinit(),
+            .immix => immix_gc.deinit(),
+        }
+        initialized = false;
     }
 };
 
-/// Initialize the heap allocator.
+/// Select the runtime backend before the first allocation. Called by
+/// LLVM-generated `main()` when the program was built with a non-
+/// default `--rts`. Calling this after the heap has already been
+/// initialised is a no-op for the matching backend and a fatal error
+/// for a different backend (no live-swap support).
+pub export fn rts_set_backend(value: u32) callconv(.c) void {
+    const requested: RtsBackend = switch (value) {
+        @intFromEnum(RtsBackend.arena) => .arena,
+        @intFromEnum(RtsBackend.immix) => .immix,
+        else => @panic("rts_set_backend: unknown backend id"),
+    };
+    if (State.initialized) {
+        if (State.selected != requested) {
+            @panic("rts_set_backend called after heap was initialised");
+        }
+        return;
+    }
+    State.selected = requested;
+}
+
+/// Initialize the heap allocator. Optional — the heap initialises
+/// itself on first allocation. Provided so callers (tests, the WASM
+/// reactor entry) can pre-warm the heap.
 pub fn init() void {
-    _ = State.get();
+    State.ensureInit();
 }
 
 /// Cleanup the heap allocator.
 pub fn deinit() void {
-    if (State.initialized) {
-        State.arena_gc.deinit();
-        State.initialized = false;
-    }
+    State.deinitImpl();
 }
 
 /// Get the global heap as a generic allocator (routed through the
 /// GC-swappable interface's accounting).
 pub fn allocator() std.mem.Allocator {
-    return State.get().allocator();
+    State.ensureInit();
+    return switch (State.selected) {
+        .arena => State.arena_gc.allocator(),
+        .immix => State.immix_gc.allocator(),
+    };
 }
 
 /// Get the global heap through the GC-swappable interface.
 pub fn gcAllocator() GcAllocator {
-    return State.get().gcAllocator();
+    State.ensureInit();
+    return switch (State.selected) {
+        .arena => State.arena_gc.gcAllocator(),
+        .immix => State.immix_gc.gcAllocator(),
+    };
+}
+
+/// Currently-selected backend. Useful for diagnostics and tests.
+pub fn currentBackend() RtsBackend {
+    return State.selected;
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/src/rts/root.zig
+++ b/src/rts/root.zig
@@ -34,6 +34,7 @@ comptime {
     _ = &heap.init;
     _ = &heap.deinit;
     _ = &heap.allocator;
+    _ = &heap.rts_set_backend;
     
     // For WASM targets, also force compilation of the _start entry point
     // to allow automatic execution when the module is instantiated

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -275,6 +275,54 @@ test "e2e: -O3 invokes LLVM aggressive pipeline without crashing (#755)" {
     try testE2eOpt(std.testing.allocator, "e2e_001_hello", "-O3");
 }
 
+// ── Immix backend smoke tests (#776) ────────────────────────────────────
+//
+// Run a representative subset of programs under `--rts=immix` and
+// assert that they produce the same output as the default arena
+// backend. Once #781 lands (auto-trigger from the allocator), these
+// will start exercising collection on every run; until then they
+// verify the wiring (rts_set_backend → ImmixGc init → allocation
+// goes through the new backend) is correct.
+
+fn testE2eImmix(allocator: std.mem.Allocator, comptime basename: []const u8) !void {
+    return harness.testProgramWithFlags(
+        allocator,
+        e2e_dir,
+        basename,
+        null,
+        &.{ "--rts", "immix" },
+    );
+}
+
+test "e2e: --rts=immix runs hello world (#776)" {
+    try testE2eImmix(std.testing.allocator, "e2e_001_hello");
+}
+
+test "e2e: --rts=immix runs multi-putStrLn (#776)" {
+    try testE2eImmix(std.testing.allocator, "e2e_003_multi_putStrLn");
+}
+
+test "e2e: --rts=immix runs nested datatypes (#776)" {
+    try testE2eImmix(std.testing.allocator, "e2e_005_nested_datatypes");
+}
+
+test "e2e: rhc build rejects unknown --rts backend (#776)" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    const rhc_path = e2e_options.rhc_path;
+
+    const argv = [_][]const u8{ rhc_path, "build", "--rts", "bogus", "tests/e2e/e2e_001_hello.hs" };
+    const result = try process.run(allocator, io, .{ .argv = &argv });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .exited => |code| try std.testing.expect(code != 0),
+        else => return error.UnexpectedTermination,
+    }
+    try std.testing.expect(std.mem.indexOf(u8, result.stderr, "unknown RTS backend") != null);
+}
+
 test "e2e: rhc build rejects unknown -O level (#755)" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;

--- a/tests/hs_test_harness.zig
+++ b/tests/hs_test_harness.zig
@@ -134,6 +134,7 @@ fn runTest(
     expected_stderr: ?[]const u8,
     quiet: bool,
     opt_flag: ?[]const u8,
+    extra_build_args: []const []const u8,
 ) !bool {
     const io = std.testing.io;
     const rhc_path = e2e_options.rhc_path;
@@ -151,9 +152,9 @@ fn runTest(
     defer allocator.free(binary_path);
 
     // ── Step 1: Compile ───────────────────────────────────────────────────────
-    // Build argv with an optional `-O<level>` flag.  The flag must come
-    // before the positional source path so clap parses it correctly.
-    var argv_buf: [6][]const u8 = undefined;
+    // Build argv with optional extra `rhc build` flags.  Flags must come
+    // before the positional source path so clap parses them correctly.
+    var argv_buf: [12][]const u8 = undefined;
     var argv_len: usize = 0;
     argv_buf[argv_len] = rhc_path;
     argv_len += 1;
@@ -161,6 +162,10 @@ fn runTest(
     argv_len += 1;
     if (opt_flag) |flag| {
         argv_buf[argv_len] = flag;
+        argv_len += 1;
+    }
+    for (extra_build_args) |a| {
+        argv_buf[argv_len] = a;
         argv_len += 1;
     }
     argv_buf[argv_len] = hs_path;
@@ -257,6 +262,20 @@ pub fn testProgram(
     comptime basename: []const u8,
     opt_flag: ?[]const u8,
 ) !void {
+    return testProgramWithFlags(allocator, dir, basename, opt_flag, &.{});
+}
+
+/// Like `testProgram` but additionally forwards `extra_build_args`
+/// (e.g. `--rts=immix`) to `rhc build`. Used by the Immix end-to-end
+/// smoke tests in `e2e_test_runner.zig` to verify the same programs
+/// produce identical output under both heap backends.
+pub fn testProgramWithFlags(
+    allocator: std.mem.Allocator,
+    comptime dir: []const u8,
+    comptime basename: []const u8,
+    opt_flag: ?[]const u8,
+    extra_build_args: []const []const u8,
+) !void {
     const props = try readProperties(allocator, dir, basename);
     defer props.deinit(allocator);
     if (props.skip) return;
@@ -272,6 +291,7 @@ pub fn testProgram(
         props.expected_stderr,
         props.xfail,
         opt_flag,
+        extra_build_args,
     );
 
     if (props.xfail) {


### PR DESCRIPTION
Closes #776

## Summary

Wires `ImmixGc` behind the `GcAllocator` interface so the runtime
actually uses it. Before this PR, `ImmixGc` existed only as a class
reachable by direct construction (used by its own unit tests); the
global heap in `src/rts/heap.zig` was hardcoded to `ArenaGc`.

## How it works

- `src/rts/heap.zig` keeps the same lazy-init seam (`State.ensureInit`)
  but now switches on a `RtsBackend` enum populated by the new C-ABI
  export `rts_set_backend(value)`. Arena is the default; calling
  `rts_set_backend` after the heap has already initialised panics for
  a different backend (no live-swap).
- `rhc build --rts=arena|immix` parses the flag in `src/main.zig`
  and threads it through `emitNative`, `emitJit`, and `emitWasm` to
  the GRIN→LLVM translator.
- The translator gains an `rts_backend` field. For native `main`, if
  the user picked a non-default backend, the very first instruction
  of `main`'s entry block becomes a `call void @rts_set_backend(i32 N)`
  so the heap picks up the selection before any allocation. Arena
  matches the lazy-init default, so its codegen path stays unchanged
  (no call emitted).

## End-to-end testing

```
nix develop --command zig build test --summary all
# Build Summary: 51/51 steps succeeded; 1161/1161 tests passed
# +- run test e2e-tests 63 pass (63 total)
```

Three programs (`e2e_001_hello`, `e2e_003_multi_putStrLn`,
`e2e_005_nested_datatypes`) run under `--rts=immix` and produce the
same output as the default arena backend. A negative test asserts
`rhc build --rts=bogus` exits non-zero with the right error message.

The harness gained a public `testProgramWithFlags` entry point that
forwards an arbitrary `extra_build_args` slice to `rhc build`; the
existing `testProgram` is now a thin wrapper.

## Deliverables

- [x] `RtsBackend { arena, immix }` enum selected at startup, defaults
  to `arena`
- [x] `rhc build --rts=arena|immix` (wired through native/jit/wasm)
- [x] `ImmixGc` reachable via `heap.allocator()` / `heap.gcAllocator()`
  when the program was built with `--rts=immix`
- [x] e2e coverage of a representative sample under both backends

## Not in scope (filed)

- **#780** shadow-stack ABI for precise GC roots — still the biggest
  gating item before Immix is production-safe.
- **#781** auto-trigger collection from the allocator — until this
  lands, `--rts=immix` binaries grow monotonically until exit.
- **#779** per-constructor pointer-mask tables for precise tracing.
