### PR TITLE
bench+website: render benchmark history as Vega-Lite charts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,74 @@ The only acceptable reason to skip filing a follow-up issue is if the shortcomin
 is already tracked by an existing open issue. In that case, add a cross-reference
 comment in the code pointing to that issue number.
 
-## 6. Submit for Review
+## 6. Refresh Benchmarks (before opening a PR)
+
+Rusholme tracks its end-to-end performance against GHC over time. The
+benchmark suite lives in `bench/`, the results live in
+`bench/results.json`, and the website at `/bench/` renders the
+JSON as Vega-Lite time-series charts. **Every PR that could plausibly
+move performance** (compiler, GRIN, backend, RTS, Prelude) must
+re-run the suite locally and commit a fresh entry.
+
+### What "plausibly moves performance" means
+
+Run the benchmarks if your change touches any of:
+
+- `src/backend/`, `src/grin/`, `src/core/`, `src/typecheck/`,
+  `src/desugar/`, `src/parser/`
+- `src/rts/`, `lib/Prelude.hs`
+- `bench/` itself (a new bench program counts)
+
+Skip the benchmarks (and explain why in the PR) when your change is
+documentation-only, test-only, or strictly mechanical (renames, comment
+fixes, ROADMAP updates).
+
+### How to run
+
+From the repo root, with the dev shell active and `ghc` on `PATH`:
+
+```bash
+nix develop --command bash -c '
+  export PATH="$HOME/.ghcup/bin:$PATH"
+  zig build
+  ./scripts/bench-all.sh -n 7 -w 3
+'
+```
+
+`bench-all.sh`:
+
+1. Builds every `bench/*.hs` with both `rhc -O2` and `ghc -O2`.
+2. Diff-checks the two binaries' stdouts (aborts on divergence).
+3. Times both under `hyperfine` (7 runs, 3 warmups by default).
+4. Appends a new entry to `bench/results.json` with the current
+   commit SHA, host CPU model, GHC version, and per-program mean +
+   standard deviation in milliseconds.
+
+### Review and commit
+
+- Read the diff of `bench/results.json` before committing. A surprise
+  regression that lines up with your changes is a real signal — chase
+  it before opening the PR.
+- Stage and commit the JSON alongside the rest of the work:
+
+```bash
+git add bench/results.json
+git commit -m "#<NUMBER>: refresh bench results"
+```
+
+- The website re-renders on every push to `main` and picks up the
+  new data points automatically — no extra deploy step.
+
+### Adding a new benchmark
+
+- Drop a `.hs` file into `bench/` whose `main` writes a single line
+  to stdout.
+- Add a row to `bench/README.md` describing the perf surface the
+  program exercises.
+- Re-run `bench-all.sh` so the new program appears in
+  `bench/results.json` from day one.
+
+## 7. Submit for Review
 
 ### Commit and Push
 
@@ -270,7 +337,7 @@ git commit -m "#<NUMBER>: Update roadmap status to in-review"
 git push origin llm-agent/issue-<NUMBER>
 ```
 
-## 7. Status Legend (ROADMAP.md)
+## 8. Status Legend (ROADMAP.md)
 
 | Emoji | Meaning |
 |-------|---------|
@@ -279,7 +346,7 @@ git push origin llm-agent/issue-<NUMBER>
 | :yellow_circle: | In review (PR open) |
 | :green_circle: | Done (PR merged) |
 
-## 8. Research Issues
+## 9. Research Issues
 
 Some issues are `type:research` — their deliverable is a written document, not code.
 
@@ -290,7 +357,7 @@ Some issues are `type:research` — their deliverable is a written document, not
 4. Downstream implementation issues depend on the research decision — they cannot start
    until the research PR is merged.
 
-## 9. Common Pitfalls
+## 10. Common Pitfalls
 
 - **Verify that issue deliverables are architecturally coherent before writing
   any code.** GitHub issues are written by humans (and LLMs) and can contain

--- a/bench/results.json
+++ b/bench/results.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "runs": [
+    {
+      "commit": "ca462c5a92d1468ffeeee4e1204c07b054c04de3",
+      "date": "2026-06-10T12:14:16Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "build_list": {
+          "rhc_mean_ms": 13.01813142857143,
+          "rhc_stddev_ms": 2.1852584512554314,
+          "ghc_mean_ms": 1.184829142857143,
+          "ghc_stddev_ms": 0.09418465000099285
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 2070.4914804285713,
+          "rhc_stddev_ms": 73.22321273888966,
+          "ghc_mean_ms": 5.965808,
+          "ghc_stddev_ms": 0.29906989041693904
+        },
+        "sum_to": {
+          "rhc_mean_ms": 30.262424428571432,
+          "rhc_stddev_ms": 5.377462249860395,
+          "ghc_mean_ms": 1.0477094285714288,
+          "ghc_stddev_ms": 0.22267424506429204
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 38.53756028571429,
+          "rhc_stddev_ms": 7.6263978916186606,
+          "ghc_mean_ms": 1.9472945714285714,
+          "ghc_stddev_ms": 0.21492086189793763
+        }
+      }
+    }
+  ]
+}

--- a/scripts/bench-all.sh
+++ b/scripts/bench-all.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# bench-all.sh — run every bench/*.hs against rhc and ghc, append a
+# single dated entry to bench/results.json.
+#
+# Invoke manually before opening a PR (see CLAUDE.md §"Benchmarks").
+# The bench/results.json file is checked in; the website's deploy
+# step renders it as time-series charts at `/bench/`.
+#
+# Usage:
+#   scripts/bench-all.sh             # 7 runs, 3 warmups, -O2
+#   scripts/bench-all.sh -n 10       # 10 runs
+#   scripts/bench-all.sh --dry-run   # print the JSON entry, don't append
+#
+# Output: appends one entry to `bench/results.json`. Each entry is:
+#   {
+#     "commit":     "<git rev-parse HEAD>",
+#     "date":       "<ISO-8601 UTC>",
+#     "host":       { "os": "...", "cpu_model": "...", "ghc_version": "..." },
+#     "programs":   { "<name>": { "rhc_mean_ms": ..., "rhc_stddev_ms": ...,
+#                                 "ghc_mean_ms": ..., "ghc_stddev_ms": ... } }
+#   }
+#
+# Requirements:
+#   - hyperfine on PATH (provided by the Nix dev shell)
+#   - ghc on PATH (system ghcup install; bench-all.sh records its
+#     version into the JSON entry for reproducibility)
+#   - jq on PATH
+
+set -euo pipefail
+
+runs=7
+warmups=3
+opt_level=2
+dry_run=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -n) runs="$2"; shift 2 ;;
+        -w) warmups="$2"; shift 2 ;;
+        -O) opt_level="$2"; shift 2 ;;
+        --dry-run) dry_run=1; shift ;;
+        -h|--help)
+            sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "bench-all.sh: unknown arg: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+for tool in hyperfine ghc jq git; do
+    if ! command -v "$tool" > /dev/null; then
+        echo "bench-all.sh: $tool not on PATH" >&2
+        exit 1
+    fi
+done
+
+if [ ! -x "./zig-out/bin/rhc" ]; then
+    echo "bench-all.sh: ./zig-out/bin/rhc missing — run \`zig build\` first" >&2
+    exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [ ! -d "bench" ]; then
+    echo "bench-all.sh: no bench/ directory" >&2
+    exit 1
+fi
+
+shopt -s nullglob
+progs=( bench/*.hs )
+shopt -u nullglob
+
+if [ ${#progs[@]} -eq 0 ]; then
+    echo "bench-all.sh: no bench/*.hs files" >&2
+    exit 1
+fi
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/rhc-bench-all.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+ghc_version="$(ghc --numeric-version)"
+rhc_commit="$(git rev-parse HEAD)"
+date_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+os_kernel="$(uname -sr)"
+cpu_model="$(awk -F': ' '/model name/ {print $2; exit}' /proc/cpuinfo 2>/dev/null || echo unknown)"
+
+programs_json="$tmpdir/programs.json"
+echo "{}" > "$programs_json"
+
+for src in "${progs[@]}"; do
+    base="$(basename "${src%.hs}")"
+    rhc_bin="$tmpdir/$base-rhc"
+    ghc_bin="$tmpdir/$base-ghc"
+    ghc_outdir="$tmpdir/ghc-out-$base"
+
+    echo "bench-all.sh: building $base"
+    ./zig-out/bin/rhc build "-O$opt_level" -o "$rhc_bin" "$src" 2>&1 | grep -vE "warning|deprecat|^$" || true
+    # GHC's linker needs libgmp. Inside the Nix dev shell `-lgmp` is
+    # not on the default search path; outside it usually is. Probe a
+    # few common locations and prepend whichever holds libgmp.so.10.
+    ghc_link_args=()
+    for d in /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu /lib /lib64; do
+        if [ -e "$d/libgmp.so.10" ] || [ -e "$d/libgmp.so" ]; then
+            # `-optl-L` finds libgmp at link time; `-optl-Wl,-rpath,$d`
+            # bakes the path into the ELF so the binary still runs when
+            # invoked from inside the Nix dev shell (whose
+            # LD_LIBRARY_PATH does not include /usr/lib).
+            ghc_link_args+=( "-optl-L$d" "-optl-Wl,-rpath,$d" )
+            break
+        fi
+    done
+    ghc -O2 -outputdir "$ghc_outdir" -o "$ghc_bin" "${ghc_link_args[@]}" "$src" > /dev/null
+
+    rhc_out="$("$rhc_bin")"
+    ghc_out="$("$ghc_bin")"
+    if [ "$rhc_out" != "$ghc_out" ]; then
+        echo "bench-all.sh: SANITY $base: rhc vs ghc output differ" >&2
+        echo "rhc: $rhc_out" >&2
+        echo "ghc: $ghc_out" >&2
+        exit 2
+    fi
+
+    echo "bench-all.sh: timing $base"
+    hyperfine --shell=none --warmup "$warmups" --runs "$runs" \
+        --export-json "$tmpdir/$base.json" \
+        --command-name "rhc -O$opt_level" "$rhc_bin" \
+        --command-name "ghc -O2" "$ghc_bin" > /dev/null
+
+    # hyperfine JSON gives mean/stddev in seconds — convert to ms.
+    rhc_mean_ms=$(jq '.results[0].mean * 1000'   "$tmpdir/$base.json")
+    rhc_std_ms=$(jq  '.results[0].stddev * 1000' "$tmpdir/$base.json")
+    ghc_mean_ms=$(jq '.results[1].mean * 1000'   "$tmpdir/$base.json")
+    ghc_std_ms=$(jq  '.results[1].stddev * 1000' "$tmpdir/$base.json")
+
+    programs_json_new="$tmpdir/programs.next.json"
+    jq --arg name "$base" \
+       --argjson rm "$rhc_mean_ms" --argjson rs "$rhc_std_ms" \
+       --argjson gm "$ghc_mean_ms" --argjson gs "$ghc_std_ms" \
+       '. + { ($name): { rhc_mean_ms: $rm, rhc_stddev_ms: $rs,
+                         ghc_mean_ms: $gm, ghc_stddev_ms: $gs } }' \
+       "$programs_json" > "$programs_json_new"
+    mv "$programs_json_new" "$programs_json"
+done
+
+entry="$(jq -n \
+    --arg commit  "$rhc_commit" \
+    --arg date    "$date_iso" \
+    --arg os      "$os_kernel" \
+    --arg cpu     "$cpu_model" \
+    --arg ghcv    "$ghc_version" \
+    --argjson opt "$opt_level" \
+    --argjson runs "$runs" \
+    --slurpfile programs "$programs_json" \
+    '{
+        commit: $commit,
+        date:   $date,
+        host:   { os: $os, cpu_model: $cpu, ghc_version: $ghcv },
+        opt_level: $opt,
+        runs:   $runs,
+        programs: $programs[0]
+    }')"
+
+if [ "$dry_run" -eq 1 ]; then
+    echo "$entry" | jq .
+    exit 0
+fi
+
+results=bench/results.json
+if [ ! -f "$results" ]; then
+    jq -n '{ schema_version: 1, runs: [] }' > "$results"
+fi
+
+merged="$tmpdir/merged.json"
+jq --argjson entry "$entry" '.runs += [$entry]' "$results" > "$merged"
+mv "$merged" "$results"
+
+echo "bench-all.sh: appended entry to $results"
+echo "bench-all.sh: review the change, then \`git add bench/results.json\` and commit"

--- a/website/build.js
+++ b/website/build.js
@@ -248,6 +248,146 @@ function generateRecentProgressHTML(issues) {
     </div>`).join('');
 }
 
+// ── Benchmark section ─────────────────────────────────────────────────
+
+/**
+ * Read the checked-in bench/results.json (committed by hand after
+ * `scripts/bench-all.sh` runs locally). Returns null when the file
+ * is missing so build can still complete on branches that pre-date
+ * the bench scaffold.
+ */
+function loadBenchResults() {
+  const benchPath = path.join(__dirname, '../bench/results.json');
+  if (!fs.existsSync(benchPath)) return null;
+  try {
+    const data = JSON.parse(fs.readFileSync(benchPath, 'utf-8'));
+    if (!data.runs || data.runs.length === 0) return null;
+    return data;
+  } catch (err) {
+    console.warn(`   ⚠️  Failed to parse bench/results.json: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Summary cards — one per program — showing the gap to GHC as
+ * measured in the most recent committed run. Colour-coded by how
+ * close to parity we are: green ≤ 5×, amber ≤ 25×, red beyond.
+ */
+function generateBenchSummaryHTML(bench) {
+  const latest = bench.runs[bench.runs.length - 1];
+  const names = Object.keys(latest.programs).sort();
+  return names.map(name => {
+    const p = latest.programs[name];
+    const gap = p.rhc_mean_ms / p.ghc_mean_ms;
+    let badgeColour, gapColour;
+    if (gap <= 5) { badgeColour = 'bg-emerald-500/10 border-emerald-500/30'; gapColour = 'text-emerald-300'; }
+    else if (gap <= 25) { badgeColour = 'bg-amber-500/10 border-amber-500/30'; gapColour = 'text-amber-300'; }
+    else { badgeColour = 'bg-rose-500/10 border-rose-500/30'; gapColour = 'text-rose-300'; }
+    const fmt = (ms) => ms >= 100 ? ms.toFixed(0) : ms.toFixed(2);
+    return `
+    <div class="rounded-2xl border ${badgeColour} p-5 backdrop-blur">
+      <div class="flex items-baseline justify-between gap-2">
+        <h3 class="text-sm font-mono text-gray-300 truncate">${escapeHtml(name)}</h3>
+        <span class="text-xs ${gapColour} font-semibold">${gap.toFixed(1)}× slower</span>
+      </div>
+      <div class="mt-3 flex items-baseline gap-2">
+        <span class="text-2xl font-bold text-white">${fmt(p.rhc_mean_ms)}</span>
+        <span class="text-xs text-gray-400">ms — rhc</span>
+      </div>
+      <div class="mt-1 flex items-baseline gap-2">
+        <span class="text-sm font-medium text-gray-300">${fmt(p.ghc_mean_ms)}</span>
+        <span class="text-xs text-gray-500">ms — ghc</span>
+      </div>
+    </div>`;
+  }).join('\n');
+}
+
+/**
+ * One Vega-Lite chart per program. Each chart plots the rhc and ghc
+ * mean-of-runs over time (x = commit date, y = ms, log scale because
+ * the gap is wide). Spec is emitted inline and rendered client-side
+ * by vega-embed.
+ */
+function generateBenchChartsHTML(bench) {
+  // Collect every (date, program, compiler, ms) tuple across all runs.
+  const records = [];
+  for (const run of bench.runs) {
+    for (const [name, p] of Object.entries(run.programs)) {
+      records.push({ program: name, date: run.date, compiler: 'rhc', mean_ms: p.rhc_mean_ms, stddev_ms: p.rhc_stddev_ms, commit: run.commit });
+      records.push({ program: name, date: run.date, compiler: 'ghc', mean_ms: p.ghc_mean_ms, stddev_ms: p.ghc_stddev_ms, commit: run.commit });
+    }
+  }
+  const names = Array.from(new Set(records.map(r => r.program))).sort();
+
+  // Detect short histories so we can render points (not just lines)
+  // when there's only one or two samples — a single dot is friendlier
+  // than an empty grid.
+  const showPoints = bench.runs.length <= 3;
+
+  let html = '';
+  let scriptInits = '';
+
+  for (const name of names) {
+    const cellId = `bench-chart-${name.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+    const data = records.filter(r => r.program === name);
+    const spec = {
+      $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+      background: 'transparent',
+      width: 'container',
+      height: 280,
+      padding: 12,
+      data: { values: data },
+      mark: { type: 'line', point: showPoints ? { filled: true, size: 70 } : false, strokeWidth: 2.5, interpolate: 'monotone' },
+      encoding: {
+        x: {
+          field: 'date', type: 'temporal',
+          axis: { title: null, format: '%b %d', labelColor: '#9ca3af', tickColor: '#374151', domainColor: '#374151' },
+        },
+        y: {
+          field: 'mean_ms', type: 'quantitative',
+          scale: { type: 'log' },
+          axis: { title: 'ms (log)', titleColor: '#9ca3af', labelColor: '#9ca3af', tickColor: '#374151', domainColor: '#374151', gridColor: '#1f2937' },
+        },
+        color: {
+          field: 'compiler', type: 'nominal',
+          scale: { domain: ['rhc', 'ghc'], range: ['#34d399', '#f7a41d'] },
+          legend: { labelColor: '#d1d5db', titleColor: '#9ca3af', orient: 'top-right' },
+        },
+        tooltip: [
+          { field: 'compiler', type: 'nominal', title: 'compiler' },
+          { field: 'mean_ms', type: 'quantitative', title: 'mean (ms)', format: '.3f' },
+          { field: 'stddev_ms', type: 'quantitative', title: 'σ (ms)', format: '.3f' },
+          { field: 'date', type: 'temporal', title: 'when' },
+          { field: 'commit', type: 'nominal', title: 'commit' },
+        ],
+      },
+      config: {
+        view: { stroke: 'transparent' },
+        axis: { grid: true, gridColor: '#1f2937' },
+        legend: { titleFontSize: 11, labelFontSize: 11 },
+      },
+    };
+    html += `
+    <div class="bg-gray-900/60 rounded-2xl border border-gray-800 p-5">
+      <h3 class="text-sm font-mono text-gray-300 mb-3">${escapeHtml(name)}.hs</h3>
+      <div id="${cellId}" class="w-full"></div>
+    </div>`;
+    scriptInits += `\n    vegaEmbed('#${cellId}', ${JSON.stringify(spec)}, { actions: false, renderer: 'svg', theme: 'dark' });`;
+  }
+
+  // The Vega-embed calls run after DOMContentLoaded so the chart
+  // divs definitely exist. Wrap in a guard so a CDN miss does not
+  // throw a ReferenceError into other scripts.
+  html += `\n<script>
+document.addEventListener('DOMContentLoaded', function () {
+  if (typeof vegaEmbed !== 'function') return;${scriptInits}
+});
+</script>`;
+
+  return html;
+}
+
 // Main build function
 async function build() {
   console.log('🏗️  Building Rusholme website...\n');
@@ -303,6 +443,28 @@ async function build() {
     console.log('   ⚠️  No placeholder found in template.html');
   }
   
+  // Benchmark section (read bench/results.json checked into the repo).
+  console.log('📊 Generating benchmark charts...');
+  const bench = loadBenchResults();
+  if (bench && bench.runs.length > 0) {
+    const summaryHTML = generateBenchSummaryHTML(bench);
+    const chartsHTML = generateBenchChartsHTML(bench);
+
+    const summaryPlaceholder = '<!-- BENCH_SUMMARY_PLACEHOLDER -->';
+    if (html.includes(summaryPlaceholder)) {
+      html = html.replace(summaryPlaceholder, summaryHTML);
+    }
+
+    const chartsPlaceholder = '<!-- BENCH_CHARTS_PLACEHOLDER -->';
+    if (html.includes(chartsPlaceholder)) {
+      html = html.replace(chartsPlaceholder, chartsHTML);
+    }
+
+    console.log(`   ✓ Rendered ${Object.keys(bench.runs[bench.runs.length - 1].programs).length} bench charts (${bench.runs.length} run${bench.runs.length === 1 ? '' : 's'} of history)`);
+  } else {
+    console.log('   ⚠️  No bench/results.json found — skipping benchmarks section');
+  }
+
   // Write output
   const outputPath = path.join(__dirname, 'index.html');
   fs.writeFileSync(outputPath, html, 'utf-8');

--- a/website/template.html
+++ b/website/template.html
@@ -45,6 +45,11 @@
     <!-- Marked for markdown rendering -->
     <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
 
+    <!-- Vega-Lite for benchmark charts (loads Vega + vega-embed). -->
+    <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+
     <!-- Lucide icons -->
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 
@@ -281,6 +286,8 @@
                         class="nav-link text-sm font-medium text-gray-300 hover:text-white transition-colors">Pipeline</a>
                     <a href="#roadmap"
                         class="nav-link text-sm font-medium text-gray-300 hover:text-white transition-colors">Roadmap</a>
+                    <a href="#benchmarks"
+                        class="nav-link text-sm font-medium text-gray-300 hover:text-white transition-colors">Benchmarks</a>
                     <a href="#grin"
                         class="nav-link text-sm font-medium text-gray-300 hover:text-white transition-colors">GRIN</a>
                     <a href="#design"
@@ -717,6 +724,47 @@
                 </div>
             </div>
 
+        </div>
+    </section>
+
+    <!-- Benchmarks Section -->
+    <section id="benchmarks" class="py-24 px-4 sm:px-6 lg:px-8 bg-gray-900/40 relative">
+        <div class="max-w-7xl mx-auto">
+            <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-12">
+                <div>
+                    <span class="text-emerald-400 font-semibold text-sm uppercase tracking-wider">Performance</span>
+                    <h2 class="text-4xl md:text-5xl font-bold text-white mt-4">Benchmarks</h2>
+                    <p class="text-gray-400 mt-4 max-w-2xl">
+                        Wall-clock execution time on a small set of micro-benchmarks.
+                        Rusholme (<code class="text-emerald-400">rhc -O2</code>) is plotted alongside
+                        GHC (<code class="text-zig">ghc -O2</code>) on the same program. Lower is
+                        better; the gap between the two lines is the headroom that compiler / GC
+                        work still has to close.
+                    </p>
+                </div>
+                <a href="https://github.com/adinapoli/rusholme/tree/main/bench" target="_blank"
+                    class="flex items-center gap-2 text-emerald-400 hover:text-emerald-300 transition-colors group whitespace-nowrap">
+                    View bench/
+                    <i data-lucide="external-link" class="w-4 h-4 group-hover:translate-x-1 transition-transform"></i>
+                </a>
+            </div>
+
+            <!-- Summary cards: current gap-to-GHC per program. -->
+            <div id="bench-summary" class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-12">
+                <!-- BENCH_SUMMARY_PLACEHOLDER -->
+            </div>
+
+            <!-- Per-program time-series charts (Vega-Lite). -->
+            <div id="bench-charts" class="grid lg:grid-cols-2 gap-6">
+                <!-- BENCH_CHARTS_PLACEHOLDER -->
+            </div>
+
+            <p class="text-gray-500 text-xs mt-8 text-center">
+                Numbers measured locally and committed alongside the code in
+                <code class="text-emerald-400/80">bench/results.json</code>. Run
+                <code class="text-emerald-400/80">scripts/bench-all.sh</code> before opening a PR to
+                refresh.
+            </p>
         </div>
     </section>
 


### PR DESCRIPTION
Stacks on #797 (bench scaffold). Merge that first; this PR rebases trivially once it lands.

## What this adds

Three pieces wired end-to-end:

### 1. `scripts/bench-all.sh`

Loops over every \`bench/*.hs\`, builds with \`rhc -O2\` + \`ghc -O2\`,
diff-checks stdout, times both under hyperfine, and appends a single
entry to \`bench/results.json\`. Captures commit SHA, host OS / CPU
model, GHC version, opt level, runs count, and per-program mean +
standard deviation (ms).

Handles the Nix-dev-shell libgmp case by probing system lib dirs and
passing both \`-L\` and \`-rpath\` to ghc. \`--dry-run\` prints the
JSON without mutating the checked-in file.

### 2. \`bench/results.json\`

Single source of truth for historical perf data, checked in. Seeded
with one baseline entry from today's run:

| program     | rhc -O2  | ghc -O2  | gap   |
|-------------|----------|----------|-------|
| fib_rec     | 2070 ms  | 6.0 ms   | 347×  |
| sum_to      | 30 ms    | 1.0 ms   | 29×   |
| build_list  | 13 ms    | 1.2 ms   | 11×   |
| tree_sum    | 39 ms    | 1.9 ms   | 20×   |

### 3. Website /bench/ section

- New "Benchmarks" entry in the nav, section right after the Roadmap.
- Summary cards (one per program) — current gap-to-GHC, colour-coded
  (≤5× green, ≤25× amber, else rose).
- Vega-Lite time-series chart per program with rhc + ghc lines on a
  log y-axis (dark theme, monotone interpolate, hover tooltips).
- Server-side data, client-side render. No bundler, no extra build
  step in the deploy workflow — \`website/build.js\` reads
  \`bench/results.json\` at \`npm run build\` time and emits inline
  Vega-Lite specs.

### 4. CLAUDE.md

New §6 "Refresh Benchmarks (before opening a PR)" with scope rules
(when to run vs skip), the exact \`bench-all.sh\` invocation, and
the commit-the-JSON step. Following sections re-numbered.

## How the loop closes

1. Developer touches the compiler / GC / Prelude.
2. Before opening a PR: \`nix develop --command ./scripts/bench-all.sh\`.
3. Reviews the diff of \`bench/results.json\`. Surprise regression
   that lines up with the change → chase it before merging.
4. Commits the JSON alongside the rest of the PR.
5. Merge to main → existing deploy workflow re-runs
   \`website/build.js\` → new data points appear in the site.

## Out of scope

- CI integration (deliberately — the user wants reproducible local
  measurements, not noisy hosted-runner samples).
- zBench-style RTS micros (separate follow-up; this PR covers the
  end-to-end-binary benches that motivated the gap-to-GHC discussion).