### PR TITLE
#655: multi-boot driver — prepend RHC.Prim before Prelude

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -325,6 +325,16 @@ pub fn build(b: *std.Build) void {
     const prelude_path_wf = b.addNamedWriteFiles("prelude_path");
     const prelude_path_file = prelude_path_wf.add("path.txt", prelude_path_option);
 
+    // RHC.Prim source path: the innermost boot package, holds every
+    // `foreign import prim` declaration.  Compiled before Prelude.
+    const rhc_prim_path_option = b.option(
+        []const u8,
+        "rhc-prim-path",
+        "Path to lib/rhc-prim/RHC/Prim.hs",
+    ) orelse b.getInstallPath(.@"prefix", "lib/rhc-prim/RHC/Prim.hs");
+    const rhc_prim_path_wf = b.addNamedWriteFiles("rhc_prim_path");
+    const rhc_prim_path_file = rhc_prim_path_wf.add("path.txt", rhc_prim_path_option);
+
     // Here we define an executable. An executable needs to have a root module
     // which needs to expose a `main` function. While we could add a main function
     // to the module defined above, it's sometimes preferable to split business
@@ -387,6 +397,9 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addAnonymousImport("prelude_path", .{
         .root_source_file = prelude_path_file,
     });
+    exe.root_module.addAnonymousImport("rhc_prim_path", .{
+        .root_source_file = rhc_prim_path_file,
+    });
 
     // This declares intent for the executable to be installed into the
     // install prefix when running `zig build` (i.e. when executing the default
@@ -397,6 +410,8 @@ pub fn build(b: *std.Build) void {
     // Install the Prelude source file alongside the binary so the compiler
     // can find it at runtime via the baked-in prelude_path.
     b.installFile("lib/Prelude.hs", "lib/Prelude.hs");
+    // Same for RHC.Prim, the innermost boot package compiled before Prelude.
+    b.installFile("lib/rhc-prim/RHC/Prim.hs", "lib/rhc-prim/RHC/Prim.hs");
 
     // This creates a top level step. Top level steps have a name and can be
     // invoked by name when running `zig build` (e.g. `zig build run`).

--- a/lib/rhc-prim/RHC/Prim.hs
+++ b/lib/rhc-prim/RHC/Prim.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+-- | RHC.Prim — the innermost boot package (placeholder).
+--
+-- This module will eventually own every `foreign import prim`
+-- declaration in the system: the raw doorway into Rusholme's PrimOp
+-- registry.  See `docs/plans/2026-06-13-ghc-internal-base-split.md`
+-- §3 Milestone 1a for the contents that move here from `lib/Prelude.hs`.
+--
+-- For now the module is empty: it exists so that the multi-boot driver
+-- pipeline (`build.zig` + `cmdBuild`) compiles it ahead of `Prelude`
+-- and we can prove the layered Prelude stack works end-to-end before
+-- moving real declarations.  The actual primop move is tracked
+-- separately in the milestone follow-up.
+module RHC.Prim where

--- a/src/main.zig
+++ b/src/main.zig
@@ -96,6 +96,32 @@ fn getPreludePath() []const u8 {
     return @embedFile("prelude_path");
 }
 
+/// Get the path to the RHC.Prim source file baked in at compile time.
+/// RHC.Prim is the innermost boot package and is compiled before Prelude.
+fn getRhcPrimPath() []const u8 {
+    return @embedFile("rhc_prim_path");
+}
+
+/// Boot modules that the driver auto-prepends, in dependency order.
+///
+/// These mirror the planned `ghc-internal → base` package layering
+/// (decision 0008, amended by `docs/plans/2026-06-13-ghc-internal-base-split.md`):
+/// the innermost layer is `RHC.Prim`, then the public `Prelude`.  More
+/// boot modules (`GHC.Base`, `Data.List`, …) will be added here as the
+/// split progresses.
+///
+/// Each entry pairs a declared module name with a callable that returns
+/// the baked-in source path.  We use a callable rather than a path string
+/// because `@embedFile` requires a compile-time-known import name.
+const BootModule = struct {
+    module_name: []const u8,
+    pathFn: *const fn () []const u8,
+};
+const boot_modules = [_]BootModule{
+    .{ .module_name = "RHC.Prim", .pathFn = getRhcPrimPath },
+    .{ .module_name = "Prelude", .pathFn = getPreludePath },
+};
+
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     const io = init.io;
@@ -975,40 +1001,45 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
     const compile_env_mod = rusholme.modules.compile_env;
     var source_modules: std.ArrayListUnmanaged(compile_env_mod.SourceModule) = .empty;
 
-    // ── Auto-prepend Prelude unless the user explicitly passed it ────────
-    // Check if any user-provided file is the Prelude module.
-    var user_provides_prelude = false;
+    // ── Auto-prepend boot modules unless the user explicitly passed them ─
+    //
+    // The boot modules (`RHC.Prim`, `Prelude`, …) form the layered
+    // Prelude stack.  We prepend them in declared dependency order so
+    // the module graph topo-sorts them ahead of user code.  An entry is
+    // skipped when the user has already supplied a file whose inferred
+    // module name matches — this lets a test or a custom Prelude shadow
+    // a boot module wholesale.
+    var user_module_names: std.StringHashMapUnmanaged(void) = .empty;
     for (file_paths) |fp| {
         const mod_name = try rusholme.modules.module_graph.inferModuleName(arena_alloc, fp);
-        if (std.mem.eql(u8, mod_name, "Prelude")) {
-            user_provides_prelude = true;
-            break;
-        }
+        try user_module_names.put(arena_alloc, mod_name, {});
     }
 
-    // File ID 0 is reserved for the Prelude; user modules start at 1.
+    // File IDs are assigned monotonically; boot modules take the low IDs.
     var next_file_id: u32 = 0;
 
-    if (!user_provides_prelude) {
-        const prelude_path = getPreludePath();
-        if (readSourceFile(arena_alloc, io, prelude_path)) |prelude_source| {
+    for (boot_modules) |boot| {
+        if (user_module_names.contains(boot.module_name)) continue;
+        const boot_path = boot.pathFn();
+        if (readSourceFile(arena_alloc, io, boot_path)) |boot_source| {
             try source_modules.append(arena_alloc, .{
-                .module_name = "Prelude",
-                .source = prelude_source,
+                .module_name = boot.module_name,
+                .source = boot_source,
                 .file_id = next_file_id,
-                .source_path = prelude_path,
+                .source_path = boot_path,
             });
             next_file_id += 1;
         } else |err| {
-            // Prelude not found is non-fatal in development; warn and continue
-            // without implicit Prelude compilation. User modules will still
-            // get wired-in names from populateWiredIn/initBuiltins.
+            // A missing boot module is non-fatal in development: warn and
+            // continue without it.  User modules still get wired-in names
+            // from `initBuiltins` / `populateWiredIn`.  This matches the
+            // pre-split behaviour for a missing Prelude.
             var stderr_buf: [4096]u8 = undefined;
             var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
             const stderr = &stderr_fw.interface;
             switch (err) {
-                error.FileNotFound => try stderr.print("rhc: warning: Prelude not found at '{s}'; using built-in names only\n", .{prelude_path}),
-                else => try stderr.print("rhc: warning: cannot read Prelude '{s}': {}; using built-in names only\n", .{ prelude_path, err }),
+                error.FileNotFound => try stderr.print("rhc: warning: boot module '{s}' not found at '{s}'; using built-in names only\n", .{ boot.module_name, boot_path }),
+                else => try stderr.print("rhc: warning: cannot read boot module '{s}' at '{s}': {}; using built-in names only\n", .{ boot.module_name, boot_path, err }),
             }
             try stderr.flush();
         }

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -520,12 +520,25 @@ pub const CompileEnv = struct {
 
         // ── Build interface ───────────────────────────────────────────────
         const export_list = module.exports;
+        // Collect the ifaces of every directly-imported module so that
+        // `buildModIface` can satisfy re-export entries (issue #368) by
+        // copying matching `ExportedValue` / `ExportedDataDecl` records.
+        // Imports whose source did not appear in this build (e.g. resolved
+        // via `--package-db`, or simply missing) are silently skipped — the
+        // earlier compilation stages have already diagnosed those.
+        var imported_ifaces_list: std.ArrayListUnmanaged(ModIface) = .empty;
+        defer imported_ifaces_list.deinit(self.alloc);
+        for (module.imports) |imp| {
+            const imp_iface = self.ifaces.get(imp.module_name) orelse continue;
+            try imported_ifaces_list.append(self.alloc, imp_iface);
+        }
         var iface = try mod_iface.buildModIface(
             self.alloc,
             module_name,
             export_list,
             core_prog,
             &module_types,
+            imported_ifaces_list.items,
         );
         // Extend the interface with class and dictionary name data so that
         // downstream modules can reconstruct a ClassEnv and DictNameMap from
@@ -1992,4 +2005,143 @@ test "compileProgram: missing import emits module_not_found diagnostic" {
         }
     }
     try testing.expect(found);
+}
+
+// ── Re-export of imported names (issue #368) ─────────────────────────────
+
+test "compileProgram: Var re-export — Main resolves a name defined upstream and re-exported" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const io = testing.io;
+
+    const a_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module A (foo) where
+        \\foo :: Int
+        \\foo = 42
+        \\
+    ;
+    const b_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module B (foo) where
+        \\import A (foo)
+        \\
+    ;
+    const main_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module Main where
+        \\import B (foo)
+        \\answer :: Int
+        \\answer = foo
+        \\
+    ;
+
+    var r = try compileProgram(alloc, io, &.{
+        .{ .module_name = "A", .source = a_src, .file_id = 1 },
+        .{ .module_name = "B", .source = b_src, .file_id = 2 },
+        .{ .module_name = "Main", .source = main_src, .file_id = 3 },
+    }, &.{});
+    defer r.env.deinit();
+
+    try testing.expect(!r.result.had_errors);
+
+    // B's iface must re-publish `foo` so the renamer can resolve it from Main.
+    const b_iface = r.env.ifaces.get("B").?;
+    var saw_foo = false;
+    for (b_iface.values) |ev| {
+        if (std.mem.eql(u8, ev.name, "foo")) saw_foo = true;
+    }
+    try testing.expect(saw_foo);
+}
+
+test "compileProgram: module re-export — `module B` propagates all of B's exports" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const io = testing.io;
+
+    const a_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module A (foo, bar) where
+        \\foo :: Int
+        \\foo = 1
+        \\bar :: Int
+        \\bar = 2
+        \\
+    ;
+    // Wrapper module that imports A and re-exports the entire A surface.
+    const wrap_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module Wrap (module A) where
+        \\import A
+        \\
+    ;
+    const main_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module Main where
+        \\import Wrap
+        \\answer :: Int
+        \\answer = foo
+        \\other :: Int
+        \\other = bar
+        \\
+    ;
+
+    var r = try compileProgram(alloc, io, &.{
+        .{ .module_name = "A", .source = a_src, .file_id = 1 },
+        .{ .module_name = "Wrap", .source = wrap_src, .file_id = 2 },
+        .{ .module_name = "Main", .source = main_src, .file_id = 3 },
+    }, &.{});
+    defer r.env.deinit();
+
+    try testing.expect(!r.result.had_errors);
+
+    const wrap_iface = r.env.ifaces.get("Wrap").?;
+    var saw_foo = false;
+    var saw_bar = false;
+    for (wrap_iface.values) |ev| {
+        if (std.mem.eql(u8, ev.name, "foo")) saw_foo = true;
+        if (std.mem.eql(u8, ev.name, "bar")) saw_bar = true;
+    }
+    try testing.expect(saw_foo);
+    try testing.expect(saw_bar);
+}
+
+test "compileProgram: Type(..) re-export — data declaration with constructors flows through" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const io = testing.io;
+
+    const a_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module A (Shape(..)) where
+        \\data Shape = Square | Circle
+        \\
+    ;
+    // The parser does not yet accept `Shape(..)` in an import spec, so B uses
+    // a whole-module `import A` to bring `Shape` and its constructors into
+    // scope.  The re-export side of the test is the only thing under test.
+    const b_src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\module B (Shape(..)) where
+        \\import A
+        \\
+    ;
+
+    var r = try compileProgram(alloc, io, &.{
+        .{ .module_name = "A", .source = a_src, .file_id = 1 },
+        .{ .module_name = "B", .source = b_src, .file_id = 2 },
+    }, &.{});
+    defer r.env.deinit();
+
+    try testing.expect(!r.result.had_errors);
+
+    const b_iface = r.env.ifaces.get("B").?;
+    try testing.expectEqual(@as(usize, 1), b_iface.data_decls.len);
+    const dd = b_iface.data_decls[0];
+    try testing.expectEqualStrings("Shape", dd.name);
+    // `Shape(..)` propagates both constructors.
+    try testing.expectEqual(@as(usize, 2), dd.constructors.len);
 }

--- a/src/modules/mod_iface.zig
+++ b/src/modules/mod_iface.zig
@@ -409,6 +409,7 @@ pub fn buildModIface(
     export_list: ?[]const ExportSpec,
     core_prog: CoreProgram,
     module_types: *const ModuleTypes,
+    imported_ifaces: []const ModIface,
 ) std.mem.Allocator.Error!ModIface {
     // ── Expand class `C(..)` exports into method name Var entries ───────
     // Haskell 2010 §5.2: `C(..)` for a class C exports all of C's methods.
@@ -497,11 +498,119 @@ pub fn buildModIface(
         });
     }
 
+    // ── Re-export of imported names (issue #368) ────────────────────────
+    //
+    // An export-list entry can name something this module imports rather than
+    // defines.  Haskell 2010 §5.2 makes no distinction at the export point —
+    // the importer cannot tell whether the name was defined here or merely
+    // re-exported.  We satisfy any such entry by copying the matching
+    // `ExportedValue` / `ExportedDataDecl` from an upstream iface.
+    //
+    // Variants:
+    //   - `Var v` / `Con c` → copy the matching value from any imported iface.
+    //   - `Type ts`         → copy the matching data decl; if the entry is
+    //                         `T` (no `(..)`), strip constructors so the
+    //                         downstream importer cannot pattern-match on them.
+    //   - `Module m`        → copy every value and data decl exported by the
+    //                         iface whose name is `m` (and not already
+    //                         satisfied locally).
+    //
+    // Class methods carried by `class C(..)` are expanded into synthetic
+    // `Var` entries above and flow through the `Var` branch here, so an
+    // imported class re-exported via `C(..)` exposes its method selectors
+    // correctly.  Class and instance declarations themselves are already
+    // republished by `serialiseClassEnvIntoIface` because the importer's
+    // `class_env` is seeded transitively before serialisation.
+    if (export_list != null) {
+        for (effective_exports.?) |spec| {
+            switch (spec) {
+                .Var => |name_str| {
+                    if (containsValueByName(values.items, name_str)) continue;
+                    try reexportValueByName(alloc, &values, imported_ifaces, name_str);
+                },
+                .Con => |name_str| {
+                    if (containsValueByName(values.items, name_str)) continue;
+                    try reexportValueByName(alloc, &values, imported_ifaces, name_str);
+                },
+                .Type => |ts| {
+                    if (containsTypeByName(data_decls.items, ts.name)) continue;
+                    try reexportTypeByName(alloc, &data_decls, imported_ifaces, ts.name, ts.with_constructors);
+                },
+                .Module => |m| {
+                    for (imported_ifaces) |imp| {
+                        if (!std.mem.eql(u8, imp.module_name, m)) continue;
+                        for (imp.values) |ev| {
+                            if (containsValueByName(values.items, ev.name)) continue;
+                            try values.append(alloc, ev);
+                        }
+                        for (imp.data_decls) |dd| {
+                            if (containsTypeByName(data_decls.items, dd.name)) continue;
+                            try data_decls.append(alloc, dd);
+                        }
+                    }
+                },
+            }
+        }
+    }
+
     return ModIface{
         .module_name = module_name,
         .values = try values.toOwnedSlice(alloc),
         .data_decls = try data_decls.toOwnedSlice(alloc),
     };
+}
+
+fn containsValueByName(list: []const ExportedValue, name_str: []const u8) bool {
+    for (list) |ev| {
+        if (std.mem.eql(u8, ev.name, name_str)) return true;
+    }
+    return false;
+}
+
+fn containsTypeByName(list: []const ExportedDataDecl, name_str: []const u8) bool {
+    for (list) |dd| {
+        if (std.mem.eql(u8, dd.name, name_str)) return true;
+    }
+    return false;
+}
+
+fn reexportValueByName(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(ExportedValue),
+    imported_ifaces: []const ModIface,
+    name_str: []const u8,
+) std.mem.Allocator.Error!void {
+    for (imported_ifaces) |imp| {
+        for (imp.values) |ev| {
+            if (std.mem.eql(u8, ev.name, name_str)) {
+                try out.append(alloc, ev);
+                return;
+            }
+        }
+    }
+}
+
+fn reexportTypeByName(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(ExportedDataDecl),
+    imported_ifaces: []const ModIface,
+    name_str: []const u8,
+    with_constructors: bool,
+) std.mem.Allocator.Error!void {
+    for (imported_ifaces) |imp| {
+        for (imp.data_decls) |dd| {
+            if (!std.mem.eql(u8, dd.name, name_str)) continue;
+            const exported = if (with_constructors) dd else ExportedDataDecl{
+                .name = dd.name,
+                .unique = dd.unique,
+                .tyvar_names = dd.tyvar_names,
+                .tyvar_uniques = dd.tyvar_uniques,
+                .constructors = &.{},
+            };
+            try out.append(alloc, exported);
+            return;
+        }
+    }
 }
 
 /// Build an `ExportedValue` for a single binder, looking up its scheme

--- a/src/typechecker/class_env.zig
+++ b/src/typechecker/class_env.zig
@@ -132,6 +132,37 @@ pub const InstanceInfo = struct {
     rigid_scope: []const RigidBinding = &.{},
 };
 
+/// The unique of the outermost type constructor of an instance head.
+///
+/// For `instance Eq Int` the head is `Con(Int)`, so this is `Int`'s unique;
+/// for `instance Eq a => Eq [a]` it is `[]`'s unique.  In Haskell 2010 (no
+/// overlapping instances) there is at most one instance per (class, head type
+/// constructor), so this constructor — together with the class and the
+/// defining source span — identifies an instance definition.  Returns `null`
+/// for a head with no outermost constructor (e.g. a bare type variable), in
+/// which case identity falls back to the class and span alone.
+fn instanceHeadKey(head: HType) ?u64 {
+    return switch (head) {
+        .Con => |c| c.name.unique.value,
+        else => null,
+    };
+}
+
+/// Whether two `InstanceInfo`s denote the *same instance definition*.
+///
+/// They do iff they share a class, an instance-head type constructor, and a
+/// defining source span.  `mergeFrom` relies on this to treat instance
+/// environments as sets: importing one instance along several module-graph
+/// paths (a diamond) must be idempotent, since instances are global and always
+/// transitively visible in Haskell.  Two *distinct* definitions of the same
+/// (class, head) live at different source spans, so they are preserved and the
+/// solver still reports them as a genuine overlapping-instance error.
+fn sameInstanceDefinition(a: InstanceInfo, b: InstanceInfo) bool {
+    if (a.class_name.unique.value != b.class_name.unique.value) return false;
+    if (instanceHeadKey(a.head) != instanceHeadKey(b.head)) return false;
+    return std.meta.eql(a.span, b.span);
+}
+
 // ── ClassEnv ──────────────────────────────────────────────────────────
 
 /// The class and instance environment.
@@ -244,13 +275,20 @@ pub const ClassEnv = struct {
         return &.{};
     }
 
-    /// Merge all classes and instances from `other` into `self`.
+    /// Merge all classes and instances from `other` into `self` as a set union.
     ///
     /// Classes are copied by unique ID (existing entries are overwritten).
-    /// Instances are appended to the existing instance list for each class.
+    /// Instances are unioned: an instance already present (per
+    /// `sameInstanceDefinition`) is not appended again, so merging is
+    /// idempotent.  This matters because instances are global and transitively
+    /// visible — a module reachable along several import paths (a diamond in
+    /// the module graph) would otherwise contribute its instances multiple
+    /// times, which the solver then misreports as overlapping instances.
+    /// Genuinely distinct definitions of the same (class, head) differ in their
+    /// source span and are still kept, preserving real overlap detection.
     ///
-    /// Used by the REPL to seed a fresh `InferCtx.class_env` with
-    /// classes/instances accumulated from prior inputs, and to merge
+    /// Used to seed a module's `InferCtx.class_env` from its imports, by the
+    /// REPL to accumulate classes/instances across inputs, and to merge
     /// newly-declared classes/instances back into the session state.
     pub fn mergeFrom(self: *ClassEnv, other: *const ClassEnv) !void {
         // Merge class declarations.
@@ -259,7 +297,7 @@ pub const ClassEnv = struct {
             try self.classes.put(self.alloc, entry.key_ptr.*, entry.value_ptr.*);
         }
 
-        // Merge instance declarations.
+        // Merge instance declarations as a set (skip definitions already present).
         var inst_it = other.instances.iterator();
         while (inst_it.next()) |entry| {
             const gop = try self.instances.getOrPut(self.alloc, entry.key_ptr.*);
@@ -267,7 +305,11 @@ pub const ClassEnv = struct {
                 gop.value_ptr.* = .empty;
             }
             for (entry.value_ptr.items) |inst| {
-                try gop.value_ptr.append(self.alloc, inst);
+                for (gop.value_ptr.items) |existing| {
+                    if (sameInstanceDefinition(existing, inst)) break;
+                } else {
+                    try gop.value_ptr.append(self.alloc, inst);
+                }
             }
         }
     }
@@ -332,6 +374,67 @@ test "ClassEnv: add and lookup instances" {
     // No instances for Show
     const show_instances = env.lookupInstances(Known.Class.Show.unique.value);
     try testing.expectEqual(0, show_instances.len);
+}
+
+test "ClassEnv: mergeFrom unions identical instances idempotently" {
+    // The same instance definition (same class, head, and span) reachable along
+    // two import paths must not be double-counted (diamond import).
+    const inst: InstanceInfo = .{
+        .class_name = Known.Class.Eq,
+        .head = HType{ .Con = .{ .name = Known.Type.Int, .args = &.{} } },
+        .context = &.{},
+        .span = testSpan(),
+    };
+
+    var a = ClassEnv.init(testing.allocator);
+    defer a.deinit();
+    try a.addInstance(inst);
+
+    var b = ClassEnv.init(testing.allocator);
+    defer b.deinit();
+    try b.addInstance(inst);
+
+    try a.mergeFrom(&b);
+    try testing.expectEqual(1, a.lookupInstances(Known.Class.Eq.unique.value).len);
+
+    // Merging again is still a no-op.
+    try a.mergeFrom(&b);
+    try testing.expectEqual(1, a.lookupInstances(Known.Class.Eq.unique.value).len);
+}
+
+test "ClassEnv: mergeFrom keeps genuinely distinct instances" {
+    // Same (class, head) but different defining spans = a real
+    // overlapping-instance error, which must survive the merge so the solver
+    // can report it.  Different heads must also both survive.
+    const span1 = SourceSpan.init(span_mod.SourcePos.init(1, 1, 1), span_mod.SourcePos.init(1, 1, 2));
+    const span2 = SourceSpan.init(span_mod.SourcePos.init(2, 9, 1), span_mod.SourcePos.init(2, 9, 2));
+
+    var a = ClassEnv.init(testing.allocator);
+    defer a.deinit();
+    try a.addInstance(.{
+        .class_name = Known.Class.Eq,
+        .head = HType{ .Con = .{ .name = Known.Type.Int, .args = &.{} } },
+        .context = &.{},
+        .span = span1,
+    });
+
+    var b = ClassEnv.init(testing.allocator);
+    defer b.deinit();
+    try b.addInstance(.{ // same head, different span → distinct definition
+        .class_name = Known.Class.Eq,
+        .head = HType{ .Con = .{ .name = Known.Type.Int, .args = &.{} } },
+        .context = &.{},
+        .span = span2,
+    });
+    try b.addInstance(.{ // different head → distinct definition
+        .class_name = Known.Class.Eq,
+        .head = HType{ .Con = .{ .name = Known.Type.Bool, .args = &.{} } },
+        .context = &.{},
+        .span = span1,
+    });
+
+    try a.mergeFrom(&b);
+    try testing.expectEqual(3, a.lookupInstances(Known.Class.Eq.unique.value).len);
 }
 
 test "ClassEnv: superclass chain" {


### PR DESCRIPTION
Toward #655 — Phase 2 of decision 0008.  Lays the multi-boot driver
plumbing required by `docs/plans/2026-06-13-ghc-internal-base-split.md`
§3 Milestone 1a, with a deliberately empty `RHC.Prim` so we prove the
mechanism without breaking semantics.

**Depends on #824 (`#820`) and #825 (`#821`).**  This branch contains
both as preparatory commits so the diff stands alone; rebase onto main
once they merge.

## Summary
- `build.zig`: bakes `rhc_prim_path` alongside `prelude_path`; installs
  `lib/rhc-prim/RHC/Prim.hs`.
- `src/main.zig`: introduces `boot_modules` (RHC.Prim → Prelude);
  `cmdBuild` walks the list and prepends each entry with its declared
  name (no `inferModuleName` on the install path).
- `lib/rhc-prim/RHC/Prim.hs`: documented placeholder.
- The actual `foreign import prim` move is filed as #826 — a direct
  port tripped a SIGSEGV that needs separate diagnosis.

## Test plan
- [ ] `nix develop --command zig build test --summary all` — 1216/1216
      pass.
- [ ] `rhc build tests/e2e/e2e_001_hello.hs -o /tmp/h && /tmp/h`
      prints `Hello`.
- [ ] Confirm RHC.Prim shows up in the topo order ahead of Prelude
      when the user did not supply it.

## Out of scope (filed separately)
- #826: move primops, address the case-binder SIGSEGV.
- #822: parser dotted module name in re-export.
- #823: parser `T(..)` / `T(C1, C2)` in import specs.
