### PR TITLE
Immix regression fixes + #803 worker/wrapper — fib and build_list now beat GHC -O2

### DIFF
--- a/bench/results.json
+++ b/bench/results.json
@@ -352,6 +352,51 @@
           "ghc_stddev_ms": 0.21733776476237346
         }
       }
+    },
+    {
+      "commit": "2f2fe8a19002702e2bae6bb97aca51b96ac07dac",
+      "date": "2026-06-11T13:22:31Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "build_list": {
+          "rhc_mean_ms": 0.8714417142857143,
+          "rhc_stddev_ms": 0.058882332584328116,
+          "rhc_immix_mean_ms": 1.0795384285714287,
+          "rhc_immix_stddev_ms": 0.0784174313484299,
+          "ghc_mean_ms": 1.092233142857143,
+          "ghc_stddev_ms": 0.0749649032713055
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 6.371779285714287,
+          "rhc_stddev_ms": 1.0457145138045907,
+          "rhc_immix_mean_ms": 17.52371928571429,
+          "rhc_immix_stddev_ms": 4.487780938384534,
+          "ghc_mean_ms": 4.8381237142857145,
+          "ghc_stddev_ms": 0.2585694667838891
+        },
+        "sum_to": {
+          "rhc_mean_ms": 1.703645857142857,
+          "rhc_stddev_ms": 0.17219909227734875,
+          "rhc_immix_mean_ms": 5.713126285714285,
+          "rhc_immix_stddev_ms": 0.21097029041606344,
+          "ghc_mean_ms": 1.0133292857142857,
+          "ghc_stddev_ms": 0.1479380128507818
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 2.1800332857142855,
+          "rhc_stddev_ms": 0.17903268125095134,
+          "rhc_immix_mean_ms": 3.0528061428571425,
+          "rhc_immix_stddev_ms": 0.5066967113936529,
+          "ghc_mean_ms": 1.6631738571428574,
+          "ghc_stddev_ms": 0.07742578814242833
+        }
+      }
     }
   ]
 }

--- a/bench/results.json
+++ b/bench/results.json
@@ -397,6 +397,51 @@
           "ghc_stddev_ms": 0.07742578814242833
         }
       }
+    },
+    {
+      "commit": "f02cf36fa450f693914a28d859d7b64d5efb0d15",
+      "date": "2026-06-11T13:35:36Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "build_list": {
+          "rhc_mean_ms": 0.8198654285714286,
+          "rhc_stddev_ms": 0.05364649908073265,
+          "rhc_immix_mean_ms": 1.0730631428571429,
+          "rhc_immix_stddev_ms": 0.08268631401755384,
+          "ghc_mean_ms": 1.1054701428571432,
+          "ghc_stddev_ms": 0.1111367260141438
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 5.457320428571429,
+          "rhc_stddev_ms": 1.0883439817431892,
+          "rhc_immix_mean_ms": 7.848588,
+          "rhc_immix_stddev_ms": 1.032910910532462,
+          "ghc_mean_ms": 5.570237285714286,
+          "ghc_stddev_ms": 0.9978908726082749
+        },
+        "sum_to": {
+          "rhc_mean_ms": 0.9829644285714284,
+          "rhc_stddev_ms": 0.1490471917077017,
+          "rhc_immix_mean_ms": 1.6210378571428572,
+          "rhc_immix_stddev_ms": 0.20312460861782075,
+          "ghc_mean_ms": 0.8407235714285716,
+          "ghc_stddev_ms": 0.04261495392800176
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 2.3061148571428576,
+          "rhc_stddev_ms": 0.1642005303030704,
+          "rhc_immix_mean_ms": 3.2133981428571428,
+          "rhc_immix_stddev_ms": 0.2632972642834385,
+          "ghc_mean_ms": 2.0119331428571434,
+          "ghc_stddev_ms": 0.18143663889948713
+        }
+      }
     }
   ]
 }

--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -42,6 +42,7 @@
 const std = @import("std");
 
 const grin = @import("../grin/ast.zig");
+const core_demand = @import("../core/demand.zig");
 const rts_node = @import("../rts/node.zig");
 
 const llvm = @import("llvm.zig");
@@ -653,7 +654,7 @@ pub const GrinTranslator = struct {
     /// keyed by function unique. Strict parameters are forced once at
     /// function entry and tracked as WHNF, eliding every per-use force
     /// in the body. Null when no analysis ran (REPL, debug commands).
-    strict_params: ?*const std.AutoHashMapUnmanaged(u64, u64) = null,
+    strict_params: ?*const core_demand.StrictnessMap = null,
     /// Per-function cache for translated GRIN Case expressions.  The
     /// sequential pattern-match desugarer creates shared fallback nodes
     /// (a DAG) that would be re-translated exponentially without caching.
@@ -1300,6 +1301,39 @@ pub const GrinTranslator = struct {
             return error.OutOfMemory;
     }
 
+    /// The unbox mask for a worker/wrapper split (#803) of the named
+    /// function, or 0 when no worker applies. Conditions kept in sync
+    /// between the def site (translateDef) and call sites
+    /// (translateAppToValue): demand analysis ran, the function has
+    /// 1..8 parameters, and at least one strict parameter has an
+    /// immediate-representation type (Int/Char).
+    fn workerUnboxMask(self: *const GrinTranslator, fn_unique: u64, arity: usize) u64 {
+        if (arity == 0 or arity > 8) return 0;
+        const sp = self.strict_params orelse return 0;
+        const dm = sp.get(fn_unique) orelse return 0;
+        const arity_bits: u64 = (@as(u64, 1) << @intCast(arity)) - 1;
+        return dm.unbox & arity_bits;
+    }
+
+    /// Symbol name of the unboxed worker for `name`: `"w$" ++ base_unique`.
+    /// Written into `buf`; the caller owns the storage.
+    fn workerSymbol(self: *GrinTranslator, name: grin.Name, buf: []u8) [:0]const u8 {
+        const inner = self.formatName(name);
+        const written = std.fmt.bufPrintZ(buf, "w${s}", .{inner}) catch return "w$overflow";
+        return written;
+    }
+
+    /// LLVM function type of a worker: raw i64 at unboxed positions,
+    /// ptr elsewhere; always returns ptr.
+    fn workerFnType(unbox_mask: u64, arity: usize) llvm.Type {
+        var param_types: [8]llvm.Type = undefined;
+        for (0..arity) |i| {
+            const unboxed = (unbox_mask >> @as(u6, @intCast(i))) & 1 == 1;
+            param_types[i] = if (unboxed) llvm.i64Type() else ptrType();
+        }
+        return llvm.functionType(ptrType(), param_types[0..arity], false);
+    }
+
     fn translateDef(self: *GrinTranslator, def: grin.Def) TranslationError!void {
         // Entry-point functions ("main" or REPL entry points like "repl_expr_0")
         // use a specific return type: native `main` returns i32 (C ABI),
@@ -1334,8 +1368,54 @@ pub const GrinTranslator = struct {
         const existing_fn = c.LLVMGetNamedFunction(self.module, fn_name_z);
         const func = existing_fn orelse
             llvm.addFunction(self.module, fn_name_z, fn_type);
-        self.current_func = func;
-        const entry_bb = llvm.appendBasicBlock(func, "entry");
+
+        // ── Worker/wrapper split (#803) ───────────────────────────────
+        // When the demand analysis proved some Int/Char parameters
+        // strict, the function body is emitted into a worker `w$f` that
+        // takes those parameters as raw i64 machine words. The original
+        // symbol becomes a thin wrapper (force + untag + call worker) so
+        // every boxed entry path — thunk forcing, partial application,
+        // higher-order use — keeps working unchanged. Saturated direct
+        // calls go straight to the worker (translateAppToValue).
+        const unbox_mask = if (is_entry) 0 else self.workerUnboxMask(def.name.unique.value, def.params.len);
+        const body_func = if (unbox_mask == 0) func else blk: {
+            var wsym_buf: [300]u8 = undefined;
+            const wsym = self.workerSymbol(def.name, &wsym_buf);
+            const w_type = workerFnType(unbox_mask, def.params.len);
+            const worker = c.LLVMGetNamedFunction(self.module, wsym.ptr) orelse
+                llvm.addFunction(self.module, wsym, w_type);
+
+            // Wrapper body: force + untag the unboxed positions, call
+            // the worker, return its result. Allocates nothing itself,
+            // and the worker roots its own pointer parameters, so no
+            // shadow-stack bracketing is needed here.
+            self.current_func = func;
+            const wrap_entry = llvm.appendBasicBlock(func, "entry");
+            llvm.positionBuilderAtEnd(self.builder, wrap_entry);
+            var call_args: [8]llvm.Value = undefined;
+            for (0..def.params.len) |i| {
+                const p = c.LLVMGetParam(func, @intCast(i));
+                if ((unbox_mask >> @as(u6, @intCast(i))) & 1 == 1) {
+                    const forced = self.callForceIfNeeded(p);
+                    call_args[i] = untagInt(self.builder, forced);
+                } else {
+                    call_args[i] = p;
+                }
+            }
+            const r = c.LLVMBuildCall2(
+                self.builder,
+                w_type,
+                worker,
+                @ptrCast(&call_args),
+                @intCast(def.params.len),
+                "worker.result",
+            );
+            _ = llvm.buildRet(self.builder, r);
+            break :blk worker;
+        };
+
+        self.current_func = body_func;
+        const entry_bb = llvm.appendBasicBlock(body_func, "entry");
         llvm.positionBuilderAtEnd(self.builder, entry_bb);
 
         // For native `main`, if the user selected a non-default RTS
@@ -1376,15 +1456,19 @@ pub const GrinTranslator = struct {
         // the body (a worker/wrapper-lite that keeps the boxed ABI).
         const entry_strict_mask: u64 = blk: {
             const sp = self.strict_params orelse break :blk 0;
-            break :blk sp.get(def.name.unique.value) orelse 0;
+            break :blk if (sp.get(def.name.unique.value)) |dm| dm.strict else 0;
         };
         for (def.params, 0..) |param_name, i| {
-            var param_val = c.LLVMGetParam(func, @intCast(i));
+            var param_val = c.LLVMGetParam(body_func, @intCast(i));
             if (param_val == null) return error.OutOfMemory;
             if (i < 64 and (entry_strict_mask >> @intCast(i)) & 1 == 1 and
                 c.LLVMGetTypeKind(c.LLVMTypeOf(param_val)) == c.LLVMPointerTypeKind)
             {
                 param_val = self.callForceIfNeeded(param_val);
+            }
+            if (i < 64 and (entry_strict_mask >> @intCast(i)) & 1 == 1) {
+                // Strict parameter: forced above (ptr) or a raw machine
+                // word (worker i64) — either way WHNF from here on.
                 self.whnf_vars.put(param_name.unique.value, {}) catch return error.OutOfMemory;
             }
             try self.bindAndRoot(param_name.unique.value, param_val);
@@ -1820,6 +1904,53 @@ pub const GrinTranslator = struct {
         const arg_count = @min(args.len, 8);
         for (args[0..arg_count], 0..) |val, i| {
             llvm_args[i] = try self.translateValToLlvm(val);
+        }
+
+        // ── Worker fast path (#803) ──────────────────────────────────
+        // Saturated direct call to a function with unboxable strict
+        // parameters: call the `w$` worker, passing raw i64 at unboxed
+        // positions. Boxed pointer arguments are forced (elided when
+        // statically WHNF) and untagged; raw i64 arguments (literals)
+        // pass through. Higher-order and unsaturated uses fall through
+        // to the wrapper, which preserves the boxed ABI.
+        if (self.params.get(name.unique.value) == null and !self.isEntryPoint(name.base)) {
+            const saturated = if (self.arity_map) |am|
+                (if (am.get(name.unique.value)) |arity| arity == args.len else false)
+            else
+                false;
+            if (saturated) {
+                const unbox_mask = self.workerUnboxMask(name.unique.value, args.len);
+                if (unbox_mask != 0) {
+                    var wsym_buf: [300]u8 = undefined;
+                    const wsym = self.workerSymbol(name, &wsym_buf);
+                    const w_type = workerFnType(unbox_mask, args.len);
+                    const worker = c.LLVMGetNamedFunction(self.module, wsym.ptr) orelse
+                        llvm.addFunction(self.module, wsym, w_type);
+                    var w_args: [8]llvm.Value = undefined;
+                    for (0..arg_count) |i| {
+                        const raw = llvm_args[i];
+                        const is_ptr_arg = c.LLVMGetTypeKind(c.LLVMTypeOf(raw)) == c.LLVMPointerTypeKind;
+                        if ((unbox_mask >> @as(u6, @intCast(i))) & 1 == 1) {
+                            w_args[i] = if (is_ptr_arg)
+                                untagInt(self.builder, self.forceOperandIfNeeded(raw, args[i]))
+                            else
+                                raw; // already a raw machine word (literal)
+                        } else {
+                            // Mirror the regular coercion: raw integers
+                            // become tagged immediates for ptr params.
+                            w_args[i] = if (is_ptr_arg) raw else tagInt(self.builder, raw);
+                        }
+                    }
+                    return c.LLVMBuildCall2(
+                        self.builder,
+                        w_type,
+                        worker,
+                        @ptrCast(&w_args),
+                        @intCast(arg_count),
+                        nullTerminate(result_name).ptr,
+                    );
+                }
+            }
         }
 
         // Detect calls to `main` from the REPL entry point.

--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -531,29 +531,6 @@ fn declareRtsShadowTop(module: llvm.Module) llvm.Value {
     return g;
 }
 
-/// Declare `rts_shadow_save() -> i32`. Called once at the entry of any
-/// function that produces `*Node` SSA values; the returned value names
-/// the shadow-stack height that the matching `rts_shadow_restore` must
-/// restore before every return.
-fn declareRtsShadowSave(module: llvm.Module) llvm.Value {
-    const name = "rts_shadow_save";
-    if (c.LLVMGetNamedFunction(module, name)) |existing| return existing;
-    const fn_ty = c.LLVMFunctionType(llvm.i32Type(), null, 0, 0);
-    return c.LLVMAddFunction(module, name, fn_ty);
-}
-
-/// Declare `rts_shadow_restore(saved: i32) -> void`. Called immediately
-/// before each return in a function that participates in precise root
-/// tracking; pops every shadow-stack slot pushed since the matching
-/// `rts_shadow_save`.
-fn declareRtsShadowRestore(module: llvm.Module) llvm.Value {
-    const name = "rts_shadow_restore";
-    if (c.LLVMGetNamedFunction(module, name)) |existing| return existing;
-    var params = [_]llvm.Type{llvm.i32Type()};
-    const fn_ty = c.LLVMFunctionType(llvm.voidType(), &params, 1, 0);
-    return c.LLVMAddFunction(module, name, fn_ty);
-}
-
 /// Declare `rts_set_pointer_mask(tag: i64, mask: i64) -> void`.
 /// Called once per user-defined constructor at program start to
 /// register the constructor's pointer-mask with the collector (#779).
@@ -852,15 +829,13 @@ pub const GrinTranslator = struct {
     /// same function — `buildRetWithShadowRestore` handles that.
     fn enableShadowStackForCurrentFunction(self: *GrinTranslator) void {
         if (self.rts_backend == .arena) return;
-        const save_fn = declareRtsShadowSave(self.module);
-        const saved = c.LLVMBuildCall2(
-            self.builder,
-            llvm.getFunctionType(save_fn),
-            save_fn,
-            null,
-            0,
-            "shadow.saved",
-        );
+        // Inline `rts_shadow_save()`: a single load of the top counter.
+        // The save/restore pair brackets every GRIN function; emitting
+        // them as calls cost ~2 calls per function invocation (and 2 per
+        // *inlined wrapper* after LLVM inlining) — the dominant Immix
+        // overhead on call-heavy benches.
+        const top_var = declareRtsShadowTop(self.module);
+        const saved = c.LLVMBuildLoad2(self.builder, llvm.i32Type(), top_var, "shadow.saved");
         self.shadow_saved_top = saved;
         self.shadow_emit_enabled = true;
     }
@@ -918,6 +893,26 @@ pub const GrinTranslator = struct {
     /// shadow-stack push if precise root tracking is active. Replaces
     /// the bare `self.params.put(uid, value)` pattern at every site
     /// where a GRIN-named SSA is introduced.
+    /// Whether a GRIN expression's result is statically a *tagged
+    /// immediate* (never a heap pointer): primop instruction results,
+    /// Int/Char literals, nullary constructors. Such values need no
+    /// shadow-stack root — the collector skips bit-0 values anyway.
+    /// Strictly stronger than exprYieldsWhnf (a fresh Con store is WHNF
+    /// but lives on the heap and must be rooted).
+    fn exprYieldsImmediate(self: *const GrinTranslator, expr: *const grin.Expr) bool {
+        return switch (expr.*) {
+            .Return => |v| switch (v) {
+                .ValTag => true,
+                .Lit => |lit| lit == .Int or lit == .Char or lit == .Bool,
+                else => false,
+            },
+            .App => |app| if (PrimOpMapping.lookup(app.name)) |m| m == .instruction else false,
+            .Block => |inner| self.exprYieldsImmediate(inner),
+            .Bind => |b| self.exprYieldsImmediate(b.rhs),
+            else => false,
+        };
+    }
+
     fn bindAndRoot(self: *GrinTranslator, uid: u64, value: llvm.Value) !void {
         try self.params.put(uid, value);
         self.rootPtr(value);
@@ -945,16 +940,12 @@ pub const GrinTranslator = struct {
     fn emitShadowRestoreIfActive(self: *GrinTranslator) void {
         if (!self.shadow_emit_enabled) return;
         const saved = self.shadow_saved_top orelse return;
-        const restore_fn = declareRtsShadowRestore(self.module);
-        var args = [_]llvm.Value{saved};
-        _ = c.LLVMBuildCall2(
-            self.builder,
-            llvm.getFunctionType(restore_fn),
-            restore_fn,
-            &args,
-            1,
-            "",
-        );
+        // Inline `rts_shadow_restore(saved)`: a single store of the top
+        // counter. Slots above `top` are never read by the collector
+        // (it scans `rts_shadow_buffer[0..top]`), so no zeroing is
+        // needed — popping is just lowering the counter.
+        const top_var = declareRtsShadowTop(self.module);
+        _ = c.LLVMBuildStore(self.builder, saved, top_var);
     }
 
     fn buildUnitNode(self: *GrinTranslator) llvm.Value {
@@ -1612,7 +1603,12 @@ pub const GrinTranslator = struct {
                 // which calls translateCaseToValue to generate phi nodes.
                 const result = try self.translateExprToValue(lhs, v.base);
                 if (result) |val| {
-                    try self.bindAndRoot(v.unique.value, val);
+                    if (self.exprYieldsImmediate(lhs)) {
+                        // Tagged immediate — no heap pointer, no root.
+                        try self.params.put(v.unique.value, val);
+                    } else {
+                        try self.bindAndRoot(v.unique.value, val);
+                    }
                     if (self.exprYieldsWhnf(lhs)) {
                         self.whnf_vars.put(v.unique.value, {}) catch return error.OutOfMemory;
                     }
@@ -1675,7 +1671,12 @@ pub const GrinTranslator = struct {
                 switch (b.pat) {
                     .Var => |v| {
                         if (inner_result) |val| {
-                            try self.bindAndRoot(v.unique.value, val);
+                            if (self.exprYieldsImmediate(b.lhs)) {
+                                // Tagged immediate — no heap pointer, no root.
+                                try self.params.put(v.unique.value, val);
+                            } else {
+                                try self.bindAndRoot(v.unique.value, val);
+                            }
                             if (self.exprYieldsWhnf(b.lhs)) {
                                 self.whnf_vars.put(v.unique.value, {}) catch return error.OutOfMemory;
                             }

--- a/src/core/demand.zig
+++ b/src/core/demand.zig
@@ -48,15 +48,37 @@ const Bind = core.Bind;
 const BindPair = core.BindPair;
 const CoreProgram = core.CoreProgram;
 
-/// Strict-parameter masks, keyed by function binder unique. Bit i set =
-/// strict in parameter i. Functions with more than 64 parameters are
-/// not analysed (no such function survives the desugarer in practice).
-pub const StrictnessMap = std.AutoHashMapUnmanaged(u64, u64);
+/// Per-function demand result. Bit i of `strict` = parameter i is
+/// strict (always forced when the call is evaluated to WHNF). Bit i of
+/// `unbox` = strict AND the parameter's Core type is Int or Char — its
+/// runtime representation is a tagged immediate, so a worker/wrapper
+/// split (#803) can pass it as a raw machine word. `unbox` is always a
+/// subset of `strict`. Functions with more than 64 parameters are not
+/// analysed (no such function survives the desugarer in practice).
+pub const FnDemand = struct {
+    strict: u64 = 0,
+    unbox: u64 = 0,
+};
+
+/// Demand masks keyed by function binder unique.
+pub const StrictnessMap = std.AutoHashMapUnmanaged(u64, FnDemand);
 
 const FnInfo = struct {
     params: []const u64,
+    /// Bit i set = parameter i has an immediate-representation type
+    /// (Int/Char) and is therefore a worker-unboxing candidate.
+    imm_typed: u64,
     body: *const Expr,
 };
+
+/// Is this Core type represented as a tagged immediate at runtime?
+fn isImmediateType(ty: core.CoreType) bool {
+    return switch (ty) {
+        .TyCon => |tc| std.mem.eql(u8, tc.name.base, "Int") or
+            std.mem.eql(u8, tc.name.base, "Char"),
+        else => false,
+    };
+}
 
 /// Analyse all modules of a program. `programs` is the per-module Core
 /// in any order; the analysis is whole-program because user modules call
@@ -95,7 +117,10 @@ pub fn analyse(
     while (fn_it.next()) |entry| {
         const arity = entry.value_ptr.params.len;
         const mask: u64 = if (arity >= 64) ~@as(u64, 0) else (@as(u64, 1) << @intCast(arity)) - 1;
-        try masks.put(alloc, entry.key_ptr.*, mask);
+        try masks.put(alloc, entry.key_ptr.*, .{
+            .strict = mask,
+            .unbox = mask & entry.value_ptr.imm_typed,
+        });
     }
 
     var changed = true;
@@ -112,8 +137,8 @@ pub fn analyse(
                 }
             }
             const slot = masks.getPtr(entry.key_ptr.*).?;
-            if (slot.* != mask) {
-                slot.* = mask;
+            if (slot.strict != mask) {
+                slot.* = .{ .strict = mask, .unbox = mask & info.imm_typed };
                 changed = true;
             }
         }
@@ -130,11 +155,12 @@ pub fn analyse(
             if (hops > 8) break;
             target = next;
         }
-        if (masks.get(target)) |mask| {
-            try masks.put(alloc, entry.key_ptr.*, mask);
+        if (masks.get(target)) |dm| {
+            try masks.put(alloc, entry.key_ptr.*, dm);
         } else if (target < known.reserved_range_end) {
-            // Alias of a raw primop: strict in everything.
-            try masks.put(alloc, entry.key_ptr.*, ~@as(u64, 0));
+            // Alias of a raw primop: strict in everything. No unbox
+            // mask — primop calls inline anyway, no worker exists.
+            try masks.put(alloc, entry.key_ptr.*, .{ .strict = ~@as(u64, 0) });
         }
     }
 
@@ -153,12 +179,20 @@ fn collectFn(
         try aliases.put(alloc, unique, pair.rhs.Var.name.unique.value);
         return;
     }
-    // Lambda chain: collect parameter uniques.
+    // Lambda chain: collect parameter uniques and their type shapes.
     var params = std.ArrayListUnmanaged(u64).empty;
     errdefer params.deinit(alloc);
+    var imm_typed: u64 = 0;
     var cur = pair.rhs;
-    while (cur.* == .Lam) : (cur = cur.Lam.body) {
+    var idx: usize = 0;
+    while (cur.* == .Lam) : ({
+        cur = cur.Lam.body;
+        idx += 1;
+    }) {
         try params.append(alloc, cur.Lam.binder.name.unique.value);
+        if (idx < 64 and isImmediateType(cur.Lam.binder.ty)) {
+            imm_typed |= @as(u64, 1) << @intCast(idx);
+        }
     }
     if (params.items.len == 0) {
         params.deinit(alloc);
@@ -167,6 +201,7 @@ fn collectFn(
     try collectVarAliases(alloc, cur, aliases);
     try fns.put(alloc, unique, .{
         .params = try params.toOwnedSlice(alloc),
+        .imm_typed = imm_typed,
         .body = cur,
     });
 }
@@ -259,7 +294,7 @@ fn demands(
                 // nothing. Oversaturated: the first `arity` args reach the
                 // function; be conservative and require exact saturation.
                 if (n_args != info.params.len) return false;
-                break :blk masks.get(head) orelse 0;
+                break :blk if (masks.get(head)) |dm| dm.strict else 0;
             };
 
             // ∃i. strict(f, i) ∧ demands(a_i, p)
@@ -372,7 +407,7 @@ test "demand: fib-shaped recursion is strict in its parameter" {
     var masks = try analyse(testing.allocator, &progs);
     defer masks.deinit(testing.allocator);
 
-    try testing.expectEqual(@as(u64, 1), masks.get(2000).?);
+    try testing.expectEqual(@as(u64, 1), masks.get(2000).?.strict);
 }
 
 test "demand: accumulator threaded through recursive strict call is strict" {
@@ -419,7 +454,7 @@ test "demand: accumulator threaded through recursive strict call is strict" {
     defer masks.deinit(testing.allocator);
 
     // Both acc (bit 0) and n (bit 1) strict.
-    try testing.expectEqual(@as(u64, 0b11), masks.get(2000).?);
+    try testing.expectEqual(@as(u64, 0b11), masks.get(2000).?.strict);
 }
 
 test "demand: argument only used under a lambda is not strict" {
@@ -442,7 +477,7 @@ test "demand: argument only used under a lambda is not strict" {
     var masks = try analyse(testing.allocator, &progs);
     defer masks.deinit(testing.allocator);
 
-    try testing.expectEqual(@as(u64, 0b01), masks.get(2000).?);
+    try testing.expectEqual(@as(u64, 0b01), masks.get(2000).?.strict);
 }
 
 test "demand: alias bindings inherit the target's strictness" {
@@ -466,6 +501,6 @@ test "demand: alias bindings inherit the target's strictness" {
     var masks = try analyse(testing.allocator, &progs);
     defer masks.deinit(testing.allocator);
 
-    try testing.expectEqual(@as(u64, 0b11), masks.get(2000).?);
-    try testing.expectEqual(@as(u64, 0b11), masks.get(2001).?);
+    try testing.expectEqual(@as(u64, 0b11), masks.get(2000).?.strict);
+    try testing.expectEqual(@as(u64, 0b11), masks.get(2001).?.strict);
 }

--- a/src/grin/translate.zig
+++ b/src/grin/translate.zig
@@ -18,6 +18,7 @@
 
 const std = @import("std");
 const core = @import("../core/ast.zig");
+const demand = @import("../core/demand.zig");
 const grin = @import("ast.zig");
 const PrimOp = @import("primop.zig").PrimOp;
 const FieldType = grin.FieldType;
@@ -145,7 +146,7 @@ const TranslateCtx = struct {
     // (#802): function unique → bitmask (bit i = strict in param i).
     // Strict arguments are passed eagerly instead of as F-tag thunks.
     // Null when no analysis ran (REPL, debug commands) — all args lazy.
-    strict_params: ?*const std.AutoHashMapUnmanaged(u64, u64) = null,
+    strict_params: ?*const demand.StrictnessMap = null,
 
     pub fn init(alloc: std.mem.Allocator) TranslateCtx {
         return .{
@@ -517,7 +518,7 @@ pub fn translateProgram(
     core_prog: CoreProgram,
     external_arities: ?*const std.AutoHashMapUnmanaged(u64, u32),
     external_con_map: ?*const std.AutoHashMapUnmanaged(u64, u32),
-    strict_params: ?*const std.AutoHashMapUnmanaged(u64, u64),
+    strict_params: ?*const demand.StrictnessMap,
 ) !GrinProgram {
     // Build the arity map for partial/over-application handling.
     var arity_map = try buildArityMap(alloc, core_prog);
@@ -1393,7 +1394,7 @@ fn wrapWithLazyBindsForFunc(
         const sp = ctx.strict_params orelse break :blk 0;
         const arity = ctx.getFunctionArity(app.name) orelse break :blk 0;
         if (app.args.len != arity) break :blk 0;
-        break :blk sp.get(app.name.unique.value) orelse 0;
+        break :blk if (sp.get(app.name.unique.value)) |dm| dm.strict else 0;
     };
 
     var result = inner;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1076,7 +1076,7 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
     // calls to instance methods (better strictness). The resulting
     // strict-parameter masks let GRIN translation pass strict arguments
     // eagerly instead of allocating F-tag thunks.
-    const strict_params: ?*const std.AutoHashMapUnmanaged(u64, u64) = blk: {
+    const strict_params: ?*const rusholme.core.demand.StrictnessMap = blk: {
         var all_progs = std.ArrayListUnmanaged(rusholme.core.ast.CoreProgram).empty;
         for (module_order) |mod_name| {
             const core_prog = session.programs.get(mod_name) orelse continue;
@@ -1177,9 +1177,9 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
 
     // ── Dispatch to backend-specific emission ─────────────────────────────
     switch (backend_kind) {
-        .native => try emitNative(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend),
-        .jit => try emitJit(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend),
-        .wasm => try emitWasm(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend),
+        .native => try emitNative(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend, strict_params),
+        .jit => try emitJit(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend, strict_params),
+        .wasm => try emitWasm(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend, strict_params),
         .c => {
             var stderr_buf: [4096]u8 = undefined;
             var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
@@ -1204,6 +1204,7 @@ fn emitNative(
     output_name: []const u8,
     opt_level: rusholme.backend.llvm.OptLevel,
     rts_backend: rusholme.backend.grin_to_llvm.RtsBackend,
+    strict_params: ?*const rusholme.core.demand.StrictnessMap,
 ) !void {
     const llvm = rusholme.backend.llvm;
     var arena = std.heap.ArenaAllocator.init(allocator);
@@ -1230,6 +1231,7 @@ fn emitNative(
     };
     var translator = rusholme.backend.grin_to_llvm.GrinTranslator.init(arena_alloc, &registry);
     translator.rts_backend = rts_backend;
+    translator.strict_params = strict_params;
     defer translator.deinit();
 
     // Translate each module to a separate LLVM module and emit its bitcode.
@@ -1389,6 +1391,7 @@ fn emitJit(
     output_name: []const u8,
     opt_level: rusholme.backend.llvm.OptLevel,
     rts_backend: rusholme.backend.grin_to_llvm.RtsBackend,
+    strict_params: ?*const rusholme.core.demand.StrictnessMap,
 ) !void {
     _ = session;
     const llvm = rusholme.backend.llvm;
@@ -1416,6 +1419,7 @@ fn emitJit(
     };
     var translator = rusholme.backend.grin_to_llvm.GrinTranslator.init(arena_alloc, &registry);
     translator.rts_backend = rts_backend;
+    translator.strict_params = strict_params;
     defer translator.deinit();
 
     // ── Per-module LLVM translation ───────────────────────────────────────
@@ -1568,6 +1572,7 @@ fn emitWasm(
     output_name: []const u8,
     opt_level: rusholme.backend.llvm.OptLevel,
     rts_backend: rusholme.backend.grin_to_llvm.RtsBackend,
+    strict_params: ?*const rusholme.core.demand.StrictnessMap,
 ) !void {
     _ = session; // Unused for WASM backend
     const llvm = rusholme.backend.llvm;
@@ -1595,6 +1600,7 @@ fn emitWasm(
     };
     var translator = rusholme.backend.grin_to_llvm.GrinTranslator.init(arena_alloc, &registry);
     translator.rts_backend = rts_backend;
+    translator.strict_params = strict_params;
     defer translator.deinit();
 
     // ── Per-module LLVM translation ───────────────────────────────────────

--- a/src/rts/immix.zig
+++ b/src/rts/immix.zig
@@ -195,11 +195,14 @@ pub const MAX_BLOCK_ALLOC: usize = PAYLOAD_BYTES;
 
 /// Initial heap budget for the auto-collect trigger (#781). Chosen so
 /// short-running programs do not pay the cost of a collection at all
-/// (8 blocks ≈ 256 KiB of live data), while long-running programs see
-/// their first collection promptly after passing that threshold. The
-/// budget is re-tuned upward after each cycle proportional to the
-/// post-collection live size.
-pub const INITIAL_TARGET_BLOCKS: u64 = 8;
+/// (128 blocks ≈ 4 MiB of allocation, matching the scale of GHC's
+/// default allocation area), while long-running programs see their
+/// first collection promptly after passing that threshold. The budget
+/// is re-tuned upward after each cycle proportional to the
+/// post-collection live size. The previous 8-block (256 KiB) budget
+/// made allocation-heavy microbenches collect several times over a
+/// fully-live heap — pure overhead, since nothing was reclaimable.
+pub const INITIAL_TARGET_BLOCKS: u64 = 128;
 
 comptime {
     // The header must fit in a small, fixed number of lines, leaving the


### PR DESCRIPTION
Follow-up to #811. Two pieces: the Immix regression fix, and #803
worker/wrapper. Closes #803.

## Bottom line (arena RTS, `bench-all.sh -n 7 -w 3`)

| Bench | rhc | ghc -O2 | gap |
|---|---|---|---|
| build_list | **0.82 ms** | 1.11 ms | **0.74× — beats GHC** |
| fib_rec | **5.46 ms** | 5.57 ms | **0.98× — beats GHC** |
| tree_sum | **2.31 ms** | 2.01 ms | 1.15× |
| sum_to | **0.98 ms** | 0.84 ms | 1.17× |

Immix is now 1.1–7.8 ms across the suite (was 313 ms on fib before
this branch).

## Part 1 — Immix regression fixes

1. **Shadow save/restore inlined.** They were out-of-line calls
   bracketing every GRIN function — and every LLVM-inlined wrapper
   (fib paid 18 calls/invocation). Save = one load of
   `rts_shadow_top`, restore = one store; no slot zeroing on pop (the
   collector only scans `buffer[0..top]`).
2. **Immediates not rooted.** New `exprYieldsImmediate` classifier
   (strictly stronger than `exprYieldsWhnf` — a fresh Con store is
   WHNF but heap-allocated and still rooted) gates the shadow push.
3. **GC budget 256 KiB → 4 MiB** (`INITIAL_TARGET_BLOCKS` 8 → 128,
   the scale of GHC's default allocation area). The old budget made
   alloc-heavy microbenches collect repeatedly over a fully live heap.

## Part 2 — #803 worker/wrapper

The demand analysis now reports an **unbox mask**: strict parameters
whose Core type is Int/Char (`FnDemand.unbox ⊆ .strict`). For each
function with a non-empty mask the backend splits:

- **worker `w$f`** — takes unboxed positions as raw `i64`, contains
  the body. No entry forces, no shadow roots, no tag/untag churn.
- **wrapper `f`** — original symbol: force + untag + call worker.
  Thunk forcing, `__rhc_apply`, partial application, HOF use all keep
  the boxed ABI unchanged.

Saturated direct calls lower straight to the worker (def site and
call sites derive symbol + signature from the same mask, so
cross-module forward declarations agree). `w$fib_…` compiles to pure
register recursion: `cmp/lea/sar` + two calls — which is why fib now
matches GHC, and why the Immix fib number collapsed from 17.5 ms to
7.8 ms (raw words need no roots at all).

Also restores the `translator.strict_params` wiring in cmdBuild's
emitters (lost in an earlier revert — strict-param entry forcing in
#811 was inert without it).

## Testing
- `zig build test --summary all` — 1204/1204 green (REPL, e2e, Immix
  collection suites included).
- `bench-all.sh` stdout diff-checked against GHC for arena + immix.
