### PR TITLE
#572: Implement tuple codegen via desugar to constructor App-chain

### DIFF
--- a/src/core/desugar.zig
+++ b/src/core/desugar.zig
@@ -2484,14 +2484,40 @@ pub fn desugarExpr(ctx: *DesugarCtx, expr: renamer_mod.RExpr) std.mem.Allocator.
             // so these variants must never reach the Core desugarer.
             std.debug.panic("desugar: unexpected RExpr variant {s} (renamer desugaring failed)", .{@tagName(expr)});
         },
-        .Tuple => {
-            // Tuple expressions
-            // tracked in: https://github.com/adinapoli/rusholme/issues/361
-            node.* = .{ .Var = .{
-                .name = Name{ .base = "todo_tuple", .unique = .{ .value = 0 } },
-                .ty = ast_mod.CoreType{ .TyVar = Name{ .base = "t", .unique = .{ .value = 0 } } },
-                .span = syntheticSpan(),
-            } };
+        .Tuple => |elems| {
+            // (e1, e2, …, en) desugars to (,) e1 e2 … en — i.e. an
+            // App-chain of the appropriate tuple constructor (see
+            // `Known.Con.Tuple{2..5}`). Arity 1 is just a parenthesised
+            // expression and never reaches the renamer as a Tuple;
+            // arity 0 is the Unit constructor and is parsed separately;
+            // arities > 5 are not yet wired into the typechecker
+            // (`Known.Con.Tuple{2..5}` is the registered set).
+            // See issue #572.
+            const tuple_name = switch (elems.len) {
+                2 => Known.Con.Tuple2,
+                3 => Known.Con.Tuple3,
+                4 => Known.Con.Tuple4,
+                5 => Known.Con.Tuple5,
+                else => std.debug.panic(
+                    "desugar: tuple of arity {} is not supported (only 2..5)",
+                    .{elems.len},
+                ),
+            };
+            const tuple_ty = blk: {
+                const scheme = ctx.types.schemes.get(tuple_name.unique) orelse
+                    std.debug.panic("Missing type scheme for tuple constructor {s}", .{tuple_name.base});
+                break :blk try schemeToCore(alloc, scheme);
+            };
+            // Start from the constructor applied left-to-right.
+            var result = try alloc.create(ast_mod.Expr);
+            result.* = .{ .Var = .{ .name = tuple_name, .ty = tuple_ty, .span = syntheticSpan() } };
+            for (elems) |elem_rexpr| {
+                const elem = try desugarExpr(ctx, elem_rexpr);
+                const app = try alloc.create(ast_mod.Expr);
+                app.* = .{ .App = .{ .fn_expr = result, .arg = elem, .span = syntheticSpan() } };
+                result = app;
+            }
+            node.* = result.*;
         },
         .EnumFrom => |enum_from| {
             // [n..] → enumFrom n

--- a/tests/e2e/e2e_015_prelude_higher_order.properties
+++ b/tests/e2e/e2e_015_prelude_higher_order.properties
@@ -1,1 +1,0 @@
-xfail: tuple codegen not yet implemented (todo_tuple_0) — pre-existing compiler limitation


### PR DESCRIPTION
Closes #572

## Summary

Desugars tuple expressions properly instead of emitting a
`Var "todo_tuple"` placeholder. The Core desugarer now translates
`(e1, …, en)` into a left-associated App chain `(,) e1 e2 … en`,
mirroring the existing list-literal path. Constructor names come
from `Known.Con.Tuple{2..5}`; the typechecker already registers
those schemes.

## Before / after

```
$ rhc build tests/e2e/e2e_015_prelude_higher_order.hs
# before:
ld: undefined reference to `todo_tuple_0'
# after:
$ ./e2e_015_prelude_higher_order
id-ok
const-ok
compose-ok
dollar-ok
flip-ok
fst-ok
snd-ok
```

## Testing

```
nix develop --command zig build test --summary all
# Build Summary: 51/51 steps succeeded; 1129/1129 tests passed
```

The `e2e_015_prelude_higher_order` test now runs as a regular pass
(its `.properties` xfail entry is removed). All other tests stay green.

## Deliverables

- [x] Investigated the `todo_tuple_*` source — it was a Core desugar
  stub, not a backend issue
- [x] Implemented tuple desugar (left-fold of `App` chains over the
  registered tuple constructor)
- [x] Removed the `xfail` from
  `tests/e2e/e2e_015_prelude_higher_order.properties`
- [x] No new unit tests needed — the e2e test already exercises
  tuples through `fst`/`snd`

## Out of scope

Tuples beyond arity 5: the typechecker doesn't register schemes for
`Tuple6+` today, so the desugarer panics with a clear message
("tuple of arity N is not supported (only 2..5)"). Widening that
support is a separate task and was not requested by the issue.
