### PR TITLE
#781: Auto-trigger Immix collection from the allocator

### DIFF
--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -378,6 +378,18 @@ fn declareRtsAlloc(module: llvm.Module) llvm.Value {
     return c.LLVMAddFunction(module, name, fn_ty);
 }
 
+/// Declare `rts_set_backend(value: i32) -> void`. The RTS reads this
+/// once on the first allocation to choose between `ArenaGc` and
+/// `ImmixGc`; subsequent calls with the same value are no-ops. See
+/// `src/rts/heap.zig`.
+fn declareRtsSetBackend(module: llvm.Module) llvm.Value {
+    const name = "rts_set_backend";
+    if (c.LLVMGetNamedFunction(module, name)) |existing| return existing;
+    var params = [_]llvm.Type{llvm.i32Type()};
+    const fn_ty = c.LLVMFunctionType(llvm.voidType(), &params, 1, 0);
+    return c.LLVMAddFunction(module, name, fn_ty);
+}
+
 /// Declare `rts_store_field(node: ptr, index: i32, value: i64) -> void`.
 fn declareRtsStoreField(module: llvm.Module) llvm.Value {
     const name = "rts_store_field";
@@ -475,6 +487,20 @@ const TypeEnv = struct {
     }
 };
 
+/// Selects which RTS heap backend the generated `main` initialises
+/// before user code runs. Mirrors `RtsBackend` in `src/rts/heap.zig`
+/// — keep the numeric values in sync (they cross the C ABI).
+pub const RtsBackend = enum(u32) {
+    arena = 0,
+    immix = 1,
+
+    pub fn parse(s: []const u8) ?RtsBackend {
+        if (std.mem.eql(u8, s, "arena")) return .arena;
+        if (std.mem.eql(u8, s, "immix")) return .immix;
+        return null;
+    }
+};
+
 pub const GrinTranslator = struct {
     ctx: llvm.Context,
     module: llvm.Module,
@@ -512,6 +538,14 @@ pub const GrinTranslator = struct {
     /// Function arity map for correct forward declarations (issue #595).
     /// Maps function unique IDs to their parameter counts.
     arity_map: ?*const std.AutoHashMapUnmanaged(u64, u32) = null,
+
+    /// RTS backend selected by `rhc build --rts=…`. When non-`.arena`
+    /// the translator emits a `call void @rts_set_backend(i32 N)` at
+    /// the very start of `main`'s entry block, before any other
+    /// instruction. `.arena` matches the default lazy-init behaviour
+    /// in `src/rts/heap.zig` and is therefore a no-op for codegen.
+    /// See issue #776.
+    rts_backend: RtsBackend = .arena,
 
     pub fn init(allocator: std.mem.Allocator, registry: *TagRegistry) GrinTranslator {
         llvm.initialize();
@@ -565,6 +599,22 @@ pub const GrinTranslator = struct {
     /// Used by entry-point functions that need to return a
     /// distinguishable "no value" result (as opposed to integer 0,
     /// which is boolean False).
+    /// Emit `rts_set_backend(value)` at the current builder position.
+    /// Generated as the first instruction of native `main` whenever
+    /// the user picks a non-default backend (see #776).
+    fn emitSetRtsBackendCall(self: *GrinTranslator, value: u32) void {
+        const fn_val = declareRtsSetBackend(self.module);
+        var args = [_]llvm.Value{c.LLVMConstInt(llvm.i32Type(), value, 0)};
+        _ = c.LLVMBuildCall2(
+            self.builder,
+            llvm.getFunctionType(fn_val),
+            fn_val,
+            &args,
+            1,
+            "",
+        );
+    }
+
     fn buildUnitNode(self: *GrinTranslator) llvm.Value {
         const rts_alloc_fn = declareRtsAlloc(self.module);
         const unit_tag = @intFromEnum(rts_node.Tag.Unit);
@@ -796,6 +846,15 @@ pub const GrinTranslator = struct {
         self.current_func = func;
         const entry_bb = llvm.appendBasicBlock(func, "entry");
         llvm.positionBuilderAtEnd(self.builder, entry_bb);
+
+        // For native `main`, if the user selected a non-default RTS
+        // backend (#776), emit `call void @rts_set_backend(i32 N)` as
+        // the very first instruction so the heap picks up the
+        // selection before any allocation. Arena is the default, so
+        // codegen omits the call (it matches lazy init).
+        if (is_entry and !is_repl_entry and self.rts_backend != .arena) {
+            self.emitSetRtsBackendCall(@intFromEnum(self.rts_backend));
+        }
 
         // Clear previous function's parameter mapping and set up current one.
         self.params.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -226,6 +226,7 @@ pub fn main(init: std.process.Init) !void {
                 \\-o, --output <str>           Output file name (default: stem of first input).
                 \\-O, --opt-level <str>        Optimisation level: 0|1|2|3|s|z (default: 2 for native, 0 otherwise).
                 \\    --backend <str>          Backend: native (default), jit, wasm, c.
+                \\    --rts <str>              RTS heap backend: arena (default) or immix.
                 \\    --package-db <str>...    Package database path (may be repeated).
                 \\    --repl                   Compile for REPL use (internal).
                 \\<str>...
@@ -240,6 +241,7 @@ pub fn main(init: std.process.Init) !void {
                 \\-o, --output <str>           Output file name (default: stem of first input).
                 \\-O, --opt-level <str>        Optimisation level: 0|1|2|3|s|z (default: 2 for native, 0 otherwise).
                 \\    --backend <str>          Backend: native (default), jit, wasm, c.
+                \\    --rts <str>              RTS heap backend: arena (default) or immix.
                 \\    --package-db <str>...    Package database path (may be repeated).
                 \\<str>...
                 \\
@@ -306,6 +308,20 @@ pub fn main(init: std.process.Init) !void {
                 .jit, .wasm, .c => rusholme.backend.llvm.OptLevel.O0,
             };
 
+            const rts_backend: rusholme.backend.grin_to_llvm.RtsBackend = if (build_res.args.rts) |rts_str|
+                rusholme.backend.grin_to_llvm.RtsBackend.parse(rts_str) orelse {
+                    var buf: [512]u8 = undefined;
+                    var fw: File.Writer = .init(.stderr(), io, &buf);
+                    try fw.interface.print(
+                        "rhc build: unknown RTS backend '{s}'\nValid backends: arena, immix\n",
+                        .{rts_str},
+                    );
+                    try fw.interface.flush();
+                    std.process.exit(1);
+                }
+            else
+                rusholme.backend.grin_to_llvm.RtsBackend.arena;
+
             return cmdBuild(
                 allocator,
                 io,
@@ -315,6 +331,7 @@ pub fn main(init: std.process.Init) !void {
                 build_res.args.repl != 0,
                 build_res.args.@"package-db",
                 opt_level,
+                rts_backend,
             );
         },
 
@@ -944,7 +961,7 @@ fn loadPrelude(
 /// - native: compiles to native executable via LLVM
 /// - wasm: compiles to WebAssembly binary (.wasm)
 /// - jit, c: not yet implemented
-fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8, output_name: []const u8, backend_kind: rusholme.backend.backend_mod.BackendKind, is_repl: bool, package_dbs: []const []const u8, opt_level: rusholme.backend.llvm.OptLevel) !void {
+fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8, output_name: []const u8, backend_kind: rusholme.backend.backend_mod.BackendKind, is_repl: bool, package_dbs: []const []const u8, opt_level: rusholme.backend.llvm.OptLevel, rts_backend: rusholme.backend.grin_to_llvm.RtsBackend) !void {
     // REPL mode placeholder - for WASM backend compiles stateful REPL
     _ = is_repl;
 
@@ -1125,9 +1142,9 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
 
     // ── Dispatch to backend-specific emission ─────────────────────────────
     switch (backend_kind) {
-        .native => try emitNative(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level),
-        .jit => try emitJit(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level),
-        .wasm => try emitWasm(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level),
+        .native => try emitNative(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend),
+        .jit => try emitJit(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend),
+        .wasm => try emitWasm(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend),
         .c => {
             var stderr_buf: [4096]u8 = undefined;
             var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
@@ -1151,6 +1168,7 @@ fn emitNative(
     all_grin: rusholme.grin.ast.Program,
     output_name: []const u8,
     opt_level: rusholme.backend.llvm.OptLevel,
+    rts_backend: rusholme.backend.grin_to_llvm.RtsBackend,
 ) !void {
     const llvm = rusholme.backend.llvm;
     var arena = std.heap.ArenaAllocator.init(allocator);
@@ -1176,6 +1194,7 @@ fn emitNative(
         std.process.exit(1);
     };
     var translator = rusholme.backend.grin_to_llvm.GrinTranslator.init(arena_alloc, &registry);
+    translator.rts_backend = rts_backend;
     defer translator.deinit();
 
     // Translate each module to a separate LLVM module and emit its bitcode.
@@ -1334,6 +1353,7 @@ fn emitJit(
     all_grin: rusholme.grin.ast.Program,
     output_name: []const u8,
     opt_level: rusholme.backend.llvm.OptLevel,
+    rts_backend: rusholme.backend.grin_to_llvm.RtsBackend,
 ) !void {
     _ = session;
     const llvm = rusholme.backend.llvm;
@@ -1360,6 +1380,7 @@ fn emitJit(
         std.process.exit(1);
     };
     var translator = rusholme.backend.grin_to_llvm.GrinTranslator.init(arena_alloc, &registry);
+    translator.rts_backend = rts_backend;
     defer translator.deinit();
 
     // ── Per-module LLVM translation ───────────────────────────────────────
@@ -1511,6 +1532,7 @@ fn emitWasm(
     all_grin: rusholme.grin.ast.Program,
     output_name: []const u8,
     opt_level: rusholme.backend.llvm.OptLevel,
+    rts_backend: rusholme.backend.grin_to_llvm.RtsBackend,
 ) !void {
     _ = session; // Unused for WASM backend
     const llvm = rusholme.backend.llvm;
@@ -1537,6 +1559,7 @@ fn emitWasm(
         std.process.exit(1);
     };
     var translator = rusholme.backend.grin_to_llvm.GrinTranslator.init(arena_alloc, &registry);
+    translator.rts_backend = rts_backend;
     defer translator.deinit();
 
     // ── Per-module LLVM translation ───────────────────────────────────────

--- a/src/rts/heap.zig
+++ b/src/rts/heap.zig
@@ -1,10 +1,10 @@
-//! GC-swappable heap for the Rusholme runtime (issues #56, #70).
+//! GC-swappable heap for the Rusholme runtime (issues #56, #70, #776).
 //!
 //! All runtime heap operations go through the `GcAllocator` interface so
 //! that the GC strategy can be swapped without touching the rest of the
 //! RTS ("Phase 1 → Phase 2 is a swap, not a rewrite" — DESIGN.md):
 //!
-//!   - Phase 1 (current): `ArenaGc` — `std.heap.ArenaAllocator`-backed,
+//!   - Phase 1: `ArenaGc` — `std.heap.ArenaAllocator`-backed,
 //!     `free`/`collect` are no-ops, memory grows until program exit.
 //!   - Phase 2: Immix mark-region GC (#71, #72, #73) implementing the
 //!     same interface.
@@ -14,8 +14,17 @@
 //! additionally exposes `collect`, `stats`, and root registration —
 //! the hooks a tracing collector needs but a plain allocator does not.
 //! See docs/decisions/284-zig-gc-immix-reference.md for the design study.
+//!
+//! ## Backend selection (#776)
+//!
+//! The active backend is selected at startup via `rts_set_backend`,
+//! which generated `main()` calls before any allocation. The call is
+//! emitted by the GRIN→LLVM backend driven by the `rhc build --rts=…`
+//! flag — `arena` is the implicit default (no call emitted), so any
+//! pre-#776 binary continues to use the arena.
 
 const std = @import("std");
+const immix = @import("immix.zig");
 
 // ═══════════════════════════════════════════════════════════════════════
 // Allocation Statistics
@@ -205,45 +214,98 @@ pub const ArenaGc = struct {
 // Global Heap State
 // ═══════════════════════════════════════════════════════════════════════
 
+/// Backend identity. The numeric values are part of the
+/// `rts_set_backend` C ABI — keep them stable; new backends append.
+pub const RtsBackend = enum(u32) {
+    arena = 0,
+    immix = 1,
+};
+
 /// Global heap state for the running program.
 ///
-/// The concrete implementation is selected here at startup; everything
-/// else in the RTS sees only `GcAllocator` / `std.mem.Allocator`.
+/// The concrete backend is selected lazily on first allocation. The
+/// LLVM-generated `main()` calls `rts_set_backend` (when built with a
+/// non-default `--rts`) before any allocation so the desired backend
+/// is recorded before `State.ensureInit` runs.
 const State = struct {
-    var arena_gc: ArenaGc = undefined;
+    var selected: RtsBackend = .arena;
     var initialized: bool = false;
+    var arena_gc: ArenaGc = undefined;
+    var immix_gc: immix.ImmixGc = undefined;
 
-    fn get() *ArenaGc {
-        if (!initialized) {
-            arena_gc = ArenaGc.init(std.heap.page_allocator);
-            initialized = true;
+    fn ensureInit() void {
+        if (initialized) return;
+        switch (selected) {
+            .arena => arena_gc = ArenaGc.init(std.heap.page_allocator),
+            .immix => immix_gc = immix.ImmixGc.init(std.heap.page_allocator),
         }
-        return &arena_gc;
+        initialized = true;
+    }
+
+    fn deinitImpl() void {
+        if (!initialized) return;
+        switch (selected) {
+            .arena => arena_gc.deinit(),
+            .immix => immix_gc.deinit(),
+        }
+        initialized = false;
     }
 };
 
-/// Initialize the heap allocator.
+/// Select the runtime backend before the first allocation. Called by
+/// LLVM-generated `main()` when the program was built with a non-
+/// default `--rts`. Calling this after the heap has already been
+/// initialised is a no-op for the matching backend and a fatal error
+/// for a different backend (no live-swap support).
+pub export fn rts_set_backend(value: u32) callconv(.c) void {
+    const requested: RtsBackend = switch (value) {
+        @intFromEnum(RtsBackend.arena) => .arena,
+        @intFromEnum(RtsBackend.immix) => .immix,
+        else => @panic("rts_set_backend: unknown backend id"),
+    };
+    if (State.initialized) {
+        if (State.selected != requested) {
+            @panic("rts_set_backend called after heap was initialised");
+        }
+        return;
+    }
+    State.selected = requested;
+}
+
+/// Initialize the heap allocator. Optional — the heap initialises
+/// itself on first allocation. Provided so callers (tests, the WASM
+/// reactor entry) can pre-warm the heap.
 pub fn init() void {
-    _ = State.get();
+    State.ensureInit();
 }
 
 /// Cleanup the heap allocator.
 pub fn deinit() void {
-    if (State.initialized) {
-        State.arena_gc.deinit();
-        State.initialized = false;
-    }
+    State.deinitImpl();
 }
 
 /// Get the global heap as a generic allocator (routed through the
 /// GC-swappable interface's accounting).
 pub fn allocator() std.mem.Allocator {
-    return State.get().allocator();
+    State.ensureInit();
+    return switch (State.selected) {
+        .arena => State.arena_gc.allocator(),
+        .immix => State.immix_gc.allocator(),
+    };
 }
 
 /// Get the global heap through the GC-swappable interface.
 pub fn gcAllocator() GcAllocator {
-    return State.get().gcAllocator();
+    State.ensureInit();
+    return switch (State.selected) {
+        .arena => State.arena_gc.gcAllocator(),
+        .immix => State.immix_gc.gcAllocator(),
+    };
+}
+
+/// Currently-selected backend. Useful for diagnostics and tests.
+pub fn currentBackend() RtsBackend {
+    return State.selected;
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/src/rts/immix.zig
+++ b/src/rts/immix.zig
@@ -180,6 +180,14 @@ pub const PAYLOAD_BYTES: usize = PAYLOAD_LINES * LINE_SIZE;
 /// is routed to the large-object space.
 pub const MAX_BLOCK_ALLOC: usize = PAYLOAD_BYTES;
 
+/// Initial heap budget for the auto-collect trigger (#781). Chosen so
+/// short-running programs do not pay the cost of a collection at all
+/// (8 blocks ≈ 256 KiB of live data), while long-running programs see
+/// their first collection promptly after passing that threshold. The
+/// budget is re-tuned upward after each cycle proportional to the
+/// post-collection live size.
+pub const INITIAL_TARGET_BLOCKS: u64 = 8;
+
 comptime {
     // The header must fit in a small, fixed number of lines, leaving the
     // overwhelming majority of the block as payload. If this assertion
@@ -278,6 +286,27 @@ pub const ImmixGc = struct {
     /// Number of LOS slabs owned by this heap.
     large_objects_allocated: u64 = 0,
 
+    // ── Auto-collect trigger (#781) ──────────────────────────────────
+    /// When `true`, the allocator calls `collect()` automatically once
+    /// the live block count is about to exceed `target_blocks`. **Off
+    /// by default**: enabling it on a heap with no roots is
+    /// catastrophic (collect would reap everything live). Callers must
+    /// either register precise roots (`addRoot`) or arm the
+    /// conservative scan (`setStackBase`) before turning this on. See
+    /// issue #781 and the docstring on `setAutoCollect`.
+    auto_collect_enabled: bool = false,
+    /// Live block budget. Once `blocks_allocated >= target_blocks` the
+    /// allocator runs a collection before requesting fresh memory; the
+    /// budget is then re-tuned to `max(min_target_blocks, 2 × live)`.
+    target_blocks: u64 = INITIAL_TARGET_BLOCKS,
+    /// Floor for the auto-tuned budget — collections never fire more
+    /// often than once per `min_target_blocks` allocations.
+    min_target_blocks: u64 = INITIAL_TARGET_BLOCKS,
+    /// Guard: while collect() is running we must not recursively try
+    /// to collect again from inside the mark phase's child-allocator
+    /// path (the worklist is backed by `self.child`, not this heap).
+    in_collect: bool = false,
+
     pub fn init(child: std.mem.Allocator) ImmixGc {
         return .{ .child = child };
     }
@@ -289,6 +318,30 @@ pub const ImmixGc = struct {
     /// explicit roots registered via `addRoot`.
     pub fn setStackBase(self: *ImmixGc, frame_address: usize) void {
         self.stack_base = frame_address;
+    }
+
+    /// Enable or disable automatic collection from the allocation path
+    /// (#781). When enabled, the allocator runs `collect()` before
+    /// requesting a fresh block once the live block count crosses
+    /// `target_blocks`, then re-tunes the budget to twice the
+    /// post-collection live size (floored at `min_target_blocks`).
+    ///
+    /// **Safety**: enabling this on a heap with no roots reaps every
+    /// live object. Callers must either register precise roots via
+    /// `addRoot` for every live `*Node`, or arm the conservative scan
+    /// via `setStackBase` (transitional; unsafe in optimised builds —
+    /// see [#780](https://github.com/adinapoli/rusholme/issues/780)
+    /// for the precise-roots replacement).
+    pub fn setAutoCollect(self: *ImmixGc, enabled: bool) void {
+        self.auto_collect_enabled = enabled;
+    }
+
+    /// Set the heap budget (initial value of `target_blocks`). Useful
+    /// for tests that want collections to fire deterministically after
+    /// a known number of blocks.
+    pub fn setTargetBlocks(self: *ImmixGc, target: u64) void {
+        self.target_blocks = target;
+        self.min_target_blocks = target;
     }
 
     pub fn deinit(self: *ImmixGc) void {
@@ -425,44 +478,90 @@ pub const ImmixGc = struct {
         // line geometry entirely and live in the large-object space.
         if (len > MAX_BLOCK_ALLOC) return self.allocLarge(len, alignment);
 
-        // Fast path: the requested allocation fits in the current hole.
-        if (self.current_block != null) {
+        if (self.tryAllocInCurrent(len, alignment)) |p| return p;
+        if (self.tryAllocInRecyclable(len, alignment)) |p| return p;
+
+        // Recycle pool exhausted (or every hole is too small for this
+        // request). If the auto-collect trigger is armed and the heap
+        // budget has been crossed, run a collection and try the
+        // recyclable pool again — collect frees up lines so the second
+        // pass usually fits.
+        if (self.auto_collect_enabled and !self.in_collect and
+            self.blocks_allocated >= self.target_blocks)
+        {
+            self.collect();
+            self.retuneBudgetAfterCollect();
+            if (self.tryAllocInCurrent(len, alignment)) |p| return p;
+            if (self.tryAllocInRecyclable(len, alignment)) |p| return p;
+        }
+
+        // Last resort: request a fresh block from the child allocator.
+        if (self.newBlock()) |b| {
+            self.attachBlockAsCurrent(b);
+            if (self.tryAllocInCurrent(len, alignment)) |p| return p;
+        }
+        return null;
+    }
+
+    /// Try to satisfy a request from the current block — first by
+    /// bumping in the active hole, then by scanning forward through
+    /// any remaining free holes inside the same block. Returns null
+    /// without mutating state if no hole fits.
+    fn tryAllocInCurrent(self: *ImmixGc, len: usize, alignment: std.mem.Alignment) ?[*]u8 {
+        if (self.current_block == null) return null;
+        if (self.bumpInCurrentHole(len, alignment)) |p| {
+            self.stats_data.bytes_allocated += len;
+            return p;
+        }
+        while (self.advanceToHole(len, alignment)) {
             if (self.bumpInCurrentHole(len, alignment)) |p| {
                 self.stats_data.bytes_allocated += len;
                 return p;
             }
-            // Walk forward through any remaining holes in the current
-            // block — after a collection these can appear between live
-            // lines, not just at the tail.
-            while (self.advanceToHole(len, alignment)) {
-                if (self.bumpInCurrentHole(len, alignment)) |p| {
-                    self.stats_data.bytes_allocated += len;
-                    return p;
-                }
-            }
-        }
-
-        // Current block exhausted (or no current block yet). Pull
-        // blocks one at a time from recyclable/free lists or the child
-        // allocator until one offers a hole big enough.
-        //
-        // Note: the Immix paper distinguishes a dedicated *overflow
-        // cursor* (medium objects skip small holes and go to fresh
-        // blocks to avoid wasting them). We use the simpler single-
-        // cursor design here; a dedicated overflow path is tracked
-        // separately.
-        while (self.allocBlock()) |fresh| {
-            self.attachBlockAsCurrent(fresh);
-            while (self.advanceToHole(len, alignment)) {
-                if (self.bumpInCurrentHole(len, alignment)) |p| {
-                    self.stats_data.bytes_allocated += len;
-                    return p;
-                }
-            }
-            // Block is too fragmented for this request — its lists are
-            // restored on the next loop iteration's attachBlockAsCurrent.
         }
         return null;
+    }
+
+    /// Walk the recyclable and free block lists looking for one that
+    /// can satisfy the request. Each block is visited at most once —
+    /// blocks whose holes don't fit are reclassified onto the original
+    /// list and the search continues. Returns null when no eligible
+    /// block remains.
+    fn tryAllocInRecyclable(self: *ImmixGc, len: usize, alignment: std.mem.Alignment) ?[*]u8 {
+        const initial_blocks = self.blocks_allocated;
+        var visited: u64 = 0;
+        while (visited < initial_blocks) : (visited += 1) {
+            const next = self.popReusableBlock() orelse return null;
+            self.attachBlockAsCurrent(next);
+            if (self.tryAllocInCurrent(len, alignment)) |p| return p;
+        }
+        return null;
+    }
+
+    /// Detach a block from `recyclable_blocks` (preferred) or
+    /// `free_blocks`, returning it ready to be made current. Returns
+    /// null if both lists are empty.
+    fn popReusableBlock(self: *ImmixGc) ?*BlockHeader {
+        if (self.recyclable_blocks) |b| {
+            self.recyclable_blocks = b.next;
+            b.next = null;
+            return b;
+        }
+        if (self.free_blocks) |b| {
+            self.free_blocks = b.next;
+            b.next = null;
+            return b;
+        }
+        return null;
+    }
+
+    fn retuneBudgetAfterCollect(self: *ImmixGc) void {
+        var live_blocks: u64 = 0;
+        var b = self.full_blocks;
+        while (b) |bb| : (b = bb.next) live_blocks += 1;
+        b = self.recyclable_blocks;
+        while (b) |bb| : (b = bb.next) live_blocks += 1;
+        self.target_blocks = @max(self.min_target_blocks, live_blocks * 2);
     }
 
     /// Try to allocate `len` bytes from the current hole. Returns the
@@ -563,27 +662,6 @@ pub const ImmixGc = struct {
         }
     }
 
-    /// Request a fresh, zero-line-mark block from the child allocator
-    /// (or reuse one from `free_blocks` / `recyclable_blocks`). The
-    /// returned block is removed from any list it lived on.
-    fn allocBlock(self: *ImmixGc) ?*BlockHeader {
-        // Prefer recyclable blocks (paper: bump into existing holes
-        // before grabbing a fresh block). With no collection yet,
-        // recyclable_blocks is normally empty — but keeping the order
-        // correct here means #72 only needs to add free-line reclamation
-        // and the allocation policy already does the right thing.
-        if (self.recyclable_blocks) |b| {
-            self.recyclable_blocks = b.next;
-            b.next = null;
-            return b;
-        }
-        if (self.free_blocks) |b| {
-            self.free_blocks = b.next;
-            b.next = null;
-            return b;
-        }
-        return self.newBlock();
-    }
 
     /// Request a brand new 32 KB block, aligned to its own size, from
     /// the child allocator. Initialises the header and threads it onto
@@ -663,6 +741,13 @@ pub const ImmixGc = struct {
     ///   6. Reset the bump cursor so the next allocation picks a hole
     ///      from a recyclable block (if any).
     pub fn collect(self: *ImmixGc) void {
+        // Re-entry guard: the worklist allocator path or any other
+        // helper that could indirectly trigger a collection must see
+        // `in_collect` as true and skip.
+        if (self.in_collect) return;
+        self.in_collect = true;
+        defer self.in_collect = false;
+
         const new_id = std.math.add(u32, self.mark_id, 1) catch blk: {
             // u32 wrap. Reset every node's mark on the heap and start
             // over at 1. Practically unreachable for any realistic
@@ -779,7 +864,8 @@ pub const ImmixGc = struct {
         for (self.roots.items) |slot| {
             const w = slot.*;
             if (self.isHeapPointer(w)) {
-                work.append(self.child, @ptrFromInt(w)) catch @panic("Immix: out of memory during mark");
+                const addr: usize = @intCast(w);
+                work.append(self.child, @ptrFromInt(addr)) catch @panic("Immix: out of memory during mark");
             }
         }
         self.drainMarkWorklist(&work);
@@ -800,9 +886,10 @@ pub const ImmixGc = struct {
         const word_size = @sizeOf(usize);
         var p = std.mem.alignForward(usize, start, word_size);
         while (p + word_size <= end) : (p += word_size) {
-            const w = @as(*const usize, @ptrFromInt(p)).*;
+            const w: u64 = @as(*const usize, @ptrFromInt(p)).*;
             if (self.isHeapPointer(w)) {
-                work.append(self.child, @ptrFromInt(w)) catch @panic("Immix: out of memory during mark");
+                const addr: usize = @intCast(w);
+                work.append(self.child, @ptrFromInt(addr)) catch @panic("Immix: out of memory during mark");
             }
         }
         self.drainMarkWorklist(&work);
@@ -835,7 +922,8 @@ pub const ImmixGc = struct {
                     if (node.n_fields >= 1) {
                         const w = nodemod.fieldsConst(node)[0];
                         if (self.isHeapPointer(w)) {
-                            work.append(self.child, @ptrFromInt(w)) catch @panic("Immix: out of memory during mark");
+                            const addr: usize = @intCast(w);
+                            work.append(self.child, @ptrFromInt(addr)) catch @panic("Immix: out of memory during mark");
                         }
                     }
                 },
@@ -846,7 +934,8 @@ pub const ImmixGc = struct {
                     // make this precise; tracked separately.
                     for (nodemod.fieldsConst(node)) |w| {
                         if (self.isHeapPointer(w)) {
-                            work.append(self.child, @ptrFromInt(w)) catch @panic("Immix: out of memory during mark");
+                            const addr: usize = @intCast(w);
+                            work.append(self.child, @ptrFromInt(addr)) catch @panic("Immix: out of memory during mark");
                         }
                     }
                 },
@@ -1446,4 +1535,100 @@ test "Immix: isHeapPointer rejects non-pointer words" {
     try testing.expect(!gc.isHeapPointer(0));
     try testing.expect(!gc.isHeapPointer(7)); // misaligned
     try testing.expect(!gc.isHeapPointer(0xdeadbeef_00000000));
+}
+
+// ── Auto-collect trigger (#781) ──────────────────────────────────────
+
+test "Immix: auto-collect is off by default" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    try testing.expect(!gc.auto_collect_enabled);
+}
+
+test "Immix: setAutoCollect with a tiny budget triggers collect on grow" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    gc.setAutoCollect(true);
+    gc.setTargetBlocks(2);
+
+    // Allocate enough small nodes to force at least three blocks if
+    // collection never runs. With auto-collect on and no roots, the
+    // collector reaps everything between bursts, so the live block
+    // count never exceeds the budget by much and `collections > 0`.
+    const a = gc.gcAllocator();
+    // Allocate 4× the payload of a single block.  With target=2 this
+    // forces at least one auto-collect cycle.
+    var i: usize = 0;
+    while (i < 4) : (i += 1) {
+        var j: usize = 0;
+        while (j < (PAYLOAD_BYTES / 256)) : (j += 1) {
+            _ = try a.alloc(256, .of(u64));
+        }
+    }
+    try testing.expect(a.stats().collections > 0);
+}
+
+test "Immix: auto-collect with rooted node preserves the root" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    gc.setAutoCollect(true);
+    gc.setTargetBlocks(2);
+
+    // Pre-allocate a Data node and root it.
+    const live = try newNode(&gc, .Data, 1);
+    nodemod.fields(live)[0] = 0xCAFE;
+    var slot: u64 = @intFromPtr(live);
+    gc.gcAllocator().addRoot(&slot);
+    defer gc.gcAllocator().removeRoot(&slot);
+
+    // Burn enough block-sized allocations to push past the 2-block
+    // budget — 256-byte slabs are unrelated to `Node` layout but
+    // they exercise the same code path and let the iteration count
+    // match the byte budget exactly.
+    const a = gc.gcAllocator();
+    var i: usize = 0;
+    while (i < (PAYLOAD_BYTES * 4 / 256)) : (i += 1) {
+        _ = try a.alloc(256, .of(u64));
+    }
+    try testing.expect(a.stats().collections > 0);
+    // The rooted node must still be reachable and unmolested.
+    try testing.expectEqual(@as(u64, 0xCAFE), nodemod.fields(live)[0]);
+}
+
+test "Immix: target_blocks grows after a non-trivial live set" {
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    gc.setAutoCollect(true);
+    gc.setTargetBlocks(2);
+
+    // Pin a handful of nodes so each collection retains them.
+    var pinned: [4]u64 = .{ 0, 0, 0, 0 };
+    for (&pinned) |*slot| {
+        const n = try newNode(&gc, .Int, 1);
+        slot.* = @intFromPtr(n);
+        gc.gcAllocator().addRoot(slot);
+    }
+    defer for (&pinned) |*slot| gc.gcAllocator().removeRoot(slot);
+
+    const start_target = gc.target_blocks;
+    const a = gc.gcAllocator();
+    var i: usize = 0;
+    while (i < (PAYLOAD_BYTES * 4 / 256)) : (i += 1) {
+        _ = try a.alloc(256, .of(u64));
+    }
+    // After the first collection the budget should have re-tuned to
+    // at least the floor, and (since the rooted nodes are tiny) it
+    // should not have shrunk below the floor either.
+    try testing.expect(gc.target_blocks >= start_target);
+}
+
+test "Immix: collect() is re-entrant safe" {
+    // Calling collect from inside collect (defensively, e.g. if the
+    // worklist allocator path ever triggered a collection) must be a
+    // no-op rather than a stack overflow.
+    var gc = ImmixGc.init(testing.allocator);
+    defer gc.deinit();
+    gc.in_collect = true;
+    gc.collect();
+    try testing.expectEqual(@as(u64, 0), gc.stats_data.collections);
 }

--- a/src/rts/root.zig
+++ b/src/rts/root.zig
@@ -34,6 +34,7 @@ comptime {
     _ = &heap.init;
     _ = &heap.deinit;
     _ = &heap.allocator;
+    _ = &heap.rts_set_backend;
     
     // For WASM targets, also force compilation of the _start entry point
     // to allow automatic execution when the module is instantiated

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -275,6 +275,54 @@ test "e2e: -O3 invokes LLVM aggressive pipeline without crashing (#755)" {
     try testE2eOpt(std.testing.allocator, "e2e_001_hello", "-O3");
 }
 
+// ── Immix backend smoke tests (#776) ────────────────────────────────────
+//
+// Run a representative subset of programs under `--rts=immix` and
+// assert that they produce the same output as the default arena
+// backend. Once #781 lands (auto-trigger from the allocator), these
+// will start exercising collection on every run; until then they
+// verify the wiring (rts_set_backend → ImmixGc init → allocation
+// goes through the new backend) is correct.
+
+fn testE2eImmix(allocator: std.mem.Allocator, comptime basename: []const u8) !void {
+    return harness.testProgramWithFlags(
+        allocator,
+        e2e_dir,
+        basename,
+        null,
+        &.{ "--rts", "immix" },
+    );
+}
+
+test "e2e: --rts=immix runs hello world (#776)" {
+    try testE2eImmix(std.testing.allocator, "e2e_001_hello");
+}
+
+test "e2e: --rts=immix runs multi-putStrLn (#776)" {
+    try testE2eImmix(std.testing.allocator, "e2e_003_multi_putStrLn");
+}
+
+test "e2e: --rts=immix runs nested datatypes (#776)" {
+    try testE2eImmix(std.testing.allocator, "e2e_005_nested_datatypes");
+}
+
+test "e2e: rhc build rejects unknown --rts backend (#776)" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    const rhc_path = e2e_options.rhc_path;
+
+    const argv = [_][]const u8{ rhc_path, "build", "--rts", "bogus", "tests/e2e/e2e_001_hello.hs" };
+    const result = try process.run(allocator, io, .{ .argv = &argv });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .exited => |code| try std.testing.expect(code != 0),
+        else => return error.UnexpectedTermination,
+    }
+    try std.testing.expect(std.mem.indexOf(u8, result.stderr, "unknown RTS backend") != null);
+}
+
 test "e2e: rhc build rejects unknown -O level (#755)" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;

--- a/tests/hs_test_harness.zig
+++ b/tests/hs_test_harness.zig
@@ -134,6 +134,7 @@ fn runTest(
     expected_stderr: ?[]const u8,
     quiet: bool,
     opt_flag: ?[]const u8,
+    extra_build_args: []const []const u8,
 ) !bool {
     const io = std.testing.io;
     const rhc_path = e2e_options.rhc_path;
@@ -151,9 +152,9 @@ fn runTest(
     defer allocator.free(binary_path);
 
     // ── Step 1: Compile ───────────────────────────────────────────────────────
-    // Build argv with an optional `-O<level>` flag.  The flag must come
-    // before the positional source path so clap parses it correctly.
-    var argv_buf: [6][]const u8 = undefined;
+    // Build argv with optional extra `rhc build` flags.  Flags must come
+    // before the positional source path so clap parses them correctly.
+    var argv_buf: [12][]const u8 = undefined;
     var argv_len: usize = 0;
     argv_buf[argv_len] = rhc_path;
     argv_len += 1;
@@ -161,6 +162,10 @@ fn runTest(
     argv_len += 1;
     if (opt_flag) |flag| {
         argv_buf[argv_len] = flag;
+        argv_len += 1;
+    }
+    for (extra_build_args) |a| {
+        argv_buf[argv_len] = a;
         argv_len += 1;
     }
     argv_buf[argv_len] = hs_path;
@@ -257,6 +262,20 @@ pub fn testProgram(
     comptime basename: []const u8,
     opt_flag: ?[]const u8,
 ) !void {
+    return testProgramWithFlags(allocator, dir, basename, opt_flag, &.{});
+}
+
+/// Like `testProgram` but additionally forwards `extra_build_args`
+/// (e.g. `--rts=immix`) to `rhc build`. Used by the Immix end-to-end
+/// smoke tests in `e2e_test_runner.zig` to verify the same programs
+/// produce identical output under both heap backends.
+pub fn testProgramWithFlags(
+    allocator: std.mem.Allocator,
+    comptime dir: []const u8,
+    comptime basename: []const u8,
+    opt_flag: ?[]const u8,
+    extra_build_args: []const []const u8,
+) !void {
     const props = try readProperties(allocator, dir, basename);
     defer props.deinit(allocator);
     if (props.skip) return;
@@ -272,6 +291,7 @@ pub fn testProgram(
         props.expected_stderr,
         props.xfail,
         opt_flag,
+        extra_build_args,
     );
 
     if (props.xfail) {


### PR DESCRIPTION
Closes #781

Stacks on top of [#783](https://github.com/adinapoli/rusholme/pull/783)
(#776 backend selector). Rebase onto main after that merges.

## Summary

Adds the heap-budget side of "actually running Immix": once
`blocks_allocated >= target_blocks` and auto-collect is enabled, the
alloc path runs `collect()` before reaching for a fresh block; after
collection the budget re-tunes to `max(min_target_blocks, 2 × live)`.

Auto-collect is **off by default**. Enabling it on a heap with no
roots (or without an armed conservative stack scan) would reap every
live object — so the safety contract is documented at `setAutoCollect`
and the initial selection in `heap.zig` keeps it disabled. Programs
that want collection wire it on explicitly; that wiring will follow
once shadow-stack roots (#780) make the conservative scan safe to
retire.

## Bug fix in the alloc loop

The old "loop over `allocBlock`" structure infinite-looped when every
recyclable block had only a single free line at the tail (too small
to satisfy a multi-line request) — the allocator kept pulling the
same two blocks back and forth without ever falling through to
`maybeAutoCollect`. The new structure has three explicit phases and
each block is visited at most once per `alloc` call:

```
tryAllocInCurrent → tryAllocInRecyclable → collect-on-pressure → newBlock
```

The cycle bug applied to non-auto-collect configurations too — it was
only hidden because pre-#781 `alloc` never asked the allocator to
satisfy multi-line requests against single-line tail holes.

## Testing

```
nix develop --command zig build test --summary all
# Build Summary: 51/51 steps succeeded; 1171/1171 tests passed
# +- run test rts-unit-tests 62 pass (62 total)
```

Five new tests cover:

- Auto-collect default-off behaviour.
- A 2-block budget actually triggers a collection.
- A rooted node survives multiple auto-collect cycles.
- `target_blocks` re-tunes upward after collection.
- `collect()` is re-entry safe (no recursion if a collection-initiated
  allocation accidentally calls back into `collect`).

## Deliverables

- [x] Heap-size budget (`target_blocks` / `min_target_blocks`)
- [x] Allocator calls `collect()` once the budget is crossed
- [x] Re-tune the budget after each cycle proportional to live size
- [x] Disable hook for deterministic tests (default off; opt-in via
  `setAutoCollect(true)`)
- [x] Unit tests covering auto-trigger, retention of roots, budget
  growth, and re-entry safety

## Not in scope (already filed)

- **#780** shadow-stack ABI for precise GC roots — once this lands,
  the global Immix heap can have `auto_collect_enabled = true` by
  default and `--rts=immix` programs will collect for real.
- **#779** per-constructor pointer-mask tables for precise tracing.
