### PR TITLE
bench: scaffold initial micro-benchmark suite

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,45 @@
+# Rusholme micro-benchmarks
+
+Small curated set of Haskell programs used to track Rusholme's
+mutator/GC performance over time. Run any program through
+`scripts/bench.sh` (#758) — hyperfine handles warm-up, runs, and
+optional GHC -O2 comparison.
+
+## Programs
+
+| File              | Profile                                                                 |
+|-------------------|-------------------------------------------------------------------------|
+| `fib_rec.hs`      | Pure compute. No allocation. Isolates call-overhead + Int arithmetic.   |
+| `sum_to.hs`       | Tail-style recursion over an Int range. Stresses calls, no allocs.      |
+| `build_list.hs`   | Allocates one Cons cell per element; folds the list. Alloc-heavy.       |
+| `tree_sum.hs`     | Balanced binary tree of `Node Int Tree Tree`. 2 pointer fields per node — exercises the tracer's per-tag pointer mask (#779). |
+
+## Usage
+
+```sh
+# Single program, rhc only (10 runs, 3 warmups, -O2)
+scripts/bench.sh bench/build_list.hs
+
+# Compare against GHC -O2
+scripts/bench.sh -g bench/build_list.hs
+
+# Export raw timings to JSON for later trend analysis
+scripts/bench.sh -j bench/build_list.json bench/build_list.hs
+```
+
+Both binaries (`rhc` and, with `-g`, `ghc`) are run through hyperfine
+and their stdouts diffed before timing — output divergence aborts the
+benchmark with exit code 2.
+
+## Notes
+
+- `scripts/bench.sh` does not currently know about `--rts=arena|immix`.
+  To compare backends, run the script once, then compile the same
+  source with `./zig-out/bin/rhc build --rts=immix ...` and time
+  manually. A `-r arena|immix` flag for the wrapper is a follow-up.
+
+- These benchmarks are intentionally tiny so they stay portable to
+  the CI runner without ballooning iteration time. As Rusholme grows
+  more language features the suite should grow accordingly — add a
+  program (and a row in the table above) for any new performance
+  surface that needs ongoing coverage.

--- a/bench/build_list.hs
+++ b/bench/build_list.hs
@@ -1,0 +1,19 @@
+-- Bench: allocation-heavy list build + traversal.
+--
+-- Builds a long Cons list, then folds it. Every Cons cell is a
+-- heap allocation, so the inner loop is dominated by `rts_alloc`.
+-- Under `--rts=immix` this exercises the block allocator + the
+-- per-tag pointer-mask tracer (#779) + the shadow-stack root
+-- discipline (#780) + the opportunistic defrag pass (#73) when
+-- it is opted in.
+
+data List a = Nil | Cons a (List a)
+
+range :: Int -> Int -> List Int
+range lo hi = if lo > hi then Nil else Cons lo (range (lo + 1) hi)
+
+sumList :: List Int -> Int
+sumList Nil = 0
+sumList (Cons x xs) = x + sumList xs
+
+main = putStrLn (show (sumList (range 1 5000)))

--- a/bench/fib_rec.hs
+++ b/bench/fib_rec.hs
@@ -1,0 +1,11 @@
+-- Bench: pure compute, no heap allocation.
+--
+-- Naive recursive Fibonacci. Bumps the call stack but never calls
+-- `rts_alloc`. Isolates the cost of function calls + integer
+-- arithmetic from anything GC-related; a useful control against
+-- the alloc-heavy benches.
+
+fib :: Int -> Int
+fib n = if n < 2 then n else fib (n - 1) + fib (n - 2)
+
+main = putStrLn (show (fib 30))

--- a/bench/sum_to.hs
+++ b/bench/sum_to.hs
@@ -1,0 +1,12 @@
+-- Bench: arithmetic / recursion baseline.
+--
+-- Tail-style recursion over an Int range. Stresses call overhead
+-- (every step is a function call) without allocating heap nodes
+-- on the hot path. Useful as a control against the alloc-heavy
+-- benches: divergence here points at codegen quality, not at GC.
+
+sumTo :: Int -> Int -> Int
+sumTo acc 0 = acc
+sumTo acc n = sumTo (acc + n) (n - 1)
+
+main = putStrLn (show (sumTo 0 50000))

--- a/bench/tree_sum.hs
+++ b/bench/tree_sum.hs
@@ -1,0 +1,20 @@
+-- Bench: deeper tree allocation + traversal.
+--
+-- Builds a balanced binary tree, then folds it. Per node carries
+-- two pointer fields, so the GC tracer follows 2x more edges per
+-- byte than `build_list`. Useful for separating "alloc rate" from
+-- "pointer-chasing rate" in the bench results.
+
+data Tree = Leaf | Node Int Tree Tree
+
+build :: Int -> Int -> Tree
+build _ 0 = Leaf
+build seed depth =
+  let n = seed + depth
+  in Node n (build (n + 1) (depth - 1)) (build (n + 2) (depth - 1))
+
+sumTree :: Tree -> Int
+sumTree Leaf = 0
+sumTree (Node v l r) = v + sumTree l + sumTree r
+
+main = putStrLn (show (sumTree (build 1 14)))


### PR DESCRIPTION
## Summary

Adds `bench/` with four small Haskell programs covering the perf
surfaces worth tracking over time:

| File              | Profile                                                                |
|-------------------|------------------------------------------------------------------------|
| `fib_rec.hs`      | Pure compute. No allocation. Isolates call overhead + Int arithmetic.  |
| `sum_to.hs`       | Tail-style recursion over an Int range. Calls, no allocs.              |
| `build_list.hs`   | One Cons cell per element + fold. Alloc-heavy; exercises rts_alloc + shadow-stack roots + per-tag mask tracer under \`--rts=immix\`. |
| `tree_sum.hs`     | Balanced binary tree with two pointer fields per Node. Doubles tracer edge rate vs `build_list`. |

Each compiles + runs cleanly via `scripts/bench.sh` (#758).

## First numbers (rhc -O2, native, no GC tuning)

- `build_list.hs` (5 000 Cons): **12.1 ms ± 2.6** mean
- `fib_rec.hs` (fib 30): **2.04 s ± 0.10** mean

Plenty of headroom — these are baselines to beat as #788 / #779 /
#73 land their post-merge cleanups.

## Follow-up

bench.sh does not yet take `--rts=arena|immix`. Compare backends
manually for now; a `-r` flag for the wrapper is a small follow-up.