### PR TITLE
#821: buildModIface re-exports imported names (Var/Con/Type/Module)

### DIFF
--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -520,12 +520,25 @@ pub const CompileEnv = struct {
 
         // ── Build interface ───────────────────────────────────────────────
         const export_list = module.exports;
+        // Collect the ifaces of every directly-imported module so that
+        // `buildModIface` can satisfy re-export entries (issue #368) by
+        // copying matching `ExportedValue` / `ExportedDataDecl` records.
+        // Imports whose source did not appear in this build (e.g. resolved
+        // via `--package-db`, or simply missing) are silently skipped — the
+        // earlier compilation stages have already diagnosed those.
+        var imported_ifaces_list: std.ArrayListUnmanaged(ModIface) = .empty;
+        defer imported_ifaces_list.deinit(self.alloc);
+        for (module.imports) |imp| {
+            const imp_iface = self.ifaces.get(imp.module_name) orelse continue;
+            try imported_ifaces_list.append(self.alloc, imp_iface);
+        }
         var iface = try mod_iface.buildModIface(
             self.alloc,
             module_name,
             export_list,
             core_prog,
             &module_types,
+            imported_ifaces_list.items,
         );
         // Extend the interface with class and dictionary name data so that
         // downstream modules can reconstruct a ClassEnv and DictNameMap from
@@ -1992,4 +2005,143 @@ test "compileProgram: missing import emits module_not_found diagnostic" {
         }
     }
     try testing.expect(found);
+}
+
+// ── Re-export of imported names (issue #368) ─────────────────────────────
+
+test "compileProgram: Var re-export — Main resolves a name defined upstream and re-exported" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const io = testing.io;
+
+    const a_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module A (foo) where
+        \\foo :: Int
+        \\foo = 42
+        \\
+    ;
+    const b_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module B (foo) where
+        \\import A (foo)
+        \\
+    ;
+    const main_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module Main where
+        \\import B (foo)
+        \\answer :: Int
+        \\answer = foo
+        \\
+    ;
+
+    var r = try compileProgram(alloc, io, &.{
+        .{ .module_name = "A", .source = a_src, .file_id = 1 },
+        .{ .module_name = "B", .source = b_src, .file_id = 2 },
+        .{ .module_name = "Main", .source = main_src, .file_id = 3 },
+    }, &.{});
+    defer r.env.deinit();
+
+    try testing.expect(!r.result.had_errors);
+
+    // B's iface must re-publish `foo` so the renamer can resolve it from Main.
+    const b_iface = r.env.ifaces.get("B").?;
+    var saw_foo = false;
+    for (b_iface.values) |ev| {
+        if (std.mem.eql(u8, ev.name, "foo")) saw_foo = true;
+    }
+    try testing.expect(saw_foo);
+}
+
+test "compileProgram: module re-export — `module B` propagates all of B's exports" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const io = testing.io;
+
+    const a_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module A (foo, bar) where
+        \\foo :: Int
+        \\foo = 1
+        \\bar :: Int
+        \\bar = 2
+        \\
+    ;
+    // Wrapper module that imports A and re-exports the entire A surface.
+    const wrap_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module Wrap (module A) where
+        \\import A
+        \\
+    ;
+    const main_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module Main where
+        \\import Wrap
+        \\answer :: Int
+        \\answer = foo
+        \\other :: Int
+        \\other = bar
+        \\
+    ;
+
+    var r = try compileProgram(alloc, io, &.{
+        .{ .module_name = "A", .source = a_src, .file_id = 1 },
+        .{ .module_name = "Wrap", .source = wrap_src, .file_id = 2 },
+        .{ .module_name = "Main", .source = main_src, .file_id = 3 },
+    }, &.{});
+    defer r.env.deinit();
+
+    try testing.expect(!r.result.had_errors);
+
+    const wrap_iface = r.env.ifaces.get("Wrap").?;
+    var saw_foo = false;
+    var saw_bar = false;
+    for (wrap_iface.values) |ev| {
+        if (std.mem.eql(u8, ev.name, "foo")) saw_foo = true;
+        if (std.mem.eql(u8, ev.name, "bar")) saw_bar = true;
+    }
+    try testing.expect(saw_foo);
+    try testing.expect(saw_bar);
+}
+
+test "compileProgram: Type(..) re-export — data declaration with constructors flows through" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const io = testing.io;
+
+    const a_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module A (Shape(..)) where
+        \\data Shape = Square | Circle
+        \\
+    ;
+    // The parser does not yet accept `Shape(..)` in an import spec, so B uses
+    // a whole-module `import A` to bring `Shape` and its constructors into
+    // scope.  The re-export side of the test is the only thing under test.
+    const b_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module B (Shape(..)) where
+        \\import A
+        \\
+    ;
+
+    var r = try compileProgram(alloc, io, &.{
+        .{ .module_name = "A", .source = a_src, .file_id = 1 },
+        .{ .module_name = "B", .source = b_src, .file_id = 2 },
+    }, &.{});
+    defer r.env.deinit();
+
+    try testing.expect(!r.result.had_errors);
+
+    const b_iface = r.env.ifaces.get("B").?;
+    try testing.expectEqual(@as(usize, 1), b_iface.data_decls.len);
+    const dd = b_iface.data_decls[0];
+    try testing.expectEqualStrings("Shape", dd.name);
+    // `Shape(..)` propagates both constructors.
+    try testing.expectEqual(@as(usize, 2), dd.constructors.len);
 }

--- a/src/modules/mod_iface.zig
+++ b/src/modules/mod_iface.zig
@@ -409,6 +409,7 @@ pub fn buildModIface(
     export_list: ?[]const ExportSpec,
     core_prog: CoreProgram,
     module_types: *const ModuleTypes,
+    imported_ifaces: []const ModIface,
 ) std.mem.Allocator.Error!ModIface {
     // ── Expand class `C(..)` exports into method name Var entries ───────
     // Haskell 2010 §5.2: `C(..)` for a class C exports all of C's methods.
@@ -497,11 +498,119 @@ pub fn buildModIface(
         });
     }
 
+    // ── Re-export of imported names (issue #368) ────────────────────────
+    //
+    // An export-list entry can name something this module imports rather than
+    // defines.  Haskell 2010 §5.2 makes no distinction at the export point —
+    // the importer cannot tell whether the name was defined here or merely
+    // re-exported.  We satisfy any such entry by copying the matching
+    // `ExportedValue` / `ExportedDataDecl` from an upstream iface.
+    //
+    // Variants:
+    //   - `Var v` / `Con c` → copy the matching value from any imported iface.
+    //   - `Type ts`         → copy the matching data decl; if the entry is
+    //                         `T` (no `(..)`), strip constructors so the
+    //                         downstream importer cannot pattern-match on them.
+    //   - `Module m`        → copy every value and data decl exported by the
+    //                         iface whose name is `m` (and not already
+    //                         satisfied locally).
+    //
+    // Class methods carried by `class C(..)` are expanded into synthetic
+    // `Var` entries above and flow through the `Var` branch here, so an
+    // imported class re-exported via `C(..)` exposes its method selectors
+    // correctly.  Class and instance declarations themselves are already
+    // republished by `serialiseClassEnvIntoIface` because the importer's
+    // `class_env` is seeded transitively before serialisation.
+    if (export_list != null) {
+        for (effective_exports.?) |spec| {
+            switch (spec) {
+                .Var => |name_str| {
+                    if (containsValueByName(values.items, name_str)) continue;
+                    try reexportValueByName(alloc, &values, imported_ifaces, name_str);
+                },
+                .Con => |name_str| {
+                    if (containsValueByName(values.items, name_str)) continue;
+                    try reexportValueByName(alloc, &values, imported_ifaces, name_str);
+                },
+                .Type => |ts| {
+                    if (containsTypeByName(data_decls.items, ts.name)) continue;
+                    try reexportTypeByName(alloc, &data_decls, imported_ifaces, ts.name, ts.with_constructors);
+                },
+                .Module => |m| {
+                    for (imported_ifaces) |imp| {
+                        if (!std.mem.eql(u8, imp.module_name, m)) continue;
+                        for (imp.values) |ev| {
+                            if (containsValueByName(values.items, ev.name)) continue;
+                            try values.append(alloc, ev);
+                        }
+                        for (imp.data_decls) |dd| {
+                            if (containsTypeByName(data_decls.items, dd.name)) continue;
+                            try data_decls.append(alloc, dd);
+                        }
+                    }
+                },
+            }
+        }
+    }
+
     return ModIface{
         .module_name = module_name,
         .values = try values.toOwnedSlice(alloc),
         .data_decls = try data_decls.toOwnedSlice(alloc),
     };
+}
+
+fn containsValueByName(list: []const ExportedValue, name_str: []const u8) bool {
+    for (list) |ev| {
+        if (std.mem.eql(u8, ev.name, name_str)) return true;
+    }
+    return false;
+}
+
+fn containsTypeByName(list: []const ExportedDataDecl, name_str: []const u8) bool {
+    for (list) |dd| {
+        if (std.mem.eql(u8, dd.name, name_str)) return true;
+    }
+    return false;
+}
+
+fn reexportValueByName(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(ExportedValue),
+    imported_ifaces: []const ModIface,
+    name_str: []const u8,
+) std.mem.Allocator.Error!void {
+    for (imported_ifaces) |imp| {
+        for (imp.values) |ev| {
+            if (std.mem.eql(u8, ev.name, name_str)) {
+                try out.append(alloc, ev);
+                return;
+            }
+        }
+    }
+}
+
+fn reexportTypeByName(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(ExportedDataDecl),
+    imported_ifaces: []const ModIface,
+    name_str: []const u8,
+    with_constructors: bool,
+) std.mem.Allocator.Error!void {
+    for (imported_ifaces) |imp| {
+        for (imp.data_decls) |dd| {
+            if (!std.mem.eql(u8, dd.name, name_str)) continue;
+            const exported = if (with_constructors) dd else ExportedDataDecl{
+                .name = dd.name,
+                .unique = dd.unique,
+                .tyvar_names = dd.tyvar_names,
+                .tyvar_uniques = dd.tyvar_uniques,
+                .constructors = &.{},
+            };
+            try out.append(alloc, exported);
+            return;
+        }
+    }
 }
 
 /// Build an `ExportedValue` for a single binder, looking up its scheme


### PR DESCRIPTION
Closes #821.

Unblocks the layered `Prelude → GHC.Base → RHC.Prim` split (epic #10,
#655) by letting a module re-export names it merely imports.

## Summary
- `buildModIface` accepts the directly-imported `ModIface`s.
- Satisfies any export entry not covered locally:
  - `Var`/`Con` → copy matching `ExportedValue` from an import.
  - `Type ts`   → copy matching `ExportedDataDecl`; strip constructors when
                  `with_constructors` is false.
  - `Module m`  → splice in every export of the iface named `m`.
- Deduped by base name.
- Class / instance / dict re-export already works transitively via the
  `class_env` seeding pipeline.

## Out of scope (filed separately)
- #822: parser does not accept dotted name in `module M.N` export.
- #823: parser does not accept `T(..)` / `T(C1, C2)` in import specs.

The new `Type(..)` test in this PR uses whole-module `import A` because of
#823.

## Test plan
- [ ] `nix develop --command zig build test --summary all` — 1216/1216 pass.
- [ ] New tests:
  - `compileProgram: Var re-export — Main resolves a name defined upstream and re-exported`
  - `compileProgram: module re-export — \`module B\` propagates all of B's exports`
  - `compileProgram: Type(..) re-export — data declaration with constructors flows through`
