### PR TITLE
bench: capture --rts=immix column + refresh post-#798 numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,9 +258,12 @@ nix develop --command bash -c '
 
 `bench-all.sh`:
 
-1. Builds every `bench/*.hs` with both `rhc -O2` and `ghc -O2`.
-2. Diff-checks the two binaries' stdouts (aborts on divergence).
-3. Times both under `hyperfine` (7 runs, 3 warmups by default).
+1. Builds every `bench/*.hs` three times: `rhc -O2` (arena RTS),
+   `rhc -O2 --rts=immix` (Immix RTS), and `ghc -O2`.
+2. Diff-checks all three binaries' stdouts against the GHC reference
+   (aborts on divergence — that's a correctness regression, not a
+   perf one, and must be fixed before any timing run is meaningful).
+3. Times all three under `hyperfine` (7 runs, 3 warmups by default).
 4. Appends a new entry to `bench/results.json` with the current
    commit SHA, host CPU model, GHC version, and per-program mean +
    standard deviation in milliseconds.

--- a/bench/results.json
+++ b/bench/results.json
@@ -37,6 +37,51 @@
           "ghc_stddev_ms": 0.21492086189793763
         }
       }
+    },
+    {
+      "commit": "8fe41266af828477bb13af69354f2d5e7fec4dd7",
+      "date": "2026-06-10T17:02:17Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "build_list": {
+          "rhc_mean_ms": 12.489090571428571,
+          "rhc_stddev_ms": 2.79359406112764,
+          "rhc_immix_mean_ms": 19.551060142857146,
+          "rhc_immix_stddev_ms": 3.5425803699995964,
+          "ghc_mean_ms": 1.357567142857143,
+          "ghc_stddev_ms": 0.11609841642248844
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 2042.4583675714282,
+          "rhc_stddev_ms": 82.71784955134858,
+          "rhc_immix_mean_ms": 1017.6637358571428,
+          "rhc_immix_stddev_ms": 34.515897273406225,
+          "ghc_mean_ms": 6.126467857142858,
+          "ghc_stddev_ms": 0.6852380747223137
+        },
+        "sum_to": {
+          "rhc_mean_ms": 26.38894985714286,
+          "rhc_stddev_ms": 4.843251986010553,
+          "rhc_immix_mean_ms": 100.97061142857144,
+          "rhc_immix_stddev_ms": 16.47032559211336,
+          "ghc_mean_ms": 1.2062295714285713,
+          "ghc_stddev_ms": 0.18009149947536596
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 39.577201142857156,
+          "rhc_stddev_ms": 10.31559685788469,
+          "rhc_immix_mean_ms": 90.55410214285716,
+          "rhc_immix_stddev_ms": 9.292815771792538,
+          "ghc_mean_ms": 1.836496285714286,
+          "ghc_stddev_ms": 0.18613019532638467
+        }
+      }
     }
   ]
 }

--- a/scripts/bench-all.sh
+++ b/scripts/bench-all.sh
@@ -97,8 +97,11 @@ for src in "${progs[@]}"; do
     ghc_bin="$tmpdir/$base-ghc"
     ghc_outdir="$tmpdir/ghc-out-$base"
 
+    rhc_immix_bin="$tmpdir/$base-rhc-immix"
+
     echo "bench-all.sh: building $base"
     ./zig-out/bin/rhc build "-O$opt_level" -o "$rhc_bin" "$src" 2>&1 | grep -vE "warning|deprecat|^$" || true
+    ./zig-out/bin/rhc build "-O$opt_level" --rts=immix -o "$rhc_immix_bin" "$src" 2>&1 | grep -vE "warning|deprecat|^$" || true
     # GHC's linker needs libgmp. Inside the Nix dev shell `-lgmp` is
     # not on the default search path; outside it usually is. Probe a
     # few common locations and prepend whichever holds libgmp.so.10.
@@ -116,6 +119,7 @@ for src in "${progs[@]}"; do
     ghc -O2 -outputdir "$ghc_outdir" -o "$ghc_bin" "${ghc_link_args[@]}" "$src" > /dev/null
 
     rhc_out="$("$rhc_bin")"
+    rhc_immix_out="$("$rhc_immix_bin")"
     ghc_out="$("$ghc_bin")"
     if [ "$rhc_out" != "$ghc_out" ]; then
         echo "bench-all.sh: SANITY $base: rhc vs ghc output differ" >&2
@@ -123,24 +127,35 @@ for src in "${progs[@]}"; do
         echo "ghc: $ghc_out" >&2
         exit 2
     fi
+    if [ "$rhc_immix_out" != "$ghc_out" ]; then
+        echo "bench-all.sh: SANITY $base: rhc --rts=immix output differs" >&2
+        echo "rhc:immix: $rhc_immix_out" >&2
+        echo "ghc:       $ghc_out" >&2
+        exit 2
+    fi
 
     echo "bench-all.sh: timing $base"
     hyperfine --shell=none --warmup "$warmups" --runs "$runs" \
         --export-json "$tmpdir/$base.json" \
         --command-name "rhc -O$opt_level" "$rhc_bin" \
+        --command-name "rhc -O$opt_level --rts=immix" "$rhc_immix_bin" \
         --command-name "ghc -O2" "$ghc_bin" > /dev/null
 
     # hyperfine JSON gives mean/stddev in seconds — convert to ms.
     rhc_mean_ms=$(jq '.results[0].mean * 1000'   "$tmpdir/$base.json")
     rhc_std_ms=$(jq  '.results[0].stddev * 1000' "$tmpdir/$base.json")
-    ghc_mean_ms=$(jq '.results[1].mean * 1000'   "$tmpdir/$base.json")
-    ghc_std_ms=$(jq  '.results[1].stddev * 1000' "$tmpdir/$base.json")
+    rhc_immix_mean_ms=$(jq '.results[1].mean * 1000'   "$tmpdir/$base.json")
+    rhc_immix_std_ms=$(jq  '.results[1].stddev * 1000' "$tmpdir/$base.json")
+    ghc_mean_ms=$(jq '.results[2].mean * 1000'   "$tmpdir/$base.json")
+    ghc_std_ms=$(jq  '.results[2].stddev * 1000' "$tmpdir/$base.json")
 
     programs_json_new="$tmpdir/programs.next.json"
     jq --arg name "$base" \
        --argjson rm "$rhc_mean_ms" --argjson rs "$rhc_std_ms" \
+       --argjson rim "$rhc_immix_mean_ms" --argjson ris "$rhc_immix_std_ms" \
        --argjson gm "$ghc_mean_ms" --argjson gs "$ghc_std_ms" \
        '. + { ($name): { rhc_mean_ms: $rm, rhc_stddev_ms: $rs,
+                         rhc_immix_mean_ms: $rim, rhc_immix_stddev_ms: $ris,
                          ghc_mean_ms: $gm, ghc_stddev_ms: $gs } }' \
        "$programs_json" > "$programs_json_new"
     mv "$programs_json_new" "$programs_json"

--- a/website/build.js
+++ b/website/build.js
@@ -279,12 +279,22 @@ function generateBenchSummaryHTML(bench) {
   const names = Object.keys(latest.programs).sort();
   return names.map(name => {
     const p = latest.programs[name];
-    const gap = p.rhc_mean_ms / p.ghc_mean_ms;
+    // Use the fastest rhc backend for the gap-to-GHC summary.
+    const rhc_best_ms = (typeof p.rhc_immix_mean_ms === 'number')
+      ? Math.min(p.rhc_mean_ms, p.rhc_immix_mean_ms)
+      : p.rhc_mean_ms;
+    const gap = rhc_best_ms / p.ghc_mean_ms;
     let badgeColour, gapColour;
     if (gap <= 5) { badgeColour = 'bg-emerald-500/10 border-emerald-500/30'; gapColour = 'text-emerald-300'; }
     else if (gap <= 25) { badgeColour = 'bg-amber-500/10 border-amber-500/30'; gapColour = 'text-amber-300'; }
     else { badgeColour = 'bg-rose-500/10 border-rose-500/30'; gapColour = 'text-rose-300'; }
     const fmt = (ms) => ms >= 100 ? ms.toFixed(0) : ms.toFixed(2);
+    const immixLine = (typeof p.rhc_immix_mean_ms === 'number')
+      ? `<div class="mt-1 flex items-baseline gap-2">
+           <span class="text-sm font-medium text-blue-300">${fmt(p.rhc_immix_mean_ms)}</span>
+           <span class="text-xs text-gray-500">ms — rhc immix</span>
+         </div>`
+      : '';
     return `
     <div class="rounded-2xl border ${badgeColour} p-5 backdrop-blur">
       <div class="flex items-baseline justify-between gap-2">
@@ -293,8 +303,9 @@ function generateBenchSummaryHTML(bench) {
       </div>
       <div class="mt-3 flex items-baseline gap-2">
         <span class="text-2xl font-bold text-white">${fmt(p.rhc_mean_ms)}</span>
-        <span class="text-xs text-gray-400">ms — rhc</span>
+        <span class="text-xs text-gray-400">ms — rhc arena</span>
       </div>
+      ${immixLine}
       <div class="mt-1 flex items-baseline gap-2">
         <span class="text-sm font-medium text-gray-300">${fmt(p.ghc_mean_ms)}</span>
         <span class="text-xs text-gray-500">ms — ghc</span>
@@ -320,12 +331,23 @@ function generateBenchChartsHTML(bench) {
   for (const run of bench.runs) {
     for (const [name, p] of Object.entries(run.programs)) {
       records.push({
-        program: name, date: run.date, compiler: 'rhc',
+        program: name, date: run.date, compiler: 'rhc (arena)',
         mean_ms: p.rhc_mean_ms,
         lo_ms: Math.max(0.001, p.rhc_mean_ms - p.rhc_stddev_ms),
         hi_ms: p.rhc_mean_ms + p.rhc_stddev_ms,
         stddev_ms: p.rhc_stddev_ms, commit: run.commit,
       });
+      // The immix series is only recorded by post-#798 runs. Older
+      // entries skip it; older charts simply lack that line.
+      if (typeof p.rhc_immix_mean_ms === 'number') {
+        records.push({
+          program: name, date: run.date, compiler: 'rhc (immix)',
+          mean_ms: p.rhc_immix_mean_ms,
+          lo_ms: Math.max(0.001, p.rhc_immix_mean_ms - p.rhc_immix_stddev_ms),
+          hi_ms: p.rhc_immix_mean_ms + p.rhc_immix_stddev_ms,
+          stddev_ms: p.rhc_immix_stddev_ms, commit: run.commit,
+        });
+      }
       records.push({
         program: name, date: run.date, compiler: 'ghc',
         mean_ms: p.ghc_mean_ms,
@@ -357,7 +379,10 @@ function generateBenchChartsHTML(bench) {
         },
         color: {
           field: 'compiler', type: 'nominal',
-          scale: { domain: ['rhc', 'ghc'], range: ['#34d399', '#f7a41d'] },
+          scale: {
+            domain: ['rhc (arena)', 'rhc (immix)', 'ghc'],
+            range: ['#34d399', '#60a5fa', '#f7a41d'],
+          },
           legend: { labelColor: '#d1d5db', titleColor: '#9ca3af', orient: 'top-right', symbolType: 'circle' },
         },
       },


### PR DESCRIPTION
#798 lit up the inline ``rts_alloc`` path under \`--rts=immix\`. The
arena RTS is unchanged, so the default \`bench-all.sh\` runs (which
only built with arena) hide the 2× win the inline path actually
delivers on ``fib_rec``. Wire a third measurement column through the
pipeline so both backends land in ``bench/results.json`` and the
website renders them side by side.

## What changed

### \`scripts/bench-all.sh\`

- Builds each \`bench/*.hs\` three times now: \`rhc -O2\` (arena),
  \`rhc -O2 --rts=immix\`, and \`ghc -O2\`.
- Diff-checks all three stdouts against the GHC reference (a
  divergence aborts the run — that's a correctness regression and
  must be fixed before any timing run is meaningful).
- Times all three in a single \`hyperfine\` invocation.
- Each entry in \`bench/results.json\` gains \`rhc_immix_mean_ms\` /
  \`rhc_immix_stddev_ms\` fields.

### \`bench/results.json\`

Fresh entry with the dual-backend numbers:

| Bench       | rhc arena  | rhc immix  | ghc       |
|-------------|------------|------------|-----------|
| fib_rec     | 2042 ms    | **1018 ms** | 6.1 ms    |
| sum_to      | 26 ms      | 101 ms     | 1.2 ms    |
| build_list  | 12.5 ms    | 19.5 ms    | 1.36 ms   |
| tree_sum    | 39.6 ms    | 90.5 ms    | 1.84 ms   |

\`fib_rec\` is **2× faster on immix** thanks to the inline path
boxing every \`Int\` return without a C call. The alloc-heavy benches
stay slower under immix because the default 8-block budget triggers
\`collect()\` repeatedly — that's a tuning question independent of
this PR.

### \`website/build.js\`

- Chart spec gains a third series \"rhc (immix)\" (blue) next to
  \"rhc (arena)\" (green) and \"ghc\" (amber). Older entries that
  lack the immix field are skipped silently so historical data
  still renders.
- Summary card adds an \"ms — rhc immix\" line where present and
  uses the faster of the two rhc backends for the headline
  gap-to-GHC ratio.

### \`CLAUDE.md\` §6

Updated the workflow blurb to reflect the three-build shape so
future contributors don't trip over the new sanity check.