### PR TITLE
Benchmaxxing: dict specialisation, demand analysis, force elision, inline alloc — 45x -> 1.2x of GHC

### DIFF
--- a/bench/results.json
+++ b/bench/results.json
@@ -307,6 +307,51 @@
           "ghc_stddev_ms": 0.13645883037681927
         }
       }
+    },
+    {
+      "commit": "440432568327cf138a46f4e63a0f33b2153552ce",
+      "date": "2026-06-11T12:12:27Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "build_list": {
+          "rhc_mean_ms": 0.906793142857143,
+          "rhc_stddev_ms": 0.12130889976890756,
+          "rhc_immix_mean_ms": 4.480063142857143,
+          "rhc_immix_stddev_ms": 0.21587835052518867,
+          "ghc_mean_ms": 1.3197947142857143,
+          "ghc_stddev_ms": 0.058559742601649416
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 7.1996602857142875,
+          "rhc_stddev_ms": 0.17676876851479773,
+          "rhc_immix_mean_ms": 313.018943,
+          "rhc_immix_stddev_ms": 44.95690247875188,
+          "ghc_mean_ms": 5.205123142857143,
+          "ghc_stddev_ms": 1.102275040287349
+        },
+        "sum_to": {
+          "rhc_mean_ms": 1.9062820000000003,
+          "rhc_stddev_ms": 0.29029399110040155,
+          "rhc_immix_mean_ms": 11.520117714285716,
+          "rhc_immix_stddev_ms": 1.393940269765616,
+          "ghc_mean_ms": 1.0553524285714286,
+          "ghc_stddev_ms": 0.19670508944005252
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 2.4386867142857143,
+          "rhc_stddev_ms": 0.2853185232675429,
+          "rhc_immix_mean_ms": 40.161869571428575,
+          "rhc_immix_stddev_ms": 7.736376412897685,
+          "ghc_mean_ms": 1.9149832857142859,
+          "ghc_stddev_ms": 0.21733776476237346
+        }
+      }
     }
   ]
 }

--- a/bench/results.json
+++ b/bench/results.json
@@ -262,6 +262,51 @@
           "ghc_stddev_ms": 0.19257622804749294
         }
       }
+    },
+    {
+      "commit": "28b3011d0c3f334177940669393b60a7ba6381c5",
+      "date": "2026-06-11T11:58:44Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "build_list": {
+          "rhc_mean_ms": 0.9711335714285717,
+          "rhc_stddev_ms": 0.0551832007524547,
+          "rhc_immix_mean_ms": 4.031580714285715,
+          "rhc_immix_stddev_ms": 0.7250569786062138,
+          "ghc_mean_ms": 1.230212857142857,
+          "ghc_stddev_ms": 0.07272036905257605
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 22.174957857142857,
+          "rhc_stddev_ms": 2.9350408605931095,
+          "rhc_immix_mean_ms": 265.98078757142855,
+          "rhc_immix_stddev_ms": 33.1191394576659,
+          "ghc_mean_ms": 5.413652428571429,
+          "ghc_stddev_ms": 0.747493825591636
+        },
+        "sum_to": {
+          "rhc_mean_ms": 2.560975857142857,
+          "rhc_stddev_ms": 0.3918582900052128,
+          "rhc_immix_mean_ms": 12.482882142857143,
+          "rhc_immix_stddev_ms": 0.581781841200929,
+          "ghc_mean_ms": 1.1638551428571429,
+          "ghc_stddev_ms": 0.1410613508553738
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 2.4481927142857147,
+          "rhc_stddev_ms": 0.2086139292630563,
+          "rhc_immix_mean_ms": 27.77395157142857,
+          "rhc_immix_stddev_ms": 8.3299406326298,
+          "ghc_mean_ms": 1.673803857142857,
+          "ghc_stddev_ms": 0.13645883037681927
+        }
+      }
     }
   ]
 }

--- a/bench/results.json
+++ b/bench/results.json
@@ -217,6 +217,51 @@
           "ghc_stddev_ms": 0.09816577560045102
         }
       }
+    },
+    {
+      "commit": "26a806aa2287db5833adae70bdcb93fa839bcdd6",
+      "date": "2026-06-11T11:48:12Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "build_list": {
+          "rhc_mean_ms": 3.3305967142857145,
+          "rhc_stddev_ms": 0.19806792635921175,
+          "rhc_immix_mean_ms": 4.328628714285714,
+          "rhc_immix_stddev_ms": 0.42799985613304214,
+          "ghc_mean_ms": 1.1386662857142857,
+          "ghc_stddev_ms": 0.13536963578749145
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 22.683743571428572,
+          "rhc_stddev_ms": 1.3216157113697182,
+          "rhc_immix_mean_ms": 256.81617842857145,
+          "rhc_immix_stddev_ms": 9.662273307207936,
+          "ghc_mean_ms": 5.665554,
+          "ghc_stddev_ms": 0.5922934545161435
+        },
+        "sum_to": {
+          "rhc_mean_ms": 2.685663428571429,
+          "rhc_stddev_ms": 0.284686125617821,
+          "rhc_immix_mean_ms": 11.043976285714288,
+          "rhc_immix_stddev_ms": 2.1479682987367945,
+          "ghc_mean_ms": 1.156199,
+          "ghc_stddev_ms": 0.1586492874414085
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 23.564599285714287,
+          "rhc_stddev_ms": 1.7049214143924363,
+          "rhc_immix_mean_ms": 32.46553642857143,
+          "rhc_immix_stddev_ms": 9.317732159822455,
+          "ghc_mean_ms": 1.9959660000000006,
+          "ghc_stddev_ms": 0.19257622804749294
+        }
+      }
     }
   ]
 }

--- a/bench/results.json
+++ b/bench/results.json
@@ -127,6 +127,51 @@
           "ghc_stddev_ms": 0.21213959674693542
         }
       }
+    },
+    {
+      "commit": "8a01756f3711bb70d1d276502239483e2efab73c",
+      "date": "2026-06-11T11:39:07Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "build_list": {
+          "rhc_mean_ms": 3.939213285714286,
+          "rhc_stddev_ms": 0.6496333774162455,
+          "rhc_immix_mean_ms": 4.986187,
+          "rhc_immix_stddev_ms": 0.15818466938992548,
+          "ghc_mean_ms": 1.3022885714285715,
+          "ghc_stddev_ms": 0.12390188374658553
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 20.21037257142857,
+          "rhc_stddev_ms": 3.755111799276326,
+          "rhc_immix_mean_ms": 265.551616,
+          "rhc_immix_stddev_ms": 17.60987535391164,
+          "ghc_mean_ms": 6.043072857142858,
+          "ghc_stddev_ms": 0.1581974086423126
+        },
+        "sum_to": {
+          "rhc_mean_ms": 17.437050857142857,
+          "rhc_stddev_ms": 4.183479577126535,
+          "rhc_immix_mean_ms": 41.980057714285714,
+          "rhc_immix_stddev_ms": 10.958257576722492,
+          "ghc_mean_ms": 1.0446562857142858,
+          "ghc_stddev_ms": 0.0979928551863422
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 29.677300714285714,
+          "rhc_stddev_ms": 5.096560131740354,
+          "rhc_immix_mean_ms": 34.94434085714286,
+          "rhc_immix_stddev_ms": 6.5786428709553615,
+          "ghc_mean_ms": 1.8896391428571429,
+          "ghc_stddev_ms": 0.17622924512163946
+        }
+      }
     }
   ]
 }

--- a/bench/results.json
+++ b/bench/results.json
@@ -172,6 +172,51 @@
           "ghc_stddev_ms": 0.17622924512163946
         }
       }
+    },
+    {
+      "commit": "2fb3c3981a24fb384ad2b6469c4b67b322d33e93",
+      "date": "2026-06-11T11:43:53Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "build_list": {
+          "rhc_mean_ms": 4.123805142857143,
+          "rhc_stddev_ms": 0.29481191036061655,
+          "rhc_immix_mean_ms": 4.944839571428571,
+          "rhc_immix_stddev_ms": 0.30625802778967126,
+          "ghc_mean_ms": 1.3004934285714285,
+          "ghc_stddev_ms": 0.20458845249578253
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 20.403143857142858,
+          "rhc_stddev_ms": 3.8924594640380197,
+          "rhc_immix_mean_ms": 261.54511414285713,
+          "rhc_immix_stddev_ms": 31.5855326731055,
+          "ghc_mean_ms": 5.463616571428571,
+          "ghc_stddev_ms": 0.9365863830019199
+        },
+        "sum_to": {
+          "rhc_mean_ms": 2.4619058571428574,
+          "rhc_stddev_ms": 0.24620623489967963,
+          "rhc_immix_mean_ms": 12.147888571428572,
+          "rhc_immix_stddev_ms": 1.456577634014846,
+          "ghc_mean_ms": 1.0664545714285714,
+          "ghc_stddev_ms": 0.1858305045355912
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 23.422204285714287,
+          "rhc_stddev_ms": 5.394055605125167,
+          "rhc_immix_mean_ms": 35.02402085714286,
+          "rhc_immix_stddev_ms": 8.793744790448386,
+          "ghc_mean_ms": 1.9600202857142859,
+          "ghc_stddev_ms": 0.09816577560045102
+        }
+      }
     }
   ]
 }

--- a/bench/results.json
+++ b/bench/results.json
@@ -82,6 +82,51 @@
           "ghc_stddev_ms": 0.18613019532638467
         }
       }
+    },
+    {
+      "commit": "f8abafe9f9ce1c73b5998c860c7745e2cc1a9ee7",
+      "date": "2026-06-11T11:13:58Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "build_list": {
+          "rhc_mean_ms": 7.489084285714286,
+          "rhc_stddev_ms": 1.2268942670507124,
+          "rhc_immix_mean_ms": 12.167461285714287,
+          "rhc_immix_stddev_ms": 1.4674478428569682,
+          "ghc_mean_ms": 1.3069605714285717,
+          "ghc_stddev_ms": 0.2139099846624409
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 558.4572157142859,
+          "rhc_stddev_ms": 62.59751271468562,
+          "rhc_immix_mean_ms": 454.6899551428573,
+          "rhc_immix_stddev_ms": 67.7331860028219,
+          "ghc_mean_ms": 5.043164000000001,
+          "ghc_stddev_ms": 0.2697627232674423
+        },
+        "sum_to": {
+          "rhc_mean_ms": 28.330503142857143,
+          "rhc_stddev_ms": 2.9505443429693567,
+          "rhc_immix_mean_ms": 97.11788357142858,
+          "rhc_immix_stddev_ms": 21.554311505524524,
+          "ghc_mean_ms": 1.0321555714285717,
+          "ghc_stddev_ms": 0.08530503886417871
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 36.12334700000001,
+          "rhc_stddev_ms": 7.5150108729817315,
+          "rhc_immix_mean_ms": 75.98958971428571,
+          "rhc_immix_stddev_ms": 8.343125071439133,
+          "ghc_mean_ms": 2.027533428571429,
+          "ghc_stddev_ms": 0.21213959674693542
+        }
+      }
     }
   ]
 }

--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -672,6 +672,11 @@ pub const GrinTranslator = struct {
     /// immediates). Case sites consult this to elide the `__rhc_force`
     /// pre-force call (#800). Cleared at the start of each translateDef.
     whnf_vars: std.AutoHashMap(u64, void),
+    /// Strict-parameter masks from the Core demand analysis (#802),
+    /// keyed by function unique. Strict parameters are forced once at
+    /// function entry and tracked as WHNF, eliding every per-use force
+    /// in the body. Null when no analysis ran (REPL, debug commands).
+    strict_params: ?*const std.AutoHashMapUnmanaged(u64, u64) = null,
     /// Per-function cache for translated GRIN Case expressions.  The
     /// sequential pattern-match desugarer creates shared fallback nodes
     /// (a DAG) that would be re-translated exponentially without caching.
@@ -1373,9 +1378,24 @@ pub const GrinTranslator = struct {
         // Store each parameter as a named value in the params map. For
         // pointer-typed params, also push them onto the shadow stack so
         // the collector sees them as live across this function's body.
+        //
+        // Strict parameters (#802) are forced once here and tracked as
+        // WHNF: the demand analysis proved every execution path forces
+        // them, so a single entry force replaces every per-use force in
+        // the body (a worker/wrapper-lite that keeps the boxed ABI).
+        const entry_strict_mask: u64 = blk: {
+            const sp = self.strict_params orelse break :blk 0;
+            break :blk sp.get(def.name.unique.value) orelse 0;
+        };
         for (def.params, 0..) |param_name, i| {
-            const param_val = c.LLVMGetParam(func, @intCast(i));
+            var param_val = c.LLVMGetParam(func, @intCast(i));
             if (param_val == null) return error.OutOfMemory;
+            if (i < 64 and (entry_strict_mask >> @intCast(i)) & 1 == 1 and
+                c.LLVMGetTypeKind(c.LLVMTypeOf(param_val)) == c.LLVMPointerTypeKind)
+            {
+                param_val = self.callForceIfNeeded(param_val);
+                self.whnf_vars.put(param_name.unique.value, {}) catch return error.OutOfMemory;
+            }
             try self.bindAndRoot(param_name.unique.value, param_val);
         }
 
@@ -2276,7 +2296,7 @@ pub const GrinTranslator = struct {
             const operand_raw = try self.translateValToLlvm(args[0]);
             if (c.LLVMGetTypeKind(c.LLVMTypeOf(operand_raw)) == c.LLVMPointerTypeKind) {
                 // Already a pointer — force thunks and return as-is.
-                return self.callForceIfNeeded(operand_raw);
+                return self.forceOperandIfNeeded(operand_raw, args[0]);
             }
             // Raw i64 — tag as ptr to avoid mis-boxing downstream.
             return tagInt(self.builder, operand_raw);
@@ -2290,7 +2310,7 @@ pub const GrinTranslator = struct {
             // thunk (e.g. F:div).  Without forcing, ptrtoint would give the
             // heap address instead of the Haskell integer value.
             const operand_forced = if (c.LLVMGetTypeKind(c.LLVMTypeOf(operand_raw)) == c.LLVMPointerTypeKind)
-                self.callForceIfNeeded(operand_raw)
+                self.forceOperandIfNeeded(operand_raw, args[0])
             else
                 operand_raw;
             const operand = if (c.LLVMGetTypeKind(c.LLVMTypeOf(operand_forced)) == c.LLVMPointerTypeKind)
@@ -2327,11 +2347,11 @@ pub const GrinTranslator = struct {
         // thunks (e.g. F:div).  Without forcing, ptrtoint would give the
         // heap address instead of the Haskell integer value.
         const lhs_forced = if (c.LLVMGetTypeKind(c.LLVMTypeOf(lhs_raw)) == c.LLVMPointerTypeKind)
-            self.callForceIfNeeded(lhs_raw)
+            self.forceOperandIfNeeded(lhs_raw, args[0])
         else
             lhs_raw;
         const rhs_forced = if (c.LLVMGetTypeKind(c.LLVMTypeOf(rhs_raw)) == c.LLVMPointerTypeKind)
-            self.callForceIfNeeded(rhs_raw)
+            self.forceOperandIfNeeded(rhs_raw, args[1])
         else
             rhs_raw;
 
@@ -3482,18 +3502,75 @@ pub const GrinTranslator = struct {
     /// Emit a call to `__rhc_force` if the module contains F-tags.
     /// Returns the forced pointer value, or the original value unchanged
     /// if no F-tags exist (i.e. `__rhc_force` was never emitted).
+    /// Force a translated operand unless its GRIN value is statically
+    /// WHNF (strict-forced parameter, primop result, immediate).
+    fn forceOperandIfNeeded(self: *GrinTranslator, raw: llvm.Value, val: grin.Val) llvm.Value {
+        if (self.valYieldsWhnf(val)) return raw;
+        return self.callForceIfNeeded(raw);
+    }
+
     fn callForceIfNeeded(self: *GrinTranslator, val: llvm.Value) llvm.Value {
         if (self.registry.fun_tags.count() == 0 and self.registry.partial_tags.count() == 0) return val;
-        const force_fn = c.LLVMGetNamedFunction(self.module, "__rhc_force") orelse return val;
+        if (c.LLVMGetNamedFunction(self.module, "__rhc_force") == null) return val;
+        const guard = self.getOrDefineForceFastGuard();
         var args = [_]llvm.Value{val};
         return c.LLVMBuildCall2(
             self.builder,
-            llvm.getFunctionType(force_fn),
-            force_fn,
+            llvm.getFunctionType(guard),
+            guard,
             &args,
             1,
             "forced",
         );
+    }
+
+    /// Get-or-define the module-internal `__rhc_force_fast(ptr) -> ptr`:
+    /// an always-inline guard that returns tagged immediates (and null)
+    /// without a call, and defers heap pointers to the full `__rhc_force`.
+    /// After LLVM inlining, forcing a value that is statically a tagged
+    /// immediate folds away entirely, and runtime forces of immediates
+    /// cost two bit tests instead of a function call.
+    fn getOrDefineForceFastGuard(self: *GrinTranslator) llvm.Value {
+        const name = "__rhc_force_fast";
+        if (c.LLVMGetNamedFunction(self.module, name)) |existing| return existing;
+
+        const ptr_ty = ptrType();
+        const i64_ty = llvm.i64Type();
+        var param_types = [_]llvm.Type{ptr_ty};
+        const fn_ty = llvm.functionType(ptr_ty, &param_types, false);
+        const func = llvm.addFunction(self.module, name, fn_ty);
+        c.LLVMSetLinkage(func, c.LLVMInternalLinkage);
+        const ctx = c.LLVMGetModuleContext(self.module);
+        const kind_id = c.LLVMGetEnumAttributeKindForName("alwaysinline", "alwaysinline".len);
+        const attr = c.LLVMCreateEnumAttribute(ctx, kind_id, 0);
+        const fn_index: c_uint = @bitCast(@as(c_int, c.LLVMAttributeFunctionIndex));
+        c.LLVMAddAttributeAtIndex(func, fn_index, attr);
+
+        const saved_bb = c.LLVMGetInsertBlock(self.builder);
+        defer if (saved_bb != null) llvm.positionBuilderAtEnd(self.builder, saved_bb);
+
+        const entry_bb = llvm.appendBasicBlock(func, "entry");
+        const slow_bb = c.LLVMAppendBasicBlock(func, "slow");
+        const done_bb = c.LLVMAppendBasicBlock(func, "done");
+        llvm.positionBuilderAtEnd(self.builder, entry_bb);
+        const param = c.LLVMGetParam(func, 0);
+        const raw = c.LLVMBuildPtrToInt(self.builder, param, i64_ty, "raw");
+        const low = c.LLVMBuildAnd(self.builder, raw, c.LLVMConstInt(i64_ty, 1, 0), "low");
+        const is_imm = c.LLVMBuildICmp(self.builder, c.LLVMIntNE, low, c.LLVMConstInt(i64_ty, 0, 0), "is_imm");
+        const is_null = c.LLVMBuildICmp(self.builder, c.LLVMIntEQ, raw, c.LLVMConstInt(i64_ty, 0, 0), "is_null");
+        const skip = c.LLVMBuildOr(self.builder, is_imm, is_null, "skip");
+        _ = c.LLVMBuildCondBr(self.builder, skip, done_bb, slow_bb);
+
+        llvm.positionBuilderAtEnd(self.builder, slow_bb);
+        const heavy = c.LLVMGetNamedFunction(self.module, "__rhc_force").?;
+        var slow_args = [_]llvm.Value{param};
+        const forced = c.LLVMBuildCall2(self.builder, llvm.getFunctionType(heavy), heavy, &slow_args, 1, "forced.slow");
+        _ = c.LLVMBuildRet(self.builder, forced);
+
+        llvm.positionBuilderAtEnd(self.builder, done_bb);
+        _ = c.LLVMBuildRet(self.builder, param);
+
+        return func;
     }
 
     /// Force a heap pointer to WHNF by following indirections and forcing

--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -314,7 +314,6 @@ const PrimOpResult = union(enum) {
     instruction: LLVMInstruction,
 };
 
-
 // ═══════════════════════════════════════════════════════════════════════
 // Heap node helpers
 // ═══════════════════════════════════════════════════════════════════════
@@ -983,8 +982,12 @@ pub const GrinTranslator = struct {
         // exists), or the allocation does not fit the inline shape
         // (line-spanning sizes, very wide nodes).
         const padded_size: u64 = 16 + @as(u64, n_fields) * 8;
+        // Both backends bump through the shared cursor/limit globals;
+        // the arena fast path just skips the Immix line-mark stores.
+        // REPL (ORC JIT) modules cannot resolve the cursor globals
+        // against the bitcode-loaded RTS, so they keep the call path.
         const inline_eligible =
-            self.rts_backend == .immix and
+            self.repl_entry_point == null and
             padded_size <= INLINE_ALLOC_MAX_SIZE and
             n_fields <= INLINE_ALLOC_MAX_FIELDS;
         if (!inline_eligible) {
@@ -1077,27 +1080,31 @@ pub const GrinTranslator = struct {
             const slot_ptr = c.LLVMBuildIntToPtr(self.builder, slot_addr, ptr_ty, "alloc.slot_ptr");
             _ = c.LLVMBuildStore(self.builder, c.LLVMConstInt(i64_ty, 0, 0), slot_ptr);
         }
-        // Mark every line the allocation spans as used. Since
+        // Mark every line the allocation spans as used (Immix only:
+        // arena chunks have no block headers, and the line-mark store
+        // would scribble over unrelated memory). Since
         // `padded_size <= LINE_SIZE` (#798 ceiling) the allocation
         // covers at most two lines — mark both unconditionally; a
         // duplicate store on the same byte is harmless. `line_marks`
         // sits at offset 0 of `BlockHeader`, so the byte address for
         // line `i` is `block_base + i`.
-        const block_mask = c.LLVMConstInt(i64_ty, ~@as(u64, IMMIX_BLOCK_SIZE - 1), 0);
-        const block_base = c.LLVMBuildAnd(self.builder, top, block_mask, "alloc.block_base");
-        const offset_first = c.LLVMBuildSub(self.builder, top, block_base, "alloc.off_first");
-        const line_first = c.LLVMBuildLShr(self.builder, offset_first, c.LLVMConstInt(i64_ty, IMMIX_LINE_LOG2, 0), "alloc.line_first");
-        const lm_first_addr = c.LLVMBuildAdd(self.builder, block_base, line_first, "alloc.lm_first_addr");
-        const lm_first_ptr = c.LLVMBuildIntToPtr(self.builder, lm_first_addr, ptr_ty, "alloc.lm_first_ptr");
-        _ = c.LLVMBuildStore(self.builder, c.LLVMConstInt(i8_ty, 1, 0), lm_first_ptr);
-        // Second line (only different from the first when the alloc
-        // straddles a boundary). Compute via `(end - 1) >> 7`.
-        const end_inclusive = c.LLVMBuildAdd(self.builder, top, c.LLVMConstInt(i64_ty, padded_size - 1, 0), "alloc.end_inclusive");
-        const offset_last = c.LLVMBuildSub(self.builder, end_inclusive, block_base, "alloc.off_last");
-        const line_last = c.LLVMBuildLShr(self.builder, offset_last, c.LLVMConstInt(i64_ty, IMMIX_LINE_LOG2, 0), "alloc.line_last");
-        const lm_last_addr = c.LLVMBuildAdd(self.builder, block_base, line_last, "alloc.lm_last_addr");
-        const lm_last_ptr = c.LLVMBuildIntToPtr(self.builder, lm_last_addr, ptr_ty, "alloc.lm_last_ptr");
-        _ = c.LLVMBuildStore(self.builder, c.LLVMConstInt(i8_ty, 1, 0), lm_last_ptr);
+        if (self.rts_backend == .immix) {
+            const block_mask = c.LLVMConstInt(i64_ty, ~@as(u64, IMMIX_BLOCK_SIZE - 1), 0);
+            const block_base = c.LLVMBuildAnd(self.builder, top, block_mask, "alloc.block_base");
+            const offset_first = c.LLVMBuildSub(self.builder, top, block_base, "alloc.off_first");
+            const line_first = c.LLVMBuildLShr(self.builder, offset_first, c.LLVMConstInt(i64_ty, IMMIX_LINE_LOG2, 0), "alloc.line_first");
+            const lm_first_addr = c.LLVMBuildAdd(self.builder, block_base, line_first, "alloc.lm_first_addr");
+            const lm_first_ptr = c.LLVMBuildIntToPtr(self.builder, lm_first_addr, ptr_ty, "alloc.lm_first_ptr");
+            _ = c.LLVMBuildStore(self.builder, c.LLVMConstInt(i8_ty, 1, 0), lm_first_ptr);
+            // Second line (only different from the first when the alloc
+            // straddles a boundary). Compute via `(end - 1) >> 7`.
+            const end_inclusive = c.LLVMBuildAdd(self.builder, top, c.LLVMConstInt(i64_ty, padded_size - 1, 0), "alloc.end_inclusive");
+            const offset_last = c.LLVMBuildSub(self.builder, end_inclusive, block_base, "alloc.off_last");
+            const line_last = c.LLVMBuildLShr(self.builder, offset_last, c.LLVMConstInt(i64_ty, IMMIX_LINE_LOG2, 0), "alloc.line_last");
+            const lm_last_addr = c.LLVMBuildAdd(self.builder, block_base, line_last, "alloc.lm_last_addr");
+            const lm_last_ptr = c.LLVMBuildIntToPtr(self.builder, lm_last_addr, ptr_ty, "alloc.lm_last_ptr");
+            _ = c.LLVMBuildStore(self.builder, c.LLVMConstInt(i8_ty, 1, 0), lm_last_ptr);
+        }
         // Publish the new cursor.
         _ = c.LLVMBuildStore(self.builder, end_v, cursor_g);
         _ = c.LLVMBuildBr(self.builder, done_bb);
@@ -3009,7 +3016,7 @@ pub const GrinTranslator = struct {
 
             // Translate the alternative body as a value (not with ret)
             const alt_value = try self.translateExprToValue(alt.body, result_name);
-            
+
             // Every alternative must produce a value in bind context
             if (alt_value) |val| {
                 // Normalize value type: box i64 nullary constructors into heap nodes
@@ -3023,7 +3030,7 @@ pub const GrinTranslator = struct {
                     tagInt(self.builder, val)
                 else
                     val;
-                
+
                 try phi_values.append(self.allocator, normalized_val);
                 const cur_bb = c.LLVMGetInsertBlock(self.builder);
                 try phi_blocks.append(self.allocator, cur_bb);
@@ -3036,12 +3043,12 @@ pub const GrinTranslator = struct {
 
         // ── 5. Create phi node in merge block ──────────────────────────────
         llvm.positionBuilderAtEnd(self.builder, merge_bb);
-        
+
         if (phi_values.items.len == 0) return null;
-        
+
         // All values have been normalized to ptr type, so phi is always ptr
         const phi = c.LLVMBuildPhi(self.builder, ptrType(), nullTerminate(result_name).ptr);
-        
+
         c.LLVMAddIncoming(
             phi,
             @ptrCast(phi_values.items.ptr),
@@ -3052,7 +3059,7 @@ pub const GrinTranslator = struct {
         // ── 6. Emit unreachable in default block (for non-exhaustive matches) ──
         llvm.positionBuilderAtEnd(self.builder, unreachable_bb);
         _ = c.LLVMBuildUnreachable(self.builder);
-        
+
         // Reposition at merge for continuation
         llvm.positionBuilderAtEnd(self.builder, merge_bb);
 

--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -3355,11 +3355,16 @@ pub const GrinTranslator = struct {
         // to emit (now that case sites rely solely on __rhc_force, the
         // P(0) forcing must live here). A P(0) node stores all the
         // function's arguments; load them and call directly.
+        //
+        // Only saturated (missing == 0) closures are callable. An
+        // under-saturated partial application is already WHNF — it falls
+        // through the switch default to `done` and is returned as-is.
         var ptag_iter = self.registry.partial_tags.iterator();
         while (ptag_iter.next()) |ptag_entry| {
             const ptag_unique = ptag_entry.key_ptr.*;
             const ptag_disc = self.registry.discriminants.get(ptag_unique) orelse continue;
             const ptag_info = self.registry.partial_tag_info.get(ptag_unique) orelse continue;
+            if (ptag_info.missing != 0) continue;
 
             const ptag_bb = c.LLVMAppendBasicBlock(func, "ptag");
             c.LLVMAddCase(sw, c.LLVMConstInt(i64_ty, @bitCast(ptag_disc), 0), ptag_bb);

--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -343,6 +343,16 @@ fn tagInt(builder: llvm.Builder, val: llvm.Value) llvm.Value {
     return c.LLVMBuildIntToPtr(builder, tagged, ptrType(), "tagged_int");
 }
 
+/// Encode a nullary constructor as a tagged immediate: `(disc << 1) | 1`,
+/// same encoding as integers. Case dispatch untags ptr-typed scrutinees
+/// with bit 0 set and switches on the result, so a nullary constructor
+/// never needs a heap node — its discriminant *is* the value. Only valid
+/// for `.Con` tags: F-tags need a heap slot for the Ind update (#605),
+/// and P-tags carry an arity header the apply machinery inspects.
+fn tagImmediateCon(builder: llvm.Builder, disc_val: llvm.Value) llvm.Value {
+    return tagInt(builder, disc_val);
+}
+
 fn untagInt(builder: llvm.Builder, val: llvm.Value) llvm.Value {
     const i64_ty = llvm.i64Type();
     const as_int = if (c.LLVMGetTypeKind(c.LLVMTypeOf(val)) == c.LLVMPointerTypeKind)
@@ -610,6 +620,11 @@ pub const GrinTranslator = struct {
     /// Keyed by `Name.unique.value` so that variables with the same base name
     /// but different uniques (e.g. `arg_20`, `arg_21`) are kept distinct.
     params: std.AutoHashMap(u64, llvm.Value),
+    /// GRIN variable uniques whose bound value is statically known to be
+    /// in WHNF (primop results, freshly-stored constructor nodes, tagged
+    /// immediates). Case sites consult this to elide the `__rhc_force`
+    /// pre-force call (#800). Cleared at the start of each translateDef.
+    whnf_vars: std.AutoHashMap(u64, void),
     /// Per-function cache for translated GRIN Case expressions.  The
     /// sequential pattern-match desugarer creates shared fallback nodes
     /// (a DAG) that would be re-translated exponentially without caching.
@@ -674,6 +689,7 @@ pub const GrinTranslator = struct {
             .builder = llvm.createBuilder(ctx),
             .allocator = allocator,
             .params = std.AutoHashMap(u64, llvm.Value).init(allocator),
+            .whnf_vars = std.AutoHashMap(u64, void).init(allocator),
             .case_entry_cache = std.AutoHashMap(usize, llvm.BasicBlock).init(allocator),
             .registry = registry,
             .type_env = TypeEnv.init(),
@@ -683,6 +699,7 @@ pub const GrinTranslator = struct {
 
     pub fn deinit(self: *GrinTranslator) void {
         self.params.deinit();
+        self.whnf_vars.deinit();
         self.case_entry_cache.deinit();
         // registry is not owned — do not deinit it.
         self.type_env.deinit(self.allocator);
@@ -1076,7 +1093,9 @@ pub const GrinTranslator = struct {
         // engine manages a shared external __rhc_force via
         // `emitForceModuleIr` / `emitSharedForceModule` — expression
         // modules must NOT define it to avoid duplicate-symbol errors.
-        if (self.registry.fun_tags.count() > 0) {
+        // P-tags also require __rhc_force: case sites rely on it to call
+        // saturated partial applications (P(0) nodes) in scrutinees.
+        if (self.registry.fun_tags.count() > 0 or self.registry.partial_tags.count() > 0) {
             if (self.repl_entry_point == null) {
                 // Whole-program mode: emit the force function here.
                 try self.emitForceFunction();
@@ -1160,7 +1179,7 @@ pub const GrinTranslator = struct {
         // emitted by `emitForceModuleIr`.  This ensures per-def code can
         // force thunks with F-tags introduced by later REPL expressions
         // that the per-def tag table didn't know about at compile time.
-        if (self.registry.fun_tags.count() > 0) {
+        if (self.registry.fun_tags.count() > 0 or self.registry.partial_tags.count() > 0) {
             // Declare __rhc_force as an external function so that
             // callForceIfNeeded can find it via LLVMGetNamedFunction.
             const ptr_ty = ptrType();
@@ -1204,7 +1223,7 @@ pub const GrinTranslator = struct {
         self.module = mod;
         defer self.module = saved_module;
 
-        if (self.registry.fun_tags.count() > 0) {
+        if (self.registry.fun_tags.count() > 0 or self.registry.partial_tags.count() > 0) {
             try self.emitForceFunction();
         }
 
@@ -1289,6 +1308,7 @@ pub const GrinTranslator = struct {
         // Clear previous function's parameter mapping and set up current one.
         self.params.deinit();
         self.params = std.AutoHashMap(u64, llvm.Value).init(self.allocator);
+        self.whnf_vars.clearRetainingCapacity();
 
         // Clear the per-function case expression cache.  The cache prevents
         // exponential re-translation of shared GRIN expressions produced by the
@@ -1371,9 +1391,12 @@ pub const GrinTranslator = struct {
                         // Non-REPL function: ensure return value matches function signature.
                         // Primop instructions return i64, but user functions return ptr.
                         // Cast i64→ptr to match the declared return type.
+                        // The return-site force upholds the "call results
+                        // are WHNF" convention; skip it when the body's
+                        // value is statically WHNF already.
                         const val_kind2 = c.LLVMGetTypeKind(c.LLVMTypeOf(val));
                         const coerced = if (val_kind2 == c.LLVMPointerTypeKind)
-                            self.callForceIfNeeded(val)
+                            (if (self.exprYieldsWhnf(def.body)) val else self.callForceIfNeeded(val))
                         else if (val_kind2 == c.LLVMIntegerTypeKind)
                             tagInt(self.builder, val)
                         else
@@ -1447,6 +1470,54 @@ pub const GrinTranslator = struct {
         }
     }
 
+    /// Whether a GRIN value is statically known to be in WHNF when it
+    /// reaches an SSA binding: literals and tagged immediates trivially;
+    /// constructor nodes by construction; variables if already tracked.
+    fn valYieldsWhnf(self: *const GrinTranslator, val: grin.Val) bool {
+        return switch (val) {
+            .Lit, .ValTag => true,
+            .ConstTagNode => |ctn| ctn.tag.tag_type == .Con,
+            .Var => |v| self.whnf_vars.contains(v.unique.value),
+            else => false,
+        };
+    }
+
+    /// Whether a GRIN expression's result is statically known to be in
+    /// WHNF. Conservative: anything unrecognised is assumed forceable.
+    ///
+    /// Primop instruction results are tagged immediates; a `Store` of a
+    /// constructor node is WHNF (F/P-tag stores are thunks/closures and
+    /// are not). Direct function calls are WHNF by calling convention:
+    /// every non-main GRIN function forces its return value at the return
+    /// site (see translateReturn) — and that force is itself only elided
+    /// when the returned value is already statically WHNF, so the
+    /// convention is preserved inductively.
+    fn exprYieldsWhnf(self: *const GrinTranslator, expr: *const grin.Expr) bool {
+        return switch (expr.*) {
+            .Return => |v| self.valYieldsWhnf(v),
+            .Store => |v| switch (v) {
+                .ConstTagNode => |ctn| ctn.tag.tag_type == .Con,
+                else => false,
+            },
+            .App => |app| blk: {
+                // `pure` passes its argument through unevaluated.
+                if (std.mem.eql(u8, app.name.base, "pure"))
+                    break :blk app.args.len > 0 and self.valYieldsWhnf(app.args[0]);
+                if (PrimOpMapping.lookup(app.name)) |m|
+                    break :blk m == .instruction;
+                // Direct call (or apply): result forced at the callee's
+                // return site per the calling convention above.
+                break :blk true;
+            },
+            .Block => |inner| self.exprYieldsWhnf(inner),
+            // A bind chain yields its continuation's value. By the time
+            // this runs at a return site, codegen has already walked the
+            // chain and recorded WHNF-ness of every bound variable.
+            .Bind => |b| self.exprYieldsWhnf(b.rhs),
+            else => false,
+        };
+    }
+
     fn translateBind(
         self: *GrinTranslator,
         lhs: *const grin.Expr,
@@ -1467,6 +1538,9 @@ pub const GrinTranslator = struct {
                 const result = try self.translateExprToValue(lhs, v.base);
                 if (result) |val| {
                     try self.bindAndRoot(v.unique.value, val);
+                    if (self.exprYieldsWhnf(lhs)) {
+                        self.whnf_vars.put(v.unique.value, {}) catch return error.OutOfMemory;
+                    }
                 }
                 try self.translateExpr(rhs);
             },
@@ -1525,7 +1599,12 @@ pub const GrinTranslator = struct {
                 const inner_result = try self.translateExprToValue(b.lhs, inner_name);
                 switch (b.pat) {
                     .Var => |v| {
-                        if (inner_result) |val| try self.bindAndRoot(v.unique.value, val);
+                        if (inner_result) |val| {
+                            try self.bindAndRoot(v.unique.value, val);
+                            if (self.exprYieldsWhnf(b.lhs)) {
+                                self.whnf_vars.put(v.unique.value, {}) catch return error.OutOfMemory;
+                            }
+                        }
                     },
                     .Unit => {},
                     .ConstTagNode => |ctn| {
@@ -2272,7 +2351,8 @@ pub const GrinTranslator = struct {
         const false_i64 = c.LLVMConstInt(llvm.i64Type(), @bitCast(false_disc), 0);
         const tag = c.LLVMBuildSelect(self.builder, cmp_i1, true_i64, false_i64, "bool_tag");
 
-        return self.emitAlloc(tag, 0, "bool_node");
+        // Bool is nullary — encode as a tagged immediate, no allocation.
+        return tagImmediateCon(self.builder, tag);
     }
 
     /// Translate a GRIN string literal to an LLVM global string pointer.
@@ -2389,14 +2469,16 @@ pub const GrinTranslator = struct {
                 return error.UnsupportedGrinVal;
             },
             .ValTag => |t| blk: {
-                // Bare tag value — allocate a heap node with 0 fields.
-                // Using a heap node (pointer) rather than a bare i64 discriminant
-                // lets the REPL and case analysis distinguish constructors from
-                // integer literals by LLVM type (ptr vs i64).
                 const disc = self.registry.discriminant(t) orelse return error.UnsupportedGrinVal;
+                const disc_val = c.LLVMConstInt(llvm.i64Type(), @bitCast(disc), 0);
+                // Nullary constructors are tagged immediates — no heap node.
+                // F-tags still need a heap slot for the Ind update (#605).
+                if (t.tag_type == .Con) {
+                    break :blk tagImmediateCon(self.builder, disc_val);
+                }
                 const alloc_fn = declareRtsAlloc(self.module);
                 var alloc_args2 = [_]llvm.Value{
-                    c.LLVMConstInt(llvm.i64Type(), @bitCast(disc), 0),
+                    disc_val,
                     c.LLVMConstInt(llvm.i32Type(), 0, 0),
                 };
                 break :blk c.LLVMBuildCall2(
@@ -2436,6 +2518,13 @@ pub const GrinTranslator = struct {
                 // and: https://github.com/adinapoli/rusholme/issues/711
                 if (tag.tag_type == .Fun and n_fields == 0) {
                     n_fields = 1;
+                }
+
+                // Nullary constructors need no heap node at all — they are
+                // tagged immediates (see tagImmediateCon).
+                if (tag.tag_type == .Con and n_fields == 0) {
+                    const disc_val = c.LLVMConstInt(llvm.i64Type(), @bitCast(disc), 0);
+                    return tagImmediateCon(self.builder, disc_val);
                 }
 
                 // Allocate a node via the inline-alloc fast path (#798),
@@ -2518,6 +2607,51 @@ pub const GrinTranslator = struct {
     /// We load the i64 tag word then emit `LLVMBuildSwitch`.  Each alternative
     /// gets its own basic block; a shared `merge` block is appended after all
     /// alts and becomes the new insertion point.
+    /// Emit the tag dispatch for a WHNF scrutinee: a low-bit guard routes
+    /// tagged immediates (raw Ints/Chars and nullary constructors) straight
+    /// to the case dispatch with their untagged payload as the "tag", while
+    /// heap nodes go through a header tag load.
+    ///
+    /// The scrutinee must already be in WHNF — pre-forced via `__rhc_force`,
+    /// which follows indirections, forces F-tag thunks, and calls saturated
+    /// partial applications. This replaces the per-case-site inline eval
+    /// loop, which duplicated the entire F/P-tag switch table at every case
+    /// expression (a major code-size and branch-prediction cost).
+    ///
+    /// Returns the i64 tag value to switch on. The builder is left in the
+    /// dispatch block.
+    fn emitWhnfTagDispatch(self: *GrinTranslator, scrut: llvm.Value) llvm.Value {
+        const i64_ty = llvm.i64Type();
+        const guard_bb = c.LLVMGetInsertBlock(self.builder);
+        const tagload_bb = c.LLVMAppendBasicBlock(self.current_func, "case.tagload");
+        const dispatch_bb = c.LLVMAppendBasicBlock(self.current_func, "case.dispatch");
+
+        const raw = c.LLVMBuildPtrToInt(self.builder, scrut, i64_ty, "scrut.int");
+        const untagged = c.LLVMBuildAShr(self.builder, raw, c.LLVMConstInt(i64_ty, 1, 0), "scrut.untagged");
+        const low_bit = c.LLVMBuildAnd(self.builder, raw, c.LLVMConstInt(i64_ty, 1, 0), "scrut.low_bit");
+        const is_heap = c.LLVMBuildICmp(self.builder, c.LLVMIntEQ, low_bit, c.LLVMConstInt(i64_ty, 0, 0), "scrut.is_heap");
+        const is_nonnull = c.LLVMBuildICmp(self.builder, c.LLVMIntNE, raw, c.LLVMConstInt(i64_ty, 0, 0), "scrut.nonnull");
+        const is_valid = c.LLVMBuildAnd(self.builder, is_heap, is_nonnull, "scrut.valid_heap");
+        _ = c.LLVMBuildCondBr(self.builder, is_valid, tagload_bb, dispatch_bb);
+
+        llvm.positionBuilderAtEnd(self.builder, tagload_bb);
+        const header_ty = nodeHeaderType();
+        var tag_idx = [_]llvm.Value{
+            c.LLVMConstInt(llvm.i32Type(), 0, 0),
+            c.LLVMConstInt(llvm.i32Type(), 0, 0),
+        };
+        const tag_gep = c.LLVMBuildGEP2(self.builder, header_ty, scrut, &tag_idx, 2, "scrut.tag_gep");
+        const tag_val = c.LLVMBuildLoad2(self.builder, i64_ty, tag_gep, "scrut.tag");
+        _ = c.LLVMBuildBr(self.builder, dispatch_bb);
+
+        llvm.positionBuilderAtEnd(self.builder, dispatch_bb);
+        const tag_phi = c.LLVMBuildPhi(self.builder, i64_ty, "dispatch.tag");
+        var phi_vals = [_]llvm.Value{ untagged, tag_val };
+        var phi_bbs = [_]llvm.BasicBlock{ guard_bb, tagload_bb };
+        c.LLVMAddIncoming(tag_phi, @ptrCast(&phi_vals), @ptrCast(&phi_bbs), 2);
+        return tag_phi;
+    }
+
     fn translateCase(
         self: *GrinTranslator,
         scrutinee: grin.Val,
@@ -2542,275 +2676,28 @@ pub const GrinTranslator = struct {
         // After pre-forcing, the inline eval loop below is still needed for
         // non-REPL (whole-program) compilation where `__rhc_force` may not
         // exist, and for indirection following.
-        const pre_forced = if (is_ptr) self.callForceIfNeeded(scrut_llvm) else scrut_llvm;
+        // Elide the force entirely when the scrutinee is statically WHNF
+        // (primop result, fresh constructor node, tagged immediate) — #800.
+        const scrut_is_whnf = self.valYieldsWhnf(scrutinee);
+        const pre_forced = if (is_ptr and !scrut_is_whnf)
+            self.callForceIfNeeded(scrut_llvm)
+        else
+            scrut_llvm;
 
-        // ── 1c. Inline eval loop (laziness) ────────────────────────────────
+        // ── 1c. Tag dispatch ───────────────────────────────────────────────
         //
-        // If the scrutinee is a heap pointer, it may be an unevaluated thunk
-        // (F-tag), a saturated partial application (P(0)-tag), or an indirection (Ind).
-        // We insert a loop that forces thunks, evaluates P(0) closures, and follows
-        // indirections until the value is in WHNF.
-        //
-        //   eval.entry:
-        //     %scrut_phi = phi [original, entry] [forced, eval.ind] [result, eval.ftag.*] [result, eval.ptag.*]
-        //     tag = load %scrut_phi.tag
-        //     switch tag: F-tags → force, P(0)-tags → call, Ind → follow, default → case.dispatch
+        // `pre_forced` is in WHNF: `__rhc_force` follows indirections,
+        // forces F-tag thunks, and calls saturated partial applications.
+        // All that remains is routing tagged immediates vs heap nodes to
+        // the alternatives switch (emitWhnfTagDispatch). The former
+        // per-case-site inline eval loop is gone — see #800.
 
         // The "current scrutinee" used by the rest of the function.
-        // For non-pointer scrutinees, no eval loop is needed.
-        var cur_scrut: llvm.Value = pre_forced;
+        const cur_scrut: llvm.Value = pre_forced;
         var cur_tag: llvm.Value = undefined;
 
-        // Create eval loop if we have F-tags (thunks) or P-tags (partial applications) to force
-        const has_forceable_tags = self.registry.fun_tags.count() > 0 or self.registry.partial_tags.count() > 0;
-        if (is_ptr and has_forceable_tags) {
-            const entry_bb = c.LLVMGetInsertBlock(self.builder);
-
-            // Create the eval loop header and dispatch target.
-            const eval_bb = c.LLVMAppendBasicBlock(self.current_func, "eval.entry");
-            const dispatch_bb = c.LLVMAppendBasicBlock(self.current_func, "case.dispatch");
-
-            // Branch from current block to eval loop.
-            _ = c.LLVMBuildBr(self.builder, eval_bb);
-
-            // ── eval.entry: phi + heap-pointer guard + tag load + switch ──
-            llvm.positionBuilderAtEnd(self.builder, eval_bb);
-            const phi = c.LLVMBuildPhi(self.builder, ptrType(), "scrut.eval");
-
-            // Heap-pointer guard: only dereference if the pointer looks
-            // like a valid heap node (aligned to 8 bytes AND above page
-            // zero).  Raw integers stored via inttoptr (e.g. literal 42
-            // in an F-tag thunk field) fail this check and go straight
-            // to case dispatch.
-            const eval_check_bb = c.LLVMAppendBasicBlock(self.current_func, "eval.check");
-            const guard_raw_tag = c.LLVMBuildPtrToInt(self.builder, phi, llvm.i64Type(), "eval.ptr_int");
-            const untagged_raw = c.LLVMBuildAShr(self.builder, guard_raw_tag, c.LLVMConstInt(llvm.i64Type(), 1, 0), "eval.untagged");
-            {
-                const low_bit = c.LLVMBuildAnd(self.builder, guard_raw_tag, c.LLVMConstInt(llvm.i64Type(), 1, 0), "eval.low_bit");
-                const is_heap = c.LLVMBuildICmp(self.builder, c.LLVMIntEQ, low_bit, c.LLVMConstInt(llvm.i64Type(), 0, 0), "eval.is_heap");
-                const is_nonnull = c.LLVMBuildICmp(self.builder, c.LLVMIntNE, guard_raw_tag, c.LLVMConstInt(llvm.i64Type(), 0, 0), "eval.nonnull");
-                const is_valid = c.LLVMBuildAnd(self.builder, is_heap, is_nonnull, "eval.valid_heap");
-                _ = c.LLVMBuildCondBr(self.builder, is_valid, eval_check_bb, dispatch_bb);
-            }
-
-            llvm.positionBuilderAtEnd(self.builder, eval_check_bb);
-            const header_ty = nodeHeaderType();
-            var tag_idx = [_]llvm.Value{
-                c.LLVMConstInt(llvm.i32Type(), 0, 0),
-                c.LLVMConstInt(llvm.i32Type(), 0, 0),
-            };
-            const tag_gep = c.LLVMBuildGEP2(self.builder, header_ty, phi, &tag_idx, 2, "eval.tag_gep");
-            const tag_val = c.LLVMBuildLoad2(self.builder, llvm.i64Type(), tag_gep, "eval.tag");
-
-            // Count F-tags + 1 for Ind.
-            const n_eval_cases = @as(u32, @intCast(self.registry.fun_tags.count())) + 1;
-            const eval_switch = c.LLVMBuildSwitch(self.builder, tag_val, dispatch_bb, n_eval_cases);
-
-            // ── Ind case: follow indirection ─────────────────────────────
-            const ind_bb = c.LLVMAppendBasicBlock(self.current_func, "eval.ind");
-            const ind_disc = c.LLVMConstInt(llvm.i64Type(), 0x101, 0); // Tag.Ind
-            c.LLVMAddCase(eval_switch, ind_disc, ind_bb);
-
-            llvm.positionBuilderAtEnd(self.builder, ind_bb);
-            const rts_load_fn = declareRtsLoadField(self.module);
-            var ind_load_args = [_]llvm.Value{
-                phi,
-                c.LLVMConstInt(llvm.i32Type(), 0, 0),
-            };
-            const ind_target_i64 = c.LLVMBuildCall2(
-                self.builder,
-                llvm.getFunctionType(rts_load_fn),
-                rts_load_fn,
-                &ind_load_args,
-                2,
-                "ind.target",
-            );
-            const ind_target = c.LLVMBuildIntToPtr(self.builder, ind_target_i64, ptrType(), "ind.ptr");
-            _ = c.LLVMBuildBr(self.builder, eval_bb);
-
-            // ── F-tag cases: force thunk ─────────────────────────────────
-            // Collect all incoming phi values: entry_bb→pre_forced, ind_bb→ind_target, plus each ftag_bb→result.
-            var phi_incoming_vals = std.ArrayListUnmanaged(llvm.Value).empty;
-            defer phi_incoming_vals.deinit(self.allocator);
-            var phi_incoming_bbs = std.ArrayListUnmanaged(llvm.BasicBlock).empty;
-            defer phi_incoming_bbs.deinit(self.allocator);
-
-            // First two: entry (pre-forced) and ind.
-            phi_incoming_vals.append(self.allocator, pre_forced) catch return error.OutOfMemory;
-            phi_incoming_bbs.append(self.allocator, entry_bb) catch return error.OutOfMemory;
-            phi_incoming_vals.append(self.allocator, ind_target) catch return error.OutOfMemory;
-            phi_incoming_bbs.append(self.allocator, ind_bb) catch return error.OutOfMemory;
-
-            var ftag_iter = self.registry.fun_tags.iterator();
-            while (ftag_iter.next()) |ftag_entry| {
-                const ftag_unique = ftag_entry.key_ptr.*;
-                const ftag_disc = self.registry.discriminants.get(ftag_unique) orelse continue;
-                const ftag_name = self.registry.fun_tag_names.get(ftag_unique) orelse continue;
-                const ftag_n_fields = self.registry.field_counts.get(ftag_unique) orelse 0;
-
-                const ftag_bb = c.LLVMAppendBasicBlock(self.current_func, "eval.ftag");
-                c.LLVMAddCase(eval_switch, c.LLVMConstInt(llvm.i64Type(), @bitCast(ftag_disc), 0), ftag_bb);
-
-                llvm.positionBuilderAtEnd(self.builder, ftag_bb);
-
-                // Load captured arguments from the thunk node's fields.
-                var call_args: [8]llvm.Value = undefined;
-                const n_args = @min(ftag_n_fields, 8);
-                for (0..n_args) |fi| {
-                    var fld_load_args = [_]llvm.Value{
-                        phi,
-                        c.LLVMConstInt(llvm.i32Type(), @intCast(fi), 0),
-                    };
-                    const loaded_i64 = c.LLVMBuildCall2(
-                        self.builder,
-                        llvm.getFunctionType(rts_load_fn),
-                        rts_load_fn,
-                        &fld_load_args,
-                        2,
-                        "ftag.arg",
-                    );
-                    // Thunk fields are pointers (heap nodes).
-                    call_args[fi] = c.LLVMBuildIntToPtr(self.builder, loaded_i64, ptrType(), "ftag.ptr");
-                }
-
-                // Call the function.
-                const fn_name_z = self.formatName(ftag_name);
-                var param_types: [8]llvm.Type = undefined;
-                for (0..n_args) |pi| param_types[pi] = ptrType();
-                const fn_type = llvm.functionType(ptrType(), param_types[0..n_args], false);
-                const func = c.LLVMGetNamedFunction(self.module, fn_name_z) orelse
-                    llvm.addFunction(self.module, fn_name_z, fn_type);
-                const result = c.LLVMBuildCall2(
-                    self.builder,
-                    fn_type,
-                    func,
-                    @ptrCast(&call_args),
-                    @intCast(n_args),
-                    "ftag.result",
-                );
-
-                // Update the thunk with an indirection: tag = Ind, field[0] = result.
-                // All F-tag thunks are now allocated with ≥1 field (see
-                // translateStoreToValue), so the update is unconditional.
-                {
-                    const upd_tag_gep = c.LLVMBuildGEP2(self.builder, header_ty, phi, &tag_idx, 2, "ftag.upd.tag");
-                    _ = c.LLVMBuildStore(self.builder, c.LLVMConstInt(llvm.i64Type(), 0x101, 0), upd_tag_gep);
-                    const rts_store_fn = declareRtsStoreField(self.module);
-                    const result_u64 = c.LLVMBuildPtrToInt(self.builder, result, llvm.i64Type(), "ftag.upd.u64");
-                    var upd_store_args = [_]llvm.Value{
-                        phi,
-                        c.LLVMConstInt(llvm.i32Type(), 0, 0),
-                        result_u64,
-                    };
-                    _ = c.LLVMBuildCall2(
-                        self.builder,
-                        llvm.getFunctionType(rts_store_fn),
-                        rts_store_fn,
-                        &upd_store_args,
-                        3,
-                        "",
-                    );
-                }
-
-                // Loop back to re-eval the result.
-                _ = c.LLVMBuildBr(self.builder, eval_bb);
-
-                phi_incoming_vals.append(self.allocator, result) catch return error.OutOfMemory;
-                phi_incoming_bbs.append(self.allocator, ftag_bb) catch return error.OutOfMemory;
-            }
-
-            // ── P-tag cases: force partial applications ─────────────────
-            // For each P-tag, we need to apply it (possibly multiple times)
-            // until it's fully saturated, then force the result.
-            // We use __rhc_apply with a dummy argument (null) to trigger evaluation.
-            var ptag_iter = self.registry.partial_tags.iterator();
-            while (ptag_iter.next()) |ptag_entry| {
-                const ptag_unique = ptag_entry.key_ptr.*;
-                const ptag_disc = self.registry.discriminants.get(ptag_unique) orelse continue;
-
-                const ptag_bb = c.LLVMAppendBasicBlock(self.current_func, "eval.ptag");
-                c.LLVMAddCase(eval_switch, c.LLVMConstInt(llvm.i64Type(), @bitCast(ptag_disc), 0), ptag_bb);
-
-                llvm.positionBuilderAtEnd(self.builder, ptag_bb);
-
-                // A P-tag partial application in a case scrutinee needs to be fully applied.
-                // If the stored fields represent all the arguments the function needs,
-                // we can call it directly. Otherwise, it's an error.
-                const ptag_info = self.registry.partial_tag_info.get(ptag_unique) orelse continue;
-                
-                // Extract and call the function with all stored arguments
-                const fn_name_z = self.formatName(ptag_info.name);
-                const n_fields = ptag_info.n_fields;
-                
-                // Load all captured arguments
-                var call_args: [8]llvm.Value = undefined;
-                for (0..@min(n_fields, 8)) |fi| {
-                    var load_args = [_]llvm.Value{
-                        phi,
-                        c.LLVMConstInt(llvm.i32Type(), @intCast(fi), 0),
-                    };
-                    const loaded = c.LLVMBuildCall2(
-                        self.builder,
-                        llvm.getFunctionType(rts_load_fn),
-                        rts_load_fn,
-                        &load_args,
-                        2,
-                        "pap.arg",
-                    );
-                    call_args[fi] = c.LLVMBuildIntToPtr(self.builder, loaded, ptrType(), "pap.ptr");
-                }
-                
-                // Call the function with stored arguments
-                var fn_param_types: [8]llvm.Type = undefined;
-                for (0..@min(n_fields, 8)) |pi| fn_param_types[pi] = ptrType();
-                const callee_type = llvm.functionType(ptrType(), fn_param_types[0..@min(n_fields, 8)], false);
-                const callee = c.LLVMGetNamedFunction(self.module, fn_name_z) orelse
-                    llvm.addFunction(self.module, fn_name_z, callee_type);
-                const result = c.LLVMBuildCall2(
-                    self.builder,
-                    callee_type,
-                    callee,
-                    @ptrCast(&call_args),
-                    @intCast(@min(n_fields, 8)),
-                    "pap.result",
-                );
-                
-                // Loop back to re-eval the result
-                _ = c.LLVMBuildBr(self.builder, eval_bb);
-                
-                phi_incoming_vals.append(self.allocator, result) catch return error.OutOfMemory;
-                phi_incoming_bbs.append(self.allocator, ptag_bb) catch return error.OutOfMemory;
-            }
-
-            // Wire up the phi node.
-            c.LLVMAddIncoming(
-                phi,
-                @ptrCast(phi_incoming_vals.items.ptr),
-                @ptrCast(phi_incoming_bbs.items.ptr),
-                @intCast(phi_incoming_vals.items.len),
-            );
-
-            // Continue from dispatch block with the resolved scrutinee.
-            // Use a phi for the tag: when arriving from eval.check (the
-            // eval switch default), the tag was loaded from the heap node;
-            // when arriving from eval.entry (heap-guard fail), use the
-            // untagged integer value as the "tag" (for LitPat matching).
-            llvm.positionBuilderAtEnd(self.builder, dispatch_bb);
-            const tag_phi = c.LLVMBuildPhi(self.builder, llvm.i64Type(), "dispatch.tag");
-            var tag_phi_vals = [_]llvm.Value{ tag_val, untagged_raw };
-            var tag_phi_bbs = [_]llvm.BasicBlock{ eval_check_bb, eval_bb };
-            c.LLVMAddIncoming(tag_phi, @ptrCast(&tag_phi_vals), @ptrCast(&tag_phi_bbs), 2);
-            cur_scrut = phi;
-            cur_tag = tag_phi;
-        } else if (is_ptr) {
-            // No F-tags in program — just load the tag directly (no eval loop).
-            const header_ty = nodeHeaderType();
-            var idx = [_]llvm.Value{
-                c.LLVMConstInt(llvm.i32Type(), 0, 0),
-                c.LLVMConstInt(llvm.i32Type(), 0, 0),
-            };
-            const tag_gep = c.LLVMBuildGEP2(self.builder, header_ty, scrut_llvm, &idx, 2, "tag_gep");
-            cur_tag = c.LLVMBuildLoad2(self.builder, llvm.i64Type(), tag_gep, "tag");
+        if (is_ptr) {
+            cur_tag = self.emitWhnfTagDispatch(pre_forced);
         } else {
             cur_tag = scrut_llvm; // Already an i64 discriminant (nullary constructor).
         }
@@ -2956,161 +2843,21 @@ pub const GrinTranslator = struct {
         // Same as translateCase: in REPL mode, per-def modules' inline eval
         // loops only know about F-tags from Prelude compile time. Pre-force
         // via the shared external __rhc_force which knows all F-tags.
-        const pre_forced = if (is_ptr) self.callForceIfNeeded(scrut_llvm) else scrut_llvm;
+        // Elide the force entirely when the scrutinee is statically WHNF
+        // (primop result, fresh constructor node, tagged immediate) — #800.
+        const scrut_is_whnf = self.valYieldsWhnf(scrutinee);
+        const pre_forced = if (is_ptr and !scrut_is_whnf)
+            self.callForceIfNeeded(scrut_llvm)
+        else
+            scrut_llvm;
 
-        var cur_scrut: llvm.Value = pre_forced;
+        // ── 1c. Tag dispatch (same as translateCase) ───────────────────────
+        // `pre_forced` is WHNF; route immediates vs heap nodes (#800).
+        const cur_scrut: llvm.Value = pre_forced;
         var cur_tag: llvm.Value = undefined;
 
-        // Create eval loop if we have F-tags (thunks) or P-tags (partial applications) to force
-        const has_forceable_tags = self.registry.fun_tags.count() > 0 or self.registry.partial_tags.count() > 0;
-        if (is_ptr and has_forceable_tags) {
-            const entry_bb = c.LLVMGetInsertBlock(self.builder);
-            const eval_bb = c.LLVMAppendBasicBlock(self.current_func, "eval.entry");
-            const dispatch_bb = c.LLVMAppendBasicBlock(self.current_func, "case.dispatch");
-
-            _ = c.LLVMBuildBr(self.builder, eval_bb);
-
-            llvm.positionBuilderAtEnd(self.builder, eval_bb);
-            const phi = c.LLVMBuildPhi(self.builder, ptrType(), "scrut.eval");
-
-            // Heap-pointer guard (same as translateCase): skip eval for
-            // tagged integers in F-tag thunk fields.
-            const eval_check_bb = c.LLVMAppendBasicBlock(self.current_func, "eval.check");
-            const guard_raw_tag = c.LLVMBuildPtrToInt(self.builder, phi, llvm.i64Type(), "eval.ptr_int");
-            const untagged_raw = c.LLVMBuildAShr(self.builder, guard_raw_tag, c.LLVMConstInt(llvm.i64Type(), 1, 0), "eval.untagged");
-            {
-                const low_bit = c.LLVMBuildAnd(self.builder, guard_raw_tag, c.LLVMConstInt(llvm.i64Type(), 1, 0), "eval.low_bit");
-                const is_heap = c.LLVMBuildICmp(self.builder, c.LLVMIntEQ, low_bit, c.LLVMConstInt(llvm.i64Type(), 0, 0), "eval.is_heap");
-                const is_nonnull = c.LLVMBuildICmp(self.builder, c.LLVMIntNE, guard_raw_tag, c.LLVMConstInt(llvm.i64Type(), 0, 0), "eval.nonnull");
-                const is_valid = c.LLVMBuildAnd(self.builder, is_heap, is_nonnull, "eval.valid_heap");
-                _ = c.LLVMBuildCondBr(self.builder, is_valid, eval_check_bb, dispatch_bb);
-            }
-
-            llvm.positionBuilderAtEnd(self.builder, eval_check_bb);
-            const header_ty = nodeHeaderType();
-            var tag_idx = [_]llvm.Value{
-                c.LLVMConstInt(llvm.i32Type(), 0, 0),
-                c.LLVMConstInt(llvm.i32Type(), 0, 0),
-            };
-            const tag_gep = c.LLVMBuildGEP2(self.builder, header_ty, phi, &tag_idx, 2, "eval.tag_gep");
-            const tag_val = c.LLVMBuildLoad2(self.builder, llvm.i64Type(), tag_gep, "eval.tag");
-
-            const n_eval_cases = @as(u32, @intCast(self.registry.fun_tags.count())) + 1;
-            const eval_switch = c.LLVMBuildSwitch(self.builder, tag_val, dispatch_bb, n_eval_cases);
-
-            // Ind case
-            const ind_bb = c.LLVMAppendBasicBlock(self.current_func, "eval.ind");
-            const ind_disc = c.LLVMConstInt(llvm.i64Type(), 0x101, 0);
-            c.LLVMAddCase(eval_switch, ind_disc, ind_bb);
-
-            llvm.positionBuilderAtEnd(self.builder, ind_bb);
-            const rts_load_fn = declareRtsLoadField(self.module);
-            var ind_load_args = [_]llvm.Value{ phi, c.LLVMConstInt(llvm.i32Type(), 0, 0) };
-            const ind_target_i64 = c.LLVMBuildCall2(self.builder, llvm.getFunctionType(rts_load_fn), rts_load_fn, &ind_load_args, 2, "ind.target");
-            const ind_target = c.LLVMBuildIntToPtr(self.builder, ind_target_i64, ptrType(), "ind.ptr");
-            _ = c.LLVMBuildBr(self.builder, eval_bb);
-
-            var phi_incoming_vals = std.ArrayListUnmanaged(llvm.Value).empty;
-            defer phi_incoming_vals.deinit(self.allocator);
-            var phi_incoming_bbs = std.ArrayListUnmanaged(llvm.BasicBlock).empty;
-            defer phi_incoming_bbs.deinit(self.allocator);
-
-            // Entry uses pre-forced value so external __rhc_force result feeds in.
-            phi_incoming_vals.append(self.allocator, pre_forced) catch return error.OutOfMemory;
-            phi_incoming_bbs.append(self.allocator, entry_bb) catch return error.OutOfMemory;
-            phi_incoming_vals.append(self.allocator, ind_target) catch return error.OutOfMemory;
-            phi_incoming_bbs.append(self.allocator, ind_bb) catch return error.OutOfMemory;
-
-            // F-tag cases
-            var ftag_iter = self.registry.fun_tags.iterator();
-            while (ftag_iter.next()) |ftag_entry| {
-                const ftag_unique = ftag_entry.key_ptr.*;
-                const ftag_disc = self.registry.discriminants.get(ftag_unique) orelse continue;
-                const ftag_name = self.registry.fun_tag_names.get(ftag_unique) orelse continue;
-                const ftag_n_fields = self.registry.field_counts.get(ftag_unique) orelse 0;
-
-                const ftag_bb = c.LLVMAppendBasicBlock(self.current_func, "eval.ftag");
-                c.LLVMAddCase(eval_switch, c.LLVMConstInt(llvm.i64Type(), @bitCast(ftag_disc), 0), ftag_bb);
-                llvm.positionBuilderAtEnd(self.builder, ftag_bb);
-
-                var call_args: [8]llvm.Value = undefined;
-                const n_args = @min(ftag_n_fields, 8);
-                for (0..n_args) |fi| {
-                    var fld_load_args = [_]llvm.Value{ phi, c.LLVMConstInt(llvm.i32Type(), @intCast(fi), 0) };
-                    const loaded_i64 = c.LLVMBuildCall2(self.builder, llvm.getFunctionType(rts_load_fn), rts_load_fn, &fld_load_args, 2, "ftag.arg");
-                    call_args[fi] = c.LLVMBuildIntToPtr(self.builder, loaded_i64, ptrType(), "ftag.ptr");
-                }
-
-                const fn_name_z = self.formatName(ftag_name);
-                var param_types: [8]llvm.Type = undefined;
-                for (0..n_args) |pi| param_types[pi] = ptrType();
-                const fn_type = llvm.functionType(ptrType(), param_types[0..n_args], false);
-                const func = c.LLVMGetNamedFunction(self.module, fn_name_z) orelse llvm.addFunction(self.module, fn_name_z, fn_type);
-                const result = c.LLVMBuildCall2(self.builder, fn_type, func, @ptrCast(&call_args), @intCast(n_args), "ftag.result");
-
-                // Update thunk to indirection. All F-tag thunks are allocated
-                // with ≥1 field, so the update is unconditional.
-                {
-                    const upd_tag_gep = c.LLVMBuildGEP2(self.builder, header_ty, phi, &tag_idx, 2, "ftag.upd.tag");
-                    _ = c.LLVMBuildStore(self.builder, c.LLVMConstInt(llvm.i64Type(), 0x101, 0), upd_tag_gep);
-                    const rts_store_fn = declareRtsStoreField(self.module);
-                    const result_u64 = c.LLVMBuildPtrToInt(self.builder, result, llvm.i64Type(), "ftag.upd.u64");
-                    var upd_store_args = [_]llvm.Value{ phi, c.LLVMConstInt(llvm.i32Type(), 0, 0), result_u64 };
-                    _ = c.LLVMBuildCall2(self.builder, llvm.getFunctionType(rts_store_fn), rts_store_fn, &upd_store_args, 3, "");
-                }
-
-                _ = c.LLVMBuildBr(self.builder, eval_bb);
-                phi_incoming_vals.append(self.allocator, result) catch return error.OutOfMemory;
-                phi_incoming_bbs.append(self.allocator, ftag_bb) catch return error.OutOfMemory;
-            }
-
-            // P-tag cases
-            var ptag_iter = self.registry.partial_tags.iterator();
-            while (ptag_iter.next()) |ptag_entry| {
-                const ptag_unique = ptag_entry.key_ptr.*;
-                const ptag_disc = self.registry.discriminants.get(ptag_unique) orelse continue;
-                const ptag_bb = c.LLVMAppendBasicBlock(self.current_func, "eval.ptag");
-                c.LLVMAddCase(eval_switch, c.LLVMConstInt(llvm.i64Type(), @bitCast(ptag_disc), 0), ptag_bb);
-                llvm.positionBuilderAtEnd(self.builder, ptag_bb);
-
-                const ptag_info = self.registry.partial_tag_info.get(ptag_unique) orelse continue;
-                const fn_name_z = self.formatName(ptag_info.name);
-                const n_fields = ptag_info.n_fields;
-
-                var call_args: [8]llvm.Value = undefined;
-                for (0..@min(n_fields, 8)) |fi| {
-                    var load_args = [_]llvm.Value{ phi, c.LLVMConstInt(llvm.i32Type(), @intCast(fi), 0) };
-                    const loaded = c.LLVMBuildCall2(self.builder, llvm.getFunctionType(rts_load_fn), rts_load_fn, &load_args, 2, "pap.arg");
-                    call_args[fi] = c.LLVMBuildIntToPtr(self.builder, loaded, ptrType(), "pap.ptr");
-                }
-
-                var fn_param_types: [8]llvm.Type = undefined;
-                for (0..@min(n_fields, 8)) |pi| fn_param_types[pi] = ptrType();
-                const callee_type = llvm.functionType(ptrType(), fn_param_types[0..@min(n_fields, 8)], false);
-                const callee = c.LLVMGetNamedFunction(self.module, fn_name_z) orelse llvm.addFunction(self.module, fn_name_z, callee_type);
-                const result = c.LLVMBuildCall2(self.builder, callee_type, callee, @ptrCast(&call_args), @intCast(@min(n_fields, 8)), "pap.result");
-
-                _ = c.LLVMBuildBr(self.builder, eval_bb);
-                phi_incoming_vals.append(self.allocator, result) catch return error.OutOfMemory;
-                phi_incoming_bbs.append(self.allocator, ptag_bb) catch return error.OutOfMemory;
-            }
-
-            c.LLVMAddIncoming(phi, @ptrCast(phi_incoming_vals.items.ptr), @ptrCast(phi_incoming_bbs.items.ptr), @intCast(phi_incoming_vals.items.len));
-
-            // Tag phi: merge tag_val from eval.check and untagged integer from
-            // eval.entry (heap-guard fail path).
-            llvm.positionBuilderAtEnd(self.builder, dispatch_bb);
-            const tag_phi = c.LLVMBuildPhi(self.builder, llvm.i64Type(), "dispatch.tag");
-            var tag_phi_vals = [_]llvm.Value{ tag_val, untagged_raw };
-            var tag_phi_bbs = [_]llvm.BasicBlock{ eval_check_bb, eval_bb };
-            c.LLVMAddIncoming(tag_phi, @ptrCast(&tag_phi_vals), @ptrCast(&tag_phi_bbs), 2);
-            cur_scrut = phi;
-            cur_tag = tag_phi;
-        } else if (is_ptr) {
-            const header_ty = nodeHeaderType();
-            var idx = [_]llvm.Value{ c.LLVMConstInt(llvm.i32Type(), 0, 0), c.LLVMConstInt(llvm.i32Type(), 0, 0) };
-            const tag_gep = c.LLVMBuildGEP2(self.builder, header_ty, scrut_llvm, &idx, 2, "tag_gep");
-            cur_tag = c.LLVMBuildLoad2(self.builder, llvm.i64Type(), tag_gep, "tag");
+        if (is_ptr) {
+            cur_tag = self.emitWhnfTagDispatch(pre_forced);
         } else {
             cur_tag = scrut_llvm;
         }
@@ -3375,8 +3122,14 @@ pub const GrinTranslator = struct {
                     // Non-main, non-REPL functions return ptr.
                     // Force any F-tagged thunks to WHNF before returning
                     // so that callers always receive evaluated values.
+                    // (This return-site force is the convention that makes
+                    // every direct call result WHNF — see exprYieldsWhnf.)
+                    // Skip it when the value is statically WHNF already.
                     if (is_ptr) {
-                        const forced = self.callForceIfNeeded(llvm_val);
+                        const forced = if (self.valYieldsWhnf(val))
+                            llvm_val
+                        else
+                            self.callForceIfNeeded(llvm_val);
                         self.buildRetWithShadowRestore(forced);
                         return;
                     }
@@ -3491,7 +3244,7 @@ pub const GrinTranslator = struct {
         const tag_gep = c.LLVMBuildGEP2(self.builder, header_ty, phi, &tag_idx, 2, "tag_gep");
         const tag_val = c.LLVMBuildLoad2(self.builder, i64_ty, tag_gep, "tag");
 
-        const n_cases = @as(u32, @intCast(self.registry.fun_tags.count())) + 1;
+        const n_cases = @as(u32, @intCast(self.registry.fun_tags.count() + self.registry.partial_tags.count())) + 1;
         const sw = c.LLVMBuildSwitch(self.builder, tag_val, done_bb, n_cases);
 
         // ── Ind case: follow indirection ───────────────────────────────
@@ -3597,6 +3350,62 @@ pub const GrinTranslator = struct {
             phi_bbs.append(self.allocator, ftag_bb) catch return error.OutOfMemory;
         }
 
+        // ── P-tag cases: call saturated partial applications ───────────
+        // Mirrors the P-tag arm the per-case-site inline eval loops used
+        // to emit (now that case sites rely solely on __rhc_force, the
+        // P(0) forcing must live here). A P(0) node stores all the
+        // function's arguments; load them and call directly.
+        var ptag_iter = self.registry.partial_tags.iterator();
+        while (ptag_iter.next()) |ptag_entry| {
+            const ptag_unique = ptag_entry.key_ptr.*;
+            const ptag_disc = self.registry.discriminants.get(ptag_unique) orelse continue;
+            const ptag_info = self.registry.partial_tag_info.get(ptag_unique) orelse continue;
+
+            const ptag_bb = c.LLVMAppendBasicBlock(func, "ptag");
+            c.LLVMAddCase(sw, c.LLVMConstInt(i64_ty, @bitCast(ptag_disc), 0), ptag_bb);
+
+            llvm.positionBuilderAtEnd(self.builder, ptag_bb);
+
+            const fn_name_z = self.formatName(ptag_info.name);
+            const n_fields = ptag_info.n_fields;
+            var call_args: [8]llvm.Value = undefined;
+            const n_args = @min(n_fields, 8);
+            for (0..n_args) |fi| {
+                var fld_args = [_]llvm.Value{
+                    phi,
+                    c.LLVMConstInt(llvm.i32Type(), @intCast(fi), 0),
+                };
+                const loaded = c.LLVMBuildCall2(
+                    self.builder,
+                    llvm.getFunctionType(rts_load_fn),
+                    rts_load_fn,
+                    &fld_args,
+                    2,
+                    "pap_arg",
+                );
+                call_args[fi] = c.LLVMBuildIntToPtr(self.builder, loaded, ptr_ty, "pap_ptr");
+            }
+
+            var fn_param_types: [8]llvm.Type = undefined;
+            for (0..n_args) |pi| fn_param_types[pi] = ptr_ty;
+            const callee_type = llvm.functionType(ptr_ty, fn_param_types[0..n_args], false);
+            const callee = c.LLVMGetNamedFunction(self.module, fn_name_z) orelse
+                llvm.addFunction(self.module, fn_name_z, callee_type);
+            const result = c.LLVMBuildCall2(
+                self.builder,
+                callee_type,
+                callee,
+                @ptrCast(&call_args),
+                @intCast(n_args),
+                "pap_result",
+            );
+
+            _ = c.LLVMBuildBr(self.builder, eval_bb);
+
+            phi_vals.append(self.allocator, result) catch return error.OutOfMemory;
+            phi_bbs.append(self.allocator, ptag_bb) catch return error.OutOfMemory;
+        }
+
         // Wire up phi.
         c.LLVMAddIncoming(
             phi,
@@ -3614,7 +3423,7 @@ pub const GrinTranslator = struct {
     /// Returns the forced pointer value, or the original value unchanged
     /// if no F-tags exist (i.e. `__rhc_force` was never emitted).
     fn callForceIfNeeded(self: *GrinTranslator, val: llvm.Value) llvm.Value {
-        if (self.registry.fun_tags.count() == 0) return val;
+        if (self.registry.fun_tags.count() == 0 and self.registry.partial_tags.count() == 0) return val;
         const force_fn = c.LLVMGetNamedFunction(self.module, "__rhc_force") orelse return val;
         var args = [_]llvm.Value{val};
         return c.LLVMBuildCall2(

--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -437,22 +437,70 @@ fn declareRtsSetBackend(module: llvm.Module) llvm.Value {
     return c.LLVMAddFunction(module, name, fn_ty);
 }
 
-/// Declare `rts_store_field(node: ptr, index: i32, value: i64) -> void`.
+/// Get-or-define the module-private `rts_store_field(ptr, i32, i64)`.
+/// Field access is a fixed-offset store (`fields(n)[i] = v` in
+/// src/rts/node.zig); defining it as an always-inline body in every
+/// module lets LLVM fold the call away — out-of-line RTS calls for
+/// every field write were a dominant cost on alloc-heavy benches.
 fn declareRtsStoreField(module: llvm.Module) llvm.Value {
     const name = "rts_store_field";
     if (c.LLVMGetNamedFunction(module, name)) |existing| return existing;
     var params = [_]llvm.Type{ ptrType(), llvm.i32Type(), llvm.i64Type() };
     const fn_ty = c.LLVMFunctionType(llvm.voidType(), &params, 3, 0);
-    return c.LLVMAddFunction(module, name, fn_ty);
+    const func = c.LLVMAddFunction(module, name, fn_ty);
+    defineFieldAccessorBody(module, func, .store);
+    return func;
 }
 
-/// Declare `rts_load_field(node: ptr, index: i32) -> i64`.
+/// Get-or-define the module-private `rts_load_field(ptr, i32) -> i64`.
 fn declareRtsLoadField(module: llvm.Module) llvm.Value {
     const name = "rts_load_field";
     if (c.LLVMGetNamedFunction(module, name)) |existing| return existing;
     var params = [_]llvm.Type{ ptrType(), llvm.i32Type() };
     const fn_ty = c.LLVMFunctionType(llvm.i64Type(), &params, 2, 0);
-    return c.LLVMAddFunction(module, name, fn_ty);
+    const func = c.LLVMAddFunction(module, name, fn_ty);
+    defineFieldAccessorBody(module, func, .load);
+    return func;
+}
+
+/// Emit the body for an inline field accessor. The function is given
+/// internal linkage and the `alwaysinline` attribute so the symbol never
+/// clashes with the real RTS export (which remains for Zig-side callers)
+/// and the call disappears during optimisation.
+fn defineFieldAccessorBody(module: llvm.Module, func: llvm.Value, kind: enum { load, store }) void {
+    c.LLVMSetLinkage(func, c.LLVMInternalLinkage);
+    const ctx = c.LLVMGetModuleContext(module);
+    const kind_id = c.LLVMGetEnumAttributeKindForName("alwaysinline", "alwaysinline".len);
+    const attr = c.LLVMCreateEnumAttribute(ctx, kind_id, 0);
+    const fn_index: c_uint = @bitCast(@as(c_int, c.LLVMAttributeFunctionIndex));
+    c.LLVMAddAttributeAtIndex(func, fn_index, attr);
+
+    const builder = c.LLVMCreateBuilderInContext(ctx);
+    defer c.LLVMDisposeBuilder(builder);
+    const entry = llvm.appendBasicBlock(func, "entry");
+    llvm.positionBuilderAtEnd(builder, entry);
+
+    const node_ptr = c.LLVMGetParam(func, 0);
+    const index = c.LLVMGetParam(func, 1);
+    const idx64 = c.LLVMBuildZExt(builder, index, llvm.i64Type(), "idx");
+    // fields base = node + 16 bytes (2 i64 header slots), slot i at +8*i.
+    const hdr = c.LLVMConstInt(llvm.i64Type(), 2, 0);
+    var base_idx = [_]llvm.Value{hdr};
+    const base = c.LLVMBuildGEP2(builder, llvm.i64Type(), node_ptr, &base_idx, 1, "fields.base");
+    var slot_idx = [_]llvm.Value{idx64};
+    const slot = c.LLVMBuildGEP2(builder, llvm.i64Type(), base, &slot_idx, 1, "field.slot");
+
+    switch (kind) {
+        .load => {
+            const v = c.LLVMBuildLoad2(builder, llvm.i64Type(), slot, "field.val");
+            _ = c.LLVMBuildRet(builder, v);
+        },
+        .store => {
+            const v = c.LLVMGetParam(func, 2);
+            _ = c.LLVMBuildStore(builder, v, slot);
+            _ = c.LLVMBuildRetVoid(builder);
+        },
+    }
 }
 
 /// Capacity (in slots) of the shadow-stack buffer exposed by the RTS.

--- a/src/core/demand.zig
+++ b/src/core/demand.zig
@@ -164,10 +164,58 @@ fn collectFn(
         params.deinit(alloc);
         return; // CAF — nothing to analyse.
     }
+    try collectVarAliases(alloc, cur, aliases);
     try fns.put(alloc, unique, .{
         .params = try params.toOwnedSlice(alloc),
         .body = cur,
     });
+}
+
+/// Record `let x = y` variable aliases from a function body. The pattern
+/// compiler re-binds parameters under fresh names in every alternative
+/// (`let acc' = arg_0 in ...`); without resolving these, demand on the
+/// original parameter is invisible. Uniques are globally unique after
+/// renaming, so one flat map is safe (no shadowing).
+fn collectVarAliases(
+    alloc: std.mem.Allocator,
+    e: *const Expr,
+    aliases: *std.AutoHashMapUnmanaged(u64, u64),
+) std.mem.Allocator.Error!void {
+    switch (e.*) {
+        .Var, .Lit, .Type, .Coercion => {},
+        .Lam => |l| try collectVarAliases(alloc, l.body, aliases),
+        .App => |a| {
+            try collectVarAliases(alloc, a.fn_expr, aliases);
+            try collectVarAliases(alloc, a.arg, aliases);
+        },
+        .Case => |case_expr| {
+            try collectVarAliases(alloc, case_expr.scrutinee, aliases);
+            for (case_expr.alts) |alt| try collectVarAliases(alloc, alt.body, aliases);
+        },
+        .Let => |l| {
+            switch (l.bind) {
+                .NonRec => |pair| {
+                    if (pair.rhs.* == .Var) {
+                        try aliases.put(alloc, pair.binder.name.unique.value, pair.rhs.Var.name.unique.value);
+                    }
+                    try collectVarAliases(alloc, pair.rhs, aliases);
+                },
+                .Rec => |pairs| for (pairs) |pair| try collectVarAliases(alloc, pair.rhs, aliases),
+            }
+            try collectVarAliases(alloc, l.body, aliases);
+        },
+    }
+}
+
+/// Follow the alias chain to the representative unique.
+fn resolveAlias(aliases: *const std.AutoHashMapUnmanaged(u64, u64), unique: u64) u64 {
+    var cur = unique;
+    var hops: u8 = 0;
+    while (aliases.get(cur)) |next| : (hops += 1) {
+        if (hops > 8) break;
+        cur = next;
+    }
+    return cur;
 }
 
 /// Does evaluating `e` to WHNF force the variable `p`?
@@ -179,7 +227,7 @@ fn demands(
     masks: *const StrictnessMap,
 ) bool {
     switch (e.*) {
-        .Var => |id| return id.name.unique.value == p,
+        .Var => |id| return resolveAlias(aliases, id.name.unique.value) == p,
         .Lit, .Lam, .Type, .Coercion => return false,
 
         .App => {

--- a/src/core/demand.zig
+++ b/src/core/demand.zig
@@ -1,0 +1,423 @@
+//! Demand (strictness) analysis — Core-level, whole-program (#802).
+//!
+//! Computes, for every top-level function, which parameters are *strict*:
+//! `f` is strict in its i-th parameter when `f a1 .. ⊥ .. an = ⊥` — i.e.
+//! evaluating the call to WHNF necessarily forces that argument. Callers
+//! can then pass strict arguments eagerly instead of allocating thunks,
+//! with no change to semantics (the argument would have been forced
+//! anyway, and forcing it earlier cannot turn a terminating program into
+//! a diverging one for an argument that is always demanded).
+//!
+//! Algorithm (Mycroft 1980, the classic abstract-interpretation
+//! formulation restricted to flat demand — no higher-order or nested
+//! product demands):
+//!
+//! 1. Every known function starts with the most-strict assumption (all
+//!    parameters strict; abstractly `f# = ⊥`).
+//! 2. Iterate: recompute each function's strict-parameter mask from its
+//!    body under the current assumptions, until no mask changes. The
+//!    iteration descends monotonically in the mask lattice and the
+//!    fixpoint is the least fixed point of the abstract semantics —
+//!    sound for recursive and mutually recursive groups.
+//!
+//! The core predicate is `demands(e, p)`: does evaluating `e` to WHNF
+//! force the variable `p`?
+//!
+//!   demands(p)                      = true
+//!   demands(prim a1..an)           = ∃i. demands(ai)        (primops are strict)
+//!   demands(f a1..an) | saturated  = ∃i. strict(f,i) ∧ demands(ai)
+//!   demands(f a1..an) | partial    = false                  (P-node is WHNF)
+//!   demands(case s of alts)        = demands(s) ∨ ∀alt. demands(alt)
+//!   demands(let x = r in b)        = demands(b) ∨ (b demands x ∧ demands(r))
+//!   demands(λ…), demands(lit)      = false
+//!
+//! Reference: Mycroft, "The theory and practice of transforming
+//! call-by-need into call-by-value" (1980); GHC's GHC.Core.Opt.DmdAnal
+//! (this pass is the 1-bit subset).
+
+const std = @import("std");
+const core = @import("ast.zig");
+const known = @import("../naming/known.zig");
+// PrimOp name vocabulary. The demand analysis needs to know which
+// application heads are primitive operations (strict in all arguments);
+// primops appear in Core with renamer-assigned uniques, so the canonical
+// name list in grin/primop.zig is the only reliable identification.
+const primop = @import("../grin/primop.zig");
+const Expr = core.Expr;
+const Bind = core.Bind;
+const BindPair = core.BindPair;
+const CoreProgram = core.CoreProgram;
+
+/// Strict-parameter masks, keyed by function binder unique. Bit i set =
+/// strict in parameter i. Functions with more than 64 parameters are
+/// not analysed (no such function survives the desugarer in practice).
+pub const StrictnessMap = std.AutoHashMapUnmanaged(u64, u64);
+
+const FnInfo = struct {
+    params: []const u64,
+    body: *const Expr,
+};
+
+/// Analyse all modules of a program. `programs` is the per-module Core
+/// in any order; the analysis is whole-program because user modules call
+/// Prelude functions. The returned map is owned by the caller (deinit
+/// with the same allocator).
+pub fn analyse(
+    alloc: std.mem.Allocator,
+    programs: []const CoreProgram,
+) std.mem.Allocator.Error!StrictnessMap {
+    // ── Collect functions: unique → (params, body) ──────────────────
+    var fns = std.AutoHashMapUnmanaged(u64, FnInfo){};
+    defer {
+        var it = fns.valueIterator();
+        while (it.next()) |info| alloc.free(info.params);
+        fns.deinit(alloc);
+    }
+    // Alias bindings (`(+) = primAddInt`): alias unique → target unique.
+    var aliases = std.AutoHashMapUnmanaged(u64, u64){};
+    defer aliases.deinit(alloc);
+
+    for (programs) |prog| {
+        for (prog.binds) |bind| {
+            switch (bind) {
+                .NonRec => |pair| try collectFn(alloc, &fns, &aliases, pair),
+                .Rec => |pairs| for (pairs) |pair| try collectFn(alloc, &fns, &aliases, pair),
+            }
+        }
+    }
+
+    // ── Fixpoint ────────────────────────────────────────────────────
+    var masks = StrictnessMap{};
+    errdefer masks.deinit(alloc);
+
+    // Most-strict start: all parameters strict.
+    var fn_it = fns.iterator();
+    while (fn_it.next()) |entry| {
+        const arity = entry.value_ptr.params.len;
+        const mask: u64 = if (arity >= 64) ~@as(u64, 0) else (@as(u64, 1) << @intCast(arity)) - 1;
+        try masks.put(alloc, entry.key_ptr.*, mask);
+    }
+
+    var changed = true;
+    while (changed) {
+        changed = false;
+        var it = fns.iterator();
+        while (it.next()) |entry| {
+            const info = entry.value_ptr.*;
+            var mask: u64 = 0;
+            for (info.params, 0..) |param, i| {
+                if (i >= 64) break;
+                if (demands(info.body, param, &fns, &aliases, &masks)) {
+                    mask |= @as(u64, 1) << @intCast(i);
+                }
+            }
+            const slot = masks.getPtr(entry.key_ptr.*).?;
+            if (slot.* != mask) {
+                slot.* = mask;
+                changed = true;
+            }
+        }
+    }
+
+    // Resolve aliases into the final map so callers can look up either
+    // name: strict((+)) = strict(primAddInt).
+    var alias_it = aliases.iterator();
+    while (alias_it.next()) |entry| {
+        var target = entry.value_ptr.*;
+        // Follow alias chains (bounded — cycles cannot demand anything).
+        var hops: u8 = 0;
+        while (aliases.get(target)) |next| : (hops += 1) {
+            if (hops > 8) break;
+            target = next;
+        }
+        if (masks.get(target)) |mask| {
+            try masks.put(alloc, entry.key_ptr.*, mask);
+        } else if (target < known.reserved_range_end) {
+            // Alias of a raw primop: strict in everything.
+            try masks.put(alloc, entry.key_ptr.*, ~@as(u64, 0));
+        }
+    }
+
+    return masks;
+}
+
+fn collectFn(
+    alloc: std.mem.Allocator,
+    fns: *std.AutoHashMapUnmanaged(u64, FnInfo),
+    aliases: *std.AutoHashMapUnmanaged(u64, u64),
+    pair: BindPair,
+) std.mem.Allocator.Error!void {
+    const unique = pair.binder.name.unique.value;
+    // Simple alias: `f = g`.
+    if (pair.rhs.* == .Var) {
+        try aliases.put(alloc, unique, pair.rhs.Var.name.unique.value);
+        return;
+    }
+    // Lambda chain: collect parameter uniques.
+    var params = std.ArrayListUnmanaged(u64).empty;
+    errdefer params.deinit(alloc);
+    var cur = pair.rhs;
+    while (cur.* == .Lam) : (cur = cur.Lam.body) {
+        try params.append(alloc, cur.Lam.binder.name.unique.value);
+    }
+    if (params.items.len == 0) {
+        params.deinit(alloc);
+        return; // CAF — nothing to analyse.
+    }
+    try fns.put(alloc, unique, .{
+        .params = try params.toOwnedSlice(alloc),
+        .body = cur,
+    });
+}
+
+/// Does evaluating `e` to WHNF force the variable `p`?
+fn demands(
+    e: *const Expr,
+    p: u64,
+    fns: *const std.AutoHashMapUnmanaged(u64, FnInfo),
+    aliases: *const std.AutoHashMapUnmanaged(u64, u64),
+    masks: *const StrictnessMap,
+) bool {
+    switch (e.*) {
+        .Var => |id| return id.name.unique.value == p,
+        .Lit, .Lam, .Type, .Coercion => return false,
+
+        .App => {
+            // Walk the application spine.
+            var n_args: usize = 0;
+            var cur = e;
+            while (cur.* == .App) : (n_args += 1) cur = cur.App.fn_expr;
+            if (cur.* != .Var) return false;
+            var head = cur.Var.name.unique.value;
+            // Evaluating the application evaluates the head.
+            if (head == p) return true;
+
+            // Resolve aliases to the defining function.
+            var hops: u8 = 0;
+            while (aliases.get(head)) |next| : (hops += 1) {
+                if (hops > 8) break;
+                head = next;
+            }
+
+            const strict_mask: u64 = blk: {
+                if (head < known.reserved_range_end or
+                    primop.PrimOp.fromString(cur.Var.name.base) != null)
+                {
+                    // Compiler primop: strict in all arguments.
+                    break :blk ~@as(u64, 0);
+                }
+                const info = fns.get(head) orelse return false;
+                // Unsaturated application builds a closure — WHNF, forces
+                // nothing. Oversaturated: the first `arity` args reach the
+                // function; be conservative and require exact saturation.
+                if (n_args != info.params.len) return false;
+                break :blk masks.get(head) orelse 0;
+            };
+
+            // ∃i. strict(f, i) ∧ demands(a_i, p)
+            var i = n_args;
+            cur = e;
+            while (cur.* == .App) : (cur = cur.App.fn_expr) {
+                i -= 1;
+                if (i < 64 and (strict_mask >> @intCast(i)) & 1 == 1) {
+                    if (demands(cur.App.arg, p, fns, aliases, masks)) return true;
+                }
+            }
+            return false;
+        },
+
+        .Case => |case_expr| {
+            if (demands(case_expr.scrutinee, p, fns, aliases, masks)) return true;
+            if (case_expr.alts.len == 0) return false;
+            for (case_expr.alts) |alt| {
+                if (!demands(alt.body, p, fns, aliases, masks)) return false;
+            }
+            return true;
+        },
+
+        .Let => |let| {
+            if (demands(let.body, p, fns, aliases, masks)) return true;
+            // If the body demands the bound variable, the RHS is forced.
+            switch (let.bind) {
+                .NonRec => |pair| {
+                    const x = pair.binder.name.unique.value;
+                    return demands(let.body, x, fns, aliases, masks) and
+                        demands(pair.rhs, p, fns, aliases, masks);
+                },
+                .Rec => return false, // conservative
+            }
+        },
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const SourceSpan = core.SourceSpan;
+const SourcePos = core.SourcePos;
+const Id = core.Id;
+
+fn testSpan() SourceSpan {
+    return SourceSpan.init(SourcePos.init(1, 1, 1), SourcePos.init(1, 1, 2));
+}
+
+fn testId(base: []const u8, unique: u64) Id {
+    return .{
+        .name = .{ .base = base, .unique = .{ .value = unique } },
+        .ty = .{ .TyCon = .{ .name = .{ .base = "Int", .unique = .{ .value = 0 } }, .args = &.{} } },
+        .span = testSpan(),
+    };
+}
+
+fn v(alloc: std.mem.Allocator, id: Id) !*const Expr {
+    const e = try alloc.create(Expr);
+    e.* = .{ .Var = id };
+    return e;
+}
+
+fn app(alloc: std.mem.Allocator, f: *const Expr, a: *const Expr) !*const Expr {
+    const e = try alloc.create(Expr);
+    e.* = .{ .App = .{ .fn_expr = f, .arg = a, .span = testSpan() } };
+    return e;
+}
+
+fn lam(alloc: std.mem.Allocator, binder: Id, body: *const Expr) !*const Expr {
+    const e = try alloc.create(Expr);
+    e.* = .{ .Lam = .{ .binder = binder, .body = body, .span = testSpan() } };
+    return e;
+}
+
+fn lit(alloc: std.mem.Allocator, n: i64) !*const Expr {
+    const e = try alloc.create(Expr);
+    e.* = .{ .Lit = .{ .val = .{ .Int = n }, .span = testSpan() } };
+    return e;
+}
+
+test "demand: fib-shaped recursion is strict in its parameter" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // lt (unique 10, builtin range), fib (unique 2000), n (unique 1).
+    // fib = \n -> case lt n 2 of { _ -> fib n }
+    const n = testId("n", 1);
+    const lt = testId("lt_Int", 10);
+    const fib = testId("fib", 2000);
+
+    const scrut = try app(alloc, try app(alloc, try v(alloc, lt), try v(alloc, n)), try lit(alloc, 2));
+    const alt_body = try app(alloc, try v(alloc, fib), try v(alloc, n));
+    const alts = try alloc.alloc(core.Alt, 1);
+    alts[0] = .{ .con = .{ .Default = {} }, .binders = &.{}, .body = alt_body };
+    const case_e = try alloc.create(Expr);
+    case_e.* = .{ .Case = .{
+        .scrutinee = scrut,
+        .binder = testId("s", 3),
+        .ty = .{ .TyVar = .{ .base = "t", .unique = .{ .value = 0 } } },
+        .alts = alts,
+        .span = testSpan(),
+    } };
+
+    const binds = try alloc.alloc(Bind, 1);
+    binds[0] = .{ .NonRec = .{ .binder = fib, .rhs = try lam(alloc, n, case_e) } };
+    const progs = [_]CoreProgram{.{ .data_decls = &.{}, .binds = binds }};
+
+    var masks = try analyse(testing.allocator, &progs);
+    defer masks.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u64, 1), masks.get(2000).?);
+}
+
+test "demand: accumulator threaded through recursive strict call is strict" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // sumTo = \acc -> \n -> case n of { 0 -> acc; _ -> sumTo (add acc n) (sub n 1) }
+    const acc = testId("acc", 1);
+    const n = testId("n", 2);
+    const add = testId("add_Int", 10);
+    const sub = testId("sub_Int", 11);
+    const sum_to = testId("sumTo", 2000);
+
+    const rec_call = try app(
+        alloc,
+        try app(
+            alloc,
+            try v(alloc, sum_to),
+            try app(alloc, try app(alloc, try v(alloc, add), try v(alloc, acc)), try v(alloc, n)),
+        ),
+        try app(alloc, try app(alloc, try v(alloc, sub), try v(alloc, n)), try lit(alloc, 1)),
+    );
+    const alts = try alloc.alloc(core.Alt, 2);
+    alts[0] = .{ .con = .{ .LitAlt = .{ .Int = 0 } }, .binders = &.{}, .body = try v(alloc, acc) };
+    alts[1] = .{ .con = .{ .Default = {} }, .binders = &.{}, .body = rec_call };
+    const case_e = try alloc.create(Expr);
+    case_e.* = .{ .Case = .{
+        .scrutinee = try v(alloc, n),
+        .binder = testId("s", 3),
+        .ty = .{ .TyVar = .{ .base = "t", .unique = .{ .value = 0 } } },
+        .alts = alts,
+        .span = testSpan(),
+    } };
+
+    const binds = try alloc.alloc(Bind, 1);
+    binds[0] = .{ .NonRec = .{
+        .binder = sum_to,
+        .rhs = try lam(alloc, acc, try lam(alloc, n, case_e)),
+    } };
+    const progs = [_]CoreProgram{.{ .data_decls = &.{}, .binds = binds }};
+
+    var masks = try analyse(testing.allocator, &progs);
+    defer masks.deinit(testing.allocator);
+
+    // Both acc (bit 0) and n (bit 1) strict.
+    try testing.expectEqual(@as(u64, 0b11), masks.get(2000).?);
+}
+
+test "demand: argument only used under a lambda is not strict" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // constFn = \x -> \y -> x   — strict in x (returned), lazy in y.
+    const x = testId("x", 1);
+    const y = testId("y", 2);
+    const const_fn = testId("constFn", 2000);
+
+    const binds = try alloc.alloc(Bind, 1);
+    binds[0] = .{ .NonRec = .{
+        .binder = const_fn,
+        .rhs = try lam(alloc, x, try lam(alloc, y, try v(alloc, x))),
+    } };
+    const progs = [_]CoreProgram{.{ .data_decls = &.{}, .binds = binds }};
+
+    var masks = try analyse(testing.allocator, &progs);
+    defer masks.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u64, 0b01), masks.get(2000).?);
+}
+
+test "demand: alias bindings inherit the target's strictness" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // primAdd = \a -> \b -> add_Int a b ;  (+) = primAdd
+    const a = testId("a", 1);
+    const b = testId("b", 2);
+    const add = testId("add_Int", 10);
+    const prim_add = testId("primAdd", 2000);
+    const plus = testId("+", 2001);
+
+    const body = try app(alloc, try app(alloc, try v(alloc, add), try v(alloc, a)), try v(alloc, b));
+    const binds = try alloc.alloc(Bind, 2);
+    binds[0] = .{ .NonRec = .{ .binder = prim_add, .rhs = try lam(alloc, a, try lam(alloc, b, body)) } };
+    binds[1] = .{ .NonRec = .{ .binder = plus, .rhs = try v(alloc, prim_add) } };
+    const progs = [_]CoreProgram{.{ .data_decls = &.{}, .binds = binds }};
+
+    var masks = try analyse(testing.allocator, &progs);
+    defer masks.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u64, 0b11), masks.get(2000).?);
+    try testing.expectEqual(@as(u64, 0b11), masks.get(2001).?);
+}

--- a/src/core/specialise.zig
+++ b/src/core/specialise.zig
@@ -1,0 +1,481 @@
+//! Dictionary specialisation — Core to Core transformation (#807).
+//!
+//! Eliminates class-method runtime dispatch when the dictionary is
+//! statically known. The desugarer's dictionary-passing translation
+//! (Wadler & Blott 1989) turns every class-method call into
+//!
+//!   (<) dict$Ord$Int x y      -- selector + dictionary + args
+//!
+//! where `(<)` is a selector that scrutinises the dictionary node and
+//! calls the function stored in the method's slot. For monomorphic call
+//! sites the dictionary is a top-level constant, so the dispatch can be
+//! resolved at compile time:
+//!
+//!   primLtInt x y             -- direct call to the instance method
+//!
+//! The pass runs whole-program (all modules at once) because user
+//! modules reference dictionaries defined in the Prelude.
+//!
+//! Algorithm:
+//! 1. Scan all top-level binds, collecting:
+//!    a. *Dictionaries*: binds whose RHS is a saturated application of a
+//!       `MkDict$<Class>` constructor — recording the field expressions.
+//!    b. *Selectors*: binds of the shape
+//!         \dict -> \x0 .. xn -> case dict of MkDict$C f0 .. fm -> fi x0 .. xn
+//!       recording the constructor unique and the method index `i`.
+//! 2. Rewrite every sub-expression `App (Var selector) (Var dict)` to the
+//!    dictionary's field expression at the method index, when that field
+//!    is itself a variable. The rewrite deliberately targets the partial
+//!    application node, so both saturated and partially-applied method
+//!    calls specialise.
+//!
+//! Polymorphic call sites (dictionary is a lambda-bound parameter) are
+//! left untouched — they still go through runtime dispatch.
+//!
+//! Reference: GHC's `GHC.Core.Opt.Specialise` (this pass is the
+//! monomorphic-dictionary subset).
+
+const std = @import("std");
+const core = @import("ast.zig");
+const Expr = core.Expr;
+const Bind = core.Bind;
+const BindPair = core.BindPair;
+const Id = core.Id;
+const Alt = core.Alt;
+const CoreProgram = core.CoreProgram;
+
+/// A class-method selector: scrutinises a `MkDict$C` node and returns
+/// the field at `method_index`.
+const SelectorInfo = struct {
+    /// Unique of the `MkDict$<Class>` constructor the selector matches on.
+    con_unique: u64,
+    /// Which dictionary field the selector projects.
+    method_index: usize,
+};
+
+/// A statically-known dictionary: a top-level `MkDict$C e0 .. en` value.
+const DictInfo = struct {
+    /// Unique of the `MkDict$<Class>` constructor at the application head.
+    con_unique: u64,
+    /// The field expressions, in application order.
+    fields: []const *const Expr,
+};
+
+/// Environment shared across all modules of the program.
+pub const SpecialiseEnv = struct {
+    /// selector binder unique → selector shape
+    selectors: std.AutoHashMapUnmanaged(u64, SelectorInfo) = .empty,
+    /// dictionary binder unique → dictionary fields
+    dicts: std.AutoHashMapUnmanaged(u64, DictInfo) = .empty,
+
+    pub fn deinit(self: *SpecialiseEnv, alloc: std.mem.Allocator) void {
+        self.selectors.deinit(alloc);
+        self.dicts.deinit(alloc);
+    }
+};
+
+/// Collect selectors and dictionaries from one module's top-level binds.
+/// Call once per module (in any order) before rewriting.
+pub fn collectEnv(
+    alloc: std.mem.Allocator,
+    env: *SpecialiseEnv,
+    prog: CoreProgram,
+) std.mem.Allocator.Error!void {
+    for (prog.binds) |bind| {
+        switch (bind) {
+            .NonRec => |pair| try collectPair(alloc, env, pair),
+            .Rec => |pairs| for (pairs) |pair| try collectPair(alloc, env, pair),
+        }
+    }
+}
+
+fn collectPair(
+    alloc: std.mem.Allocator,
+    env: *SpecialiseEnv,
+    pair: BindPair,
+) std.mem.Allocator.Error!void {
+    const unique = pair.binder.name.unique.value;
+    if (try detectDict(alloc, pair.rhs)) |dict| {
+        try env.dicts.put(alloc, unique, dict);
+    }
+    if (detectSelector(pair.rhs)) |sel| {
+        try env.selectors.put(alloc, unique, sel);
+    }
+}
+
+/// Is `MkDict$` the prefix of this variable's base name?
+fn isMkDictName(id: Id) bool {
+    return std.mem.startsWith(u8, id.name.base, "MkDict$");
+}
+
+/// Recognise `MkDict$C e0 .. en` application spines.
+fn detectDict(
+    alloc: std.mem.Allocator,
+    rhs: *const Expr,
+) std.mem.Allocator.Error!?DictInfo {
+    // Walk down the application spine, counting arguments.
+    var n_args: usize = 0;
+    var cur = rhs;
+    while (cur.* == .App) : (n_args += 1) cur = cur.App.fn_expr;
+    if (cur.* != .Var or !isMkDictName(cur.Var)) return null;
+    if (n_args == 0) return null;
+
+    const fields = try alloc.alloc(*const Expr, n_args);
+    var i = n_args;
+    cur = rhs;
+    while (cur.* == .App) : (cur = cur.App.fn_expr) {
+        i -= 1;
+        fields[i] = cur.App.arg;
+    }
+    return .{ .con_unique = cur.Var.name.unique.value, .fields = fields };
+}
+
+/// Recognise the selector shape the desugarer generates:
+///   \dict -> \x0 .. xn -> case dict of MkDict$C f0 .. fm -> fi x0 .. xn
+/// The argument lambdas and the application of `fi` are not validated
+/// beyond locating `fi` at the head — the desugarer is the only producer
+/// of this shape, and the head position is all the rewrite needs.
+fn detectSelector(rhs: *const Expr) ?SelectorInfo {
+    if (rhs.* != .Lam) return null;
+    const dict_binder = rhs.Lam.binder.name.unique.value;
+
+    // Skip the method-argument lambdas down to the case.
+    var body = rhs.Lam.body;
+    while (body.* == .Lam) body = body.Lam.body;
+    if (body.* != .Case) return null;
+    const case = body.Case;
+
+    // The scrutinee must be the dictionary parameter itself.
+    if (case.scrutinee.* != .Var) return null;
+    if (case.scrutinee.Var.name.unique.value != dict_binder) return null;
+
+    // Exactly one constructor alternative, on a MkDict$ constructor.
+    if (case.alts.len != 1) return null;
+    const alt = case.alts[0];
+    if (alt.con != .DataAlt) return null;
+    if (!std.mem.startsWith(u8, alt.con.DataAlt.base, "MkDict$")) return null;
+
+    // The alternative body's head variable must be one of the field
+    // binders; its position is the method index.
+    var head = alt.body;
+    while (head.* == .App) head = head.App.fn_expr;
+    if (head.* != .Var) return null;
+    const head_unique = head.Var.name.unique.value;
+    for (alt.binders, 0..) |field_binder, idx| {
+        if (field_binder.name.unique.value == head_unique) {
+            return .{
+                .con_unique = alt.con.DataAlt.unique.value,
+                .method_index = idx,
+            };
+        }
+    }
+    return null;
+}
+
+/// Rewrite one module's program. Returns a program whose binds share
+/// unchanged sub-trees with the input (everything is arena-allocated).
+pub fn specialiseProgram(
+    alloc: std.mem.Allocator,
+    env: *const SpecialiseEnv,
+    prog: CoreProgram,
+) std.mem.Allocator.Error!CoreProgram {
+    const new_binds = try alloc.alloc(Bind, prog.binds.len);
+    for (prog.binds, new_binds) |bind, *out| {
+        out.* = switch (bind) {
+            .NonRec => |pair| .{ .NonRec = .{
+                .binder = pair.binder,
+                .rhs = try rewrite(alloc, env, pair.rhs),
+            } },
+            .Rec => |pairs| blk: {
+                const new_pairs = try alloc.alloc(BindPair, pairs.len);
+                for (pairs, new_pairs) |pair, *np| {
+                    np.* = .{
+                        .binder = pair.binder,
+                        .rhs = try rewrite(alloc, env, pair.rhs),
+                    };
+                }
+                break :blk .{ .Rec = new_pairs };
+            },
+        };
+    }
+    return .{ .data_decls = prog.data_decls, .binds = new_binds };
+}
+
+fn rewrite(
+    alloc: std.mem.Allocator,
+    env: *const SpecialiseEnv,
+    expr: *const Expr,
+) std.mem.Allocator.Error!*const Expr {
+    switch (expr.*) {
+        .Var, .Lit, .Type, .Coercion => return expr,
+
+        .App => |app| {
+            // The rewrite: (Var selector) (Var dict) → dictionary field.
+            if (app.fn_expr.* == .Var and app.arg.* == .Var) {
+                if (env.selectors.get(app.fn_expr.Var.name.unique.value)) |sel| {
+                    if (env.dicts.get(app.arg.Var.name.unique.value)) |dict| {
+                        if (sel.con_unique == dict.con_unique and
+                            sel.method_index < dict.fields.len)
+                        {
+                            const field = dict.fields[sel.method_index];
+                            // Only substitute variables: duplicating a
+                            // larger expression per call site would trade
+                            // a dispatch for code growth and lost sharing.
+                            if (field.* == .Var) {
+                                const e = try alloc.create(Expr);
+                                e.* = .{ .Var = .{
+                                    .name = field.Var.name,
+                                    .ty = field.Var.ty,
+                                    .span = app.span,
+                                } };
+                                return e;
+                            }
+                        }
+                    }
+                }
+            }
+            const new_fn = try rewrite(alloc, env, app.fn_expr);
+            const new_arg = try rewrite(alloc, env, app.arg);
+            if (new_fn == app.fn_expr and new_arg == app.arg) return expr;
+            const e = try alloc.create(Expr);
+            e.* = .{ .App = .{ .fn_expr = new_fn, .arg = new_arg, .span = app.span } };
+            return e;
+        },
+
+        .Lam => |lam| {
+            const new_body = try rewrite(alloc, env, lam.body);
+            if (new_body == lam.body) return expr;
+            const e = try alloc.create(Expr);
+            e.* = .{ .Lam = .{ .binder = lam.binder, .body = new_body, .span = lam.span } };
+            return e;
+        },
+
+        .Let => |let| {
+            const new_bind: Bind = switch (let.bind) {
+                .NonRec => |pair| .{ .NonRec = .{
+                    .binder = pair.binder,
+                    .rhs = try rewrite(alloc, env, pair.rhs),
+                } },
+                .Rec => |pairs| blk: {
+                    const new_pairs = try alloc.alloc(BindPair, pairs.len);
+                    for (pairs, new_pairs) |pair, *np| {
+                        np.* = .{
+                            .binder = pair.binder,
+                            .rhs = try rewrite(alloc, env, pair.rhs),
+                        };
+                    }
+                    break :blk .{ .Rec = new_pairs };
+                },
+            };
+            const new_body = try rewrite(alloc, env, let.body);
+            const e = try alloc.create(Expr);
+            e.* = .{ .Let = .{ .bind = new_bind, .body = new_body, .span = let.span } };
+            return e;
+        },
+
+        .Case => |case| {
+            const new_scrut = try rewrite(alloc, env, case.scrutinee);
+            const new_alts = try alloc.alloc(Alt, case.alts.len);
+            var changed = new_scrut != case.scrutinee;
+            for (case.alts, new_alts) |alt, *na| {
+                const new_alt_body = try rewrite(alloc, env, alt.body);
+                changed = changed or new_alt_body != alt.body;
+                na.* = .{ .con = alt.con, .binders = alt.binders, .body = new_alt_body };
+            }
+            if (!changed) return expr;
+            const e = try alloc.create(Expr);
+            e.* = .{ .Case = .{
+                .scrutinee = new_scrut,
+                .binder = case.binder,
+                .ty = case.ty,
+                .alts = new_alts,
+                .span = case.span,
+            } };
+            return e;
+        },
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const SourceSpan = core.SourceSpan;
+const SourcePos = core.SourcePos;
+
+fn testSpan() SourceSpan {
+    return SourceSpan.init(SourcePos.init(1, 1, 1), SourcePos.init(1, 1, 2));
+}
+
+fn testId(base: []const u8, unique: u64) Id {
+    return .{
+        .name = .{ .base = base, .unique = .{ .value = unique } },
+        .ty = .{ .TyCon = .{ .name = .{ .base = "Int", .unique = .{ .value = 0 } }, .args = &.{} } },
+        .span = testSpan(),
+    };
+}
+
+fn varExpr(alloc: std.mem.Allocator, id: Id) !*const Expr {
+    const e = try alloc.create(Expr);
+    e.* = .{ .Var = id };
+    return e;
+}
+
+fn appExpr(alloc: std.mem.Allocator, f: *const Expr, a: *const Expr) !*const Expr {
+    const e = try alloc.create(Expr);
+    e.* = .{ .App = .{ .fn_expr = f, .arg = a, .span = testSpan() } };
+    return e;
+}
+
+/// Build the canonical test fixture:
+///   dict$Ord$Int (u=100) = MkDict$Ord (u=50) primLtInt (u=60)
+///   <  (u=200)           = \d -> \x -> \y -> case d of MkDict$Ord f0 -> f0 x y
+///   user (u=300)         = < dict$Ord$Int 1 2   (as nested Apps on vars)
+fn buildFixture(alloc: std.mem.Allocator) !struct {
+    prog: CoreProgram,
+    call_site: *const Expr,
+} {
+    const mkdict = testId("MkDict$Ord", 50);
+    const prim_lt = testId("primLtInt", 60);
+
+    // dict$Ord$Int = MkDict$Ord primLtInt
+    const dict_rhs = try appExpr(alloc, try varExpr(alloc, mkdict), try varExpr(alloc, prim_lt));
+
+    // selector: \d -> \x -> \y -> case d of MkDict$Ord f0 -> f0 x y
+    const d = testId("d", 1);
+    const x = testId("x", 2);
+    const y = testId("y", 3);
+    const f0 = testId("f0", 4);
+    const alt_body = try appExpr(
+        alloc,
+        try appExpr(alloc, try varExpr(alloc, f0), try varExpr(alloc, x)),
+        try varExpr(alloc, y),
+    );
+    const alts = try alloc.alloc(Alt, 1);
+    alts[0] = .{
+        .con = .{ .DataAlt = .{ .base = "MkDict$Ord", .unique = .{ .value = 50 } } },
+        .binders = try alloc.dupe(Id, &.{f0}),
+        .body = alt_body,
+    };
+    const case_expr = try alloc.create(Expr);
+    case_expr.* = .{ .Case = .{
+        .scrutinee = try varExpr(alloc, d),
+        .binder = d,
+        .ty = .{ .TyVar = .{ .base = "t", .unique = .{ .value = 0 } } },
+        .alts = alts,
+        .span = testSpan(),
+    } };
+    const lam_y = try alloc.create(Expr);
+    lam_y.* = .{ .Lam = .{ .binder = y, .body = case_expr, .span = testSpan() } };
+    const lam_x = try alloc.create(Expr);
+    lam_x.* = .{ .Lam = .{ .binder = x, .body = lam_y, .span = testSpan() } };
+    const sel_rhs = try alloc.create(Expr);
+    sel_rhs.* = .{ .Lam = .{ .binder = d, .body = lam_x, .span = testSpan() } };
+
+    // call site: ((< dict$Ord$Int) a) b
+    const a = testId("a", 5);
+    const b = testId("b", 6);
+    const call = try appExpr(
+        alloc,
+        try appExpr(
+            alloc,
+            try appExpr(alloc, try varExpr(alloc, testId("<", 200)), try varExpr(alloc, testId("dict$Ord$Int", 100))),
+            try varExpr(alloc, a),
+        ),
+        try varExpr(alloc, b),
+    );
+
+    const binds = try alloc.alloc(Bind, 3);
+    binds[0] = .{ .NonRec = .{ .binder = testId("dict$Ord$Int", 100), .rhs = dict_rhs } };
+    binds[1] = .{ .NonRec = .{ .binder = testId("<", 200), .rhs = sel_rhs } };
+    binds[2] = .{ .NonRec = .{ .binder = testId("user", 300), .rhs = call } };
+
+    return .{
+        .prog = .{ .data_decls = &.{}, .binds = binds },
+        .call_site = call,
+    };
+}
+
+test "specialise: monomorphic dict call rewrites to instance method" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const fixture = try buildFixture(alloc);
+
+    var env = SpecialiseEnv{};
+    try collectEnv(alloc, &env, fixture.prog);
+    defer env.deinit(alloc);
+
+    try testing.expect(env.selectors.contains(200));
+    try testing.expect(env.dicts.contains(100));
+    try testing.expectEqual(@as(usize, 0), env.selectors.get(200).?.method_index);
+
+    const out = try specialiseProgram(alloc, &env, fixture.prog);
+
+    // user = ((primLtInt a) b) — the selector+dict collapsed to primLtInt.
+    const user_rhs = out.binds[2].NonRec.rhs;
+    const inner = user_rhs.App.fn_expr.App.fn_expr;
+    try testing.expect(inner.* == .Var);
+    try testing.expectEqualStrings("primLtInt", inner.Var.name.base);
+    try testing.expectEqual(@as(u64, 60), inner.Var.name.unique.value);
+}
+
+test "specialise: polymorphic call site (lambda-bound dict) untouched" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const fixture = try buildFixture(alloc);
+
+    var env = SpecialiseEnv{};
+    try collectEnv(alloc, &env, fixture.prog);
+    defer env.deinit(alloc);
+
+    // poly = \d2 -> < d2 a b   — d2 is not a known dictionary.
+    const d2 = testId("d2", 700);
+    const call = try appExpr(
+        alloc,
+        try varExpr(alloc, testId("<", 200)),
+        try varExpr(alloc, d2),
+    );
+    const lam = try alloc.create(Expr);
+    lam.* = .{ .Lam = .{ .binder = d2, .body = call, .span = testSpan() } };
+
+    const binds = try alloc.alloc(Bind, 1);
+    binds[0] = .{ .NonRec = .{ .binder = testId("poly", 800), .rhs = lam } };
+    const poly_prog = CoreProgram{ .data_decls = &.{}, .binds = binds };
+
+    const out = try specialiseProgram(alloc, &env, poly_prog);
+    // Unchanged: the rewrite must not fire on a lambda-bound dictionary.
+    try testing.expectEqual(lam, out.binds[0].NonRec.rhs);
+}
+
+test "specialise: mismatched class constructor does not rewrite" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const fixture = try buildFixture(alloc);
+
+    var env = SpecialiseEnv{};
+    try collectEnv(alloc, &env, fixture.prog);
+    defer env.deinit(alloc);
+
+    // A dict built from a *different* constructor (MkDict$Num, u=51).
+    const other_con = testId("MkDict$Num", 51);
+    const other_dict_rhs = try appExpr(alloc, try varExpr(alloc, other_con), try varExpr(alloc, testId("primAddInt", 61)));
+    const binds = try alloc.alloc(Bind, 2);
+    binds[0] = .{ .NonRec = .{ .binder = testId("dict$Num$Int", 101), .rhs = other_dict_rhs } };
+    // bad = < dict$Num$Int   (selector of Ord applied to a Num dict)
+    const bad_call = try appExpr(
+        alloc,
+        try varExpr(alloc, testId("<", 200)),
+        try varExpr(alloc, testId("dict$Num$Int", 101)),
+    );
+    binds[1] = .{ .NonRec = .{ .binder = testId("bad", 900), .rhs = bad_call } };
+    const prog = CoreProgram{ .data_decls = &.{}, .binds = binds };
+
+    try collectEnv(alloc, &env, prog);
+    const out = try specialiseProgram(alloc, &env, prog);
+    try testing.expectEqual(bad_call, out.binds[1].NonRec.rhs);
+}

--- a/src/grin/translate.zig
+++ b/src/grin/translate.zig
@@ -141,6 +141,11 @@ const TranslateCtx = struct {
     // GRIN expression, and the LLVM backend's eval-loop-per-case construction
     // causes exponential blowup (see e2e_007_inductive_list).
     expr_cache: std.AutoHashMapUnmanaged(usize, *GrinExpr) = .{},
+    // Whole-program strict-parameter masks from the Core demand analysis
+    // (#802): function unique → bitmask (bit i = strict in param i).
+    // Strict arguments are passed eagerly instead of as F-tag thunks.
+    // Null when no analysis ran (REPL, debug commands) — all args lazy.
+    strict_params: ?*const std.AutoHashMapUnmanaged(u64, u64) = null,
 
     pub fn init(alloc: std.mem.Allocator) TranslateCtx {
         return .{
@@ -512,6 +517,7 @@ pub fn translateProgram(
     core_prog: CoreProgram,
     external_arities: ?*const std.AutoHashMapUnmanaged(u64, u32),
     external_con_map: ?*const std.AutoHashMapUnmanaged(u64, u32),
+    strict_params: ?*const std.AutoHashMapUnmanaged(u64, u64),
 ) !GrinProgram {
     // Build the arity map for partial/over-application handling.
     var arity_map = try buildArityMap(alloc, core_prog);
@@ -527,6 +533,7 @@ pub fn translateProgram(
 
     var ctx = TranslateCtx.init(alloc);
     defer ctx.deinit();
+    ctx.strict_params = strict_params;
 
     // Copy the arity map into the context.
     var iter = arity_map.iterator();
@@ -1375,13 +1382,39 @@ fn wrapWithLazyBindsForFunc(
         return try wrapWithPendingBinds(ctx, inner, pending_binds);
     }
 
+    // Strict-parameter mask of the callee (#802): a pending bind that
+    // feeds a strict argument position is kept eager — the callee would
+    // force it anyway, so no thunk is needed and semantics are unchanged.
+    // Only applies to saturated calls; an unsaturated application packs
+    // its arguments into a P-node whose demand is unknown here.
+    const callee_strict_mask: u64 = blk: {
+        if (inner.* != .App) break :blk 0;
+        const app = inner.App;
+        const sp = ctx.strict_params orelse break :blk 0;
+        const arity = ctx.getFunctionArity(app.name) orelse break :blk 0;
+        if (app.args.len != arity) break :blk 0;
+        break :blk sp.get(app.name.unique.value) orelse 0;
+    };
+
     var result = inner;
     var i: usize = pending_binds.len;
     while (i > 0) {
         i -= 1;
         const pb = pending_binds[i];
 
-        const lhs = switch (pb.complex_expr.*) {
+        // Eager when the bind feeds a strict argument position.
+        const feeds_strict_pos = callee_strict_mask != 0 and pos: {
+            const app = inner.App;
+            for (app.args, 0..) |arg, ai| {
+                if (ai >= 64) break;
+                if (arg == .Var and arg.Var.unique.value == pb.fresh_var.unique.value) {
+                    break :pos (callee_strict_mask >> @intCast(ai)) & 1 == 1;
+                }
+            }
+            break :pos false;
+        };
+
+        const lhs = if (feeds_strict_pos) pb.complex_expr else switch (pb.complex_expr.*) {
             .App => |app| b: {
                 // Only wrap as a lazy thunk if the function is a known
                 // top-level definition with correct arity. Higher-order
@@ -2361,7 +2394,7 @@ test "translateProgram: simple identity function" {
         .binds = &.{.{ .NonRec = bind_pair }},
     };
 
-    const grin_prog = try translateProgram(alloc, core_prog, null, null);
+    const grin_prog = try translateProgram(alloc, core_prog, null, null, null);
 
     // Should have one definition with one parameter.
     try testing.expectEqual(@as(usize, 1), grin_prog.defs.len);
@@ -2436,7 +2469,7 @@ test "translateProgram: literal value" {
         .binds = &.{.{ .NonRec = bind_pair }},
     };
 
-    const grin_prog = try translateProgram(alloc, core_prog, null, null);
+    const grin_prog = try translateProgram(alloc, core_prog, null, null, null);
 
     try testing.expectEqual(@as(usize, 1), grin_prog.defs.len);
 
@@ -2616,7 +2649,7 @@ test "translateProgram: partial application generates P-tag" {
         .binds = &[_]CoreBind{ .{ .NonRec = map_pair }, .{ .NonRec = main_pair } },
     };
 
-    const grin_prog = try translateProgram(alloc, core_prog, null, null);
+    const grin_prog = try translateProgram(alloc, core_prog, null, null, null);
 
     // Should have 2 definitions: map and main
     try testing.expectEqual(@as(usize, 2), grin_prog.defs.len);
@@ -2699,7 +2732,7 @@ test "translateProgram: over-application generates chained apply calls" {
         .binds = &[_]CoreBind{ .{ .NonRec = id_pair }, .{ .NonRec = main_pair } },
     };
 
-    const grin_prog = try translateProgram(alloc, core_prog, null, null);
+    const grin_prog = try translateProgram(alloc, core_prog, null, null, null);
 
     // Should have 2 definitions: id and main
     try testing.expectEqual(@as(usize, 2), grin_prog.defs.len);
@@ -2810,7 +2843,7 @@ test "translateApp: nested application f (g x) emits Bind for complex arg (#374)
         .binds = &.{.{ .NonRec = bind_pair }},
     };
 
-    const grin_prog = try translateProgram(alloc, core_prog, null, null);
+    const grin_prog = try translateProgram(alloc, core_prog, null, null, null);
 
     // Should have one definition with 3 parameters (f, g, x).
     try testing.expectEqual(@as(usize, 1), grin_prog.defs.len);
@@ -2898,7 +2931,7 @@ test "translateProgram: external 0-arity function produces App not Return Var" {
         .binds = &.{.{ .NonRec = bind_pair }},
     };
 
-    const grin_prog = try translateProgram(alloc, core_prog, &external_arities, null);
+    const grin_prog = try translateProgram(alloc, core_prog, &external_arities, null, null);
 
     try testing.expectEqual(@as(usize, 1), grin_prog.defs.len);
 
@@ -3019,7 +3052,7 @@ test "wrapWithLazyBindsForCon: Case arg lambda-lifted into thunk (#518)" {
         .binds = &.{.{ .NonRec = bind_pair }},
     };
 
-    const grin_prog = try translateProgram(alloc, core_prog, null, null);
+    const grin_prog = try translateProgram(alloc, core_prog, null, null, null);
 
     // Should have 2 defs: f and the lifted thunk helper.
     try testing.expectEqual(@as(usize, 2), grin_prog.defs.len);
@@ -3195,7 +3228,7 @@ test "translateExpr: multi-binding Rec let emits one Update per binder (#747)" {
         .binds = &[_]CoreBind{.{ .NonRec = main_pair }},
     };
 
-    const grin_prog = try translateProgram(alloc, core_prog, null, null);
+    const grin_prog = try translateProgram(alloc, core_prog, null, null, null);
     try testing.expectEqual(@as(usize, 1), grin_prog.defs.len);
 
     const main_body = grin_prog.defs[0].body;
@@ -3272,7 +3305,7 @@ test "translateExpr: Rec backpatch chain follows dependency order (#753)" {
         .binds = &[_]CoreBind{.{ .NonRec = main_pair }},
     };
 
-    const grin_prog = try translateProgram(alloc, core_prog, null, null);
+    const grin_prog = try translateProgram(alloc, core_prog, null, null, null);
     try testing.expectEqual(@as(usize, 1), grin_prog.defs.len);
 
     var ptrs: std.ArrayListUnmanaged(GrinName) = .empty;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1052,6 +1052,25 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
 
     const module_order = session_result.result.module_order;
 
+    // ── Whole-program dictionary specialisation (#807) ──────────────────
+    // Resolve class-method dispatch through statically-known dictionaries
+    // (e.g. `(<) dict$Ord$Int x y` → `primLtInt x y`) before lambda
+    // lifting. The environment spans all modules because user code
+    // references Prelude dictionaries.
+    {
+        const specialise = rusholme.core.specialise;
+        var spec_env = specialise.SpecialiseEnv{};
+        defer spec_env.deinit(arena_alloc);
+        for (module_order) |mod_name| {
+            const core_prog = session.programs.get(mod_name) orelse continue;
+            try specialise.collectEnv(arena_alloc, &spec_env, core_prog);
+        }
+        for (module_order) |mod_name| {
+            const prog_ptr = session.programs.getPtr(mod_name) orelse continue;
+            prog_ptr.* = try specialise.specialiseProgram(arena_alloc, &spec_env, prog_ptr.*);
+        }
+    }
+
     // ── Per-module lambda lift + GRIN translation ───────────────────────
     // Each Haskell module is lambda-lifted and GRIN-translated independently.
     // The per-module GRIN programs are collected for global tag table

--- a/src/main.zig
+++ b/src/main.zig
@@ -716,7 +716,7 @@ fn cmdGrin(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     }
 
     // ── Translate to GRIN ───────────────────────────────────────────────
-    const grin_prog = try rusholme.grin.translate.translateProgram(arena_alloc, core_lifted, null, null);
+    const grin_prog = try rusholme.grin.translate.translateProgram(arena_alloc, core_lifted, null, null, null);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
@@ -835,7 +835,7 @@ fn cmdLl(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
     }
 
     // ── Translate to GRIN ───────────────────────────────────────────────
-    const grin_prog = try rusholme.grin.translate.translateProgram(arena_alloc, core_lifted, null, null);
+    const grin_prog = try rusholme.grin.translate.translateProgram(arena_alloc, core_lifted, null, null, null);
     if (diags.hasErrors()) {
         try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
         std.process.exit(1);
@@ -1071,6 +1071,22 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
         }
     }
 
+    // ── Whole-program demand (strictness) analysis (#802) ───────────────
+    // Runs after specialisation so class-method calls are already direct
+    // calls to instance methods (better strictness). The resulting
+    // strict-parameter masks let GRIN translation pass strict arguments
+    // eagerly instead of allocating F-tag thunks.
+    const strict_params: ?*const std.AutoHashMapUnmanaged(u64, u64) = blk: {
+        var all_progs = std.ArrayListUnmanaged(rusholme.core.ast.CoreProgram).empty;
+        for (module_order) |mod_name| {
+            const core_prog = session.programs.get(mod_name) orelse continue;
+            try all_progs.append(arena_alloc, core_prog);
+        }
+        const masks = try arena_alloc.create(rusholme.core.demand.StrictnessMap);
+        masks.* = try rusholme.core.demand.analyse(arena_alloc, all_progs.items);
+        break :blk masks;
+    };
+
     // ── Per-module lambda lift + GRIN translation ───────────────────────
     // Each Haskell module is lambda-lifted and GRIN-translated independently.
     // The per-module GRIN programs are collected for global tag table
@@ -1121,7 +1137,7 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
         const core_prog = session.programs.get(mod_name) orelse continue;
         const lift_result = try rusholme.core.lift.lambdaLift(arena_alloc, core_prog, cross_module_scope, next_lift_id);
         next_lift_id = lift_result.next_lifted_id;
-        const grin_prog = try rusholme.grin.translate.translateProgram(arena_alloc, lift_result.program, &cross_module_arities, &cross_module_con_map);
+        const grin_prog = try rusholme.grin.translate.translateProgram(arena_alloc, lift_result.program, &cross_module_arities, &cross_module_con_map, strict_params);
         try per_module_grin.append(arena_alloc, grin_prog);
 
         // Accumulate this module's function arities for subsequent modules

--- a/src/repl/pipeline.zig
+++ b/src/repl/pipeline.zig
@@ -406,7 +406,7 @@ pub const Pipeline = struct {
         }
 
         // ── Translate to GRIN ──────────────────────────────────────
-        const grin_prog = translate_mod.translateProgram(alloc, lift_result.program, external_arities, external_con_map) catch {
+        const grin_prog = translate_mod.translateProgram(alloc, lift_result.program, external_arities, external_con_map, null) catch {
             module_types.deinit(alloc);
             return CompileError.OutOfMemory;
         };

--- a/src/root.zig
+++ b/src/root.zig
@@ -63,6 +63,7 @@ pub const core = struct {
     pub const lint = @import("core/lint.zig");
     pub const lift = @import("core/lift.zig");
     pub const specialise = @import("core/specialise.zig");
+    pub const demand = @import("core/demand.zig");
     pub const match_check = @import("core/match_check.zig");
 };
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -62,6 +62,7 @@ pub const core = struct {
     pub const desugar = @import("core/desugar.zig");
     pub const lint = @import("core/lint.zig");
     pub const lift = @import("core/lift.zig");
+    pub const specialise = @import("core/specialise.zig");
     pub const match_check = @import("core/match_check.zig");
 };
 

--- a/src/rts/heap.zig
+++ b/src/rts/heap.zig
@@ -117,7 +117,20 @@ pub const ArenaGc = struct {
     arena: std.heap.ArenaAllocator,
     stats_data: AllocStats,
 
+    /// Bump-chunk size for the inline-allocation fast path. Each chunk
+    /// is carved from the backing arena and then bump-allocated through
+    /// the shared `rts_immix_cursor`/`rts_immix_limit` globals, so the
+    /// LLVM inline-alloc fast path (#798) works under `--rts=arena` too.
+    /// Only one heap backend is active per process, so sharing the
+    /// globals with Immix is safe.
+    pub const BUMP_CHUNK: usize = 1 << 20;
+
     pub fn init(backing: std.mem.Allocator) ArenaGc {
+        // Reset the shared bump window: a previous heap instance (e.g.
+        // an earlier unit test) may have left the globals pointing into
+        // memory that died with its backing arena.
+        rts_immix_cursor = 0;
+        rts_immix_limit = 0;
         return .{
             .arena = std.heap.ArenaAllocator.init(backing),
             .stats_data = .{},
@@ -125,6 +138,9 @@ pub const ArenaGc = struct {
     }
 
     pub fn deinit(self: *ArenaGc) void {
+        // Invalidate the bump window — the chunks die with the arena.
+        rts_immix_cursor = 0;
+        rts_immix_limit = 0;
         self.arena.deinit();
     }
 
@@ -164,6 +180,22 @@ pub const ArenaGc = struct {
 
     fn allocImpl(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment) ?[*]u8 {
         const self: *ArenaGc = @ptrCast(@alignCast(ctx));
+        // Bump fast path through the shared cursor/limit globals —
+        // mirrors what LLVM-generated inline allocations do, so RTS-side
+        // and generated-code allocations interleave in the same chunk.
+        if (@intFromEnum(alignment) <= 3 and len <= BUMP_CHUNK) {
+            const padded = (len + 7) & ~@as(usize, 7);
+            if (rts_immix_cursor + padded > rts_immix_limit) {
+                // Refill: carve a fresh chunk from the backing arena.
+                const chunk = self.arena.allocator().rawAlloc(BUMP_CHUNK, .@"8", @returnAddress()) orelse return null;
+                rts_immix_cursor = @intFromPtr(chunk);
+                rts_immix_limit = @intFromPtr(chunk) + BUMP_CHUNK;
+            }
+            const p: [*]u8 = @ptrFromInt(rts_immix_cursor);
+            rts_immix_cursor += padded;
+            self.stats_data.bytes_allocated += padded;
+            return p;
+        }
         const raw = self.arena.allocator().rawAlloc(len, alignment, @returnAddress()) orelse return null;
         self.stats_data.bytes_allocated += len;
         return raw;
@@ -279,8 +311,12 @@ pub export var rts_shadow_top: u32 = 0;
 // `.limit`. Successful inline bumps write the new cursor back to the
 // mirror; `ImmixGc` reads the mirror the next time it touches its own
 // state (e.g. when scanning for the next hole). Under `--rts=arena`
-// they stay at zero — every allocation overflows the limit and the
-// slow path (the existing `rts_alloc` export) takes over transparently.
+// they stay at zero until the first allocation, which overflows the
+// limit and lets the slow path refill.
+//
+// Under `--rts=arena` the SAME globals serve as the bump window over
+// the arena's current chunk (see `ArenaGc.BUMP_CHUNK`) — only one heap
+// backend is active per process, so the two uses never overlap.
 pub export var rts_immix_cursor: usize = 0;
 pub export var rts_immix_limit: usize = 0;
 

--- a/tests/golden_test_runner.zig
+++ b/tests/golden_test_runner.zig
@@ -371,7 +371,7 @@ fn pipelineToGrin(allocator: std.mem.Allocator, source: []const u8) ![]const u8 
     const lift_result = try rusholme.core.lift.lambdaLift(arena_alloc, core_prog, null, 0);
 
     // ── Core → GRIN ──────────────────────────────────────────────────────
-    const grin_prog = try rusholme.grin.translate.translateProgram(arena_alloc, lift_result.program, null, null);
+    const grin_prog = try rusholme.grin.translate.translateProgram(arena_alloc, lift_result.program, null, null, null);
 
     // ── Pretty-print GRIN to a heap string ───────────────────────────────
     var out: std.Io.Writer.Allocating = .init(allocator);


### PR DESCRIPTION
Closes #807. Closes #802. Substantial progress on #800 and #804's goal (boundary-force elimination).

## Summary

The benchmaxxing batch: eliminate class-method runtime dispatch, stop
heap-allocating nullary constructors, cut force-call traffic to near
zero on hot paths, pass strict arguments eagerly via a Core demand
analysis, and inline both field access and arena bump allocation.

| Bench | rhc before | rhc after | ghc | gap before → after |
|---|---|---|---|---|
| build_list | 12.5 ms | **0.91 ms** | 1.32 ms | 9.5× → **0.69× (beats GHC)** |
| tree_sum | 39.6 ms | **2.44 ms** | 1.91 ms | 20× → **1.27×** |
| fib_rec | 2042 ms | **7.2 ms** | 5.21 ms | 347× → **1.38×** |
| sum_to | 26.4 ms | **1.91 ms** | 1.06 ms | 25× → **1.81×** |

(arena RTS; geometric-mean gap went from ~45× to ~1.2×)

## Changes

### Core: dictionary specialisation (#807) — `src/core/specialise.zig`
Whole-program pass between desugar and lambda-lift: rewrites
`App (Var selector) (Var dict)` to the instance method when the
dictionary is a statically-known top-level `MkDict$C …` value.
Saturated and partial method calls both specialise; polymorphic call
sites keep the dispatch. On fib, each call previously rebuilt the
5-field Ord dictionary twice and dispatched through it.

### Core: demand analysis (#802) — `src/core/demand.zig`
Whole-program 1-bit strictness (Mycroft fixpoint): primops strict in
all args (identified by canonical name), saturated calls propagate the
callee's mask, case joins scrutinee demand with the meet over
alternatives, `let x = y` aliases resolved (the pattern compiler
re-binds parameters per alternative), alias binds inherit masks.
Consumers:
- GRIN translation passes strict arguments **eagerly** — the `(+)`/`(-)`
  argument thunks in fib/sumTo vanish (fib's body: zero allocation).
- The LLVM backend forces strict parameters **once at function entry**
  and tracks them as WHNF (worker/wrapper-lite, boxed ABI unchanged).

### Backend: forces that fold away (#800)
- Nullary constructors are tagged immediates (`(disc<<1)|1`) — no heap
  node per comparison result.
- Case sites drop the per-site inline eval loop (which duplicated the
  whole F/P-tag switch at every case) in favour of the shared
  `__rhc_force` + a compact immediate-vs-heap tag dispatch.
- `__rhc_force` gains a **saturated-only** P-tag arm (under-saturated
  closures are WHNF; calling them crashed e2e_386/REPL in an interim
  version — fixed with the `missing == 0` check).
- Statically-WHNF SSA values (primop results, fresh Con stores,
  immediates, direct-call results) skip case-site, operand, return-site
  and def-epilogue forces.
- `callForceIfNeeded` routes through a module-internal always-inline
  `__rhc_force_fast` guard: immediates fold away at compile time or
  cost two bit tests at runtime; only real heap nodes call the exported
  `__rhc_force` (whose symbol the REPL/ORC JIT still resolves).

### Backend/RTS: allocation + field access inlined
- `rts_load_field`/`rts_store_field` are emitted as module-internal
  always-inline GEP bodies — every field read/write folds to one
  load/store (the RTS exports remain for Zig-side callers).
- The **arena** backend now bump-allocates 1 MiB chunks through the
  same `rts_immix_cursor`/`rts_immix_limit` globals Immix exposes, so
  the #798 inline-alloc fast path works for both backends (the arena
  variant skips Immix line marks). `ArenaGc.init/deinit` reset the
  window so successive heaps in one process never bump into a dead
  chunk. REPL keeps the call path (ORC JIT cannot resolve the globals).

## Testing
- `zig build test --summary all` — 1204/1204 green.
- `bench-all.sh` diff-checks rhc/immix/GHC stdout before timing.
- New unit tests in specialise.zig and demand.zig (fib-shaped
  recursion, accumulator threading, lazy-under-lambda, alias
  inheritance, polymorphic/mismatch non-rewrites).

## Known follow-ups
- Immix path regressed relative to arena (fib 313 ms): shadow-stack +
  inline-alloc interaction needs its own pass — tracked under #790/#779.
- sum_to (1.8×): self tail-calls (#799).
- #804 (always-inline primop wrappers at GRIN level) attempted and
  reverted: rewriting call heads to primop names breaks F-thunk
  creation and lambda-lifting invariants; the force fast guard gets
  most of the same win without the rewrite.
