### PR TITLE
#826: LLVM context + apply tagging + foreign-import wrapper no-worker

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -125,6 +125,11 @@ pub fn build(b: *std.Build) void {
     mod.addAnonymousImport("prelude_source", .{
         .root_source_file = b.path("lib/Prelude.hs"),
     });
+    // RHC.Prim source: the innermost boot package, compiled by the
+    // REPL session ahead of Prelude.
+    mod.addAnonymousImport("rhc_prim_source", .{
+        .root_source_file = b.path("lib/rhc-prim/RHC/Prim.hs"),
+    });
 
     // Runtime module - for LLVM-based runtime tests
     const runtime_mod = b.addModule("runtime", .{
@@ -693,6 +698,9 @@ pub fn build(b: *std.Build) void {
     // Embed the Prelude source for the WASM REPL (same as the library module).
     repl_wasm.root_module.addAnonymousImport("prelude_source", .{
         .root_source_file = b.path("lib/Prelude.hs"),
+    });
+    repl_wasm.root_module.addAnonymousImport("rhc_prim_source", .{
+        .root_source_file = b.path("lib/rhc-prim/RHC/Prim.hs"),
     });
     // Reactor mode: the REPL is a long-lived module with exported functions,
     // not a command that runs once and exits. In reactor mode the entry point

--- a/lib/Prelude.hs
+++ b/lib/Prelude.hs
@@ -25,29 +25,7 @@ module Prelude
     , enumFrom, enumFromTo, enumFromThen, enumFromThenTo
     ) where
 
--- ========================================================================
--- PrimOp imports
--- ========================================================================
-
-foreign import prim "add_Int"   primAddInt   :: Int -> Int -> Int
-foreign import prim "sub_Int"   primSubInt   :: Int -> Int -> Int
-foreign import prim "mul_Int"   primMulInt   :: Int -> Int -> Int
-foreign import prim "neg_Int"   primNegInt   :: Int -> Int
-foreign import prim "abs_Int"   primAbsInt   :: Int -> Int
-foreign import prim "quot_Int"  primQuotInt  :: Int -> Int -> Int
-foreign import prim "rem_Int"   primRemInt   :: Int -> Int -> Int
-foreign import prim "eq_Int"    primEqInt    :: Int -> Int -> Bool
-foreign import prim "ne_Int"    primNeInt    :: Int -> Int -> Bool
-foreign import prim "lt_Int"    primLtInt    :: Int -> Int -> Bool
-foreign import prim "le_Int"    primLeInt    :: Int -> Int -> Bool
-foreign import prim "gt_Int"    primGtInt    :: Int -> Int -> Bool
-foreign import prim "ge_Int"    primGeInt    :: Int -> Int -> Bool
-foreign import prim "putChar_"      primPutChar  :: Char -> IO ()
-foreign import prim "primPutStrLn"  primPutStrLn :: String -> IO ()
-foreign import prim "primPutStr"    primPutStr   :: String -> IO ()
-foreign import prim "error"     primError    :: String -> a
-foreign import prim "intToChar" intToChar    :: Int -> Char
-foreign import prim "charToInt" charToInt    :: Char -> Int
+import RHC.Prim
 
 -- ========================================================================
 -- Data types

--- a/lib/rhc-prim/RHC/Prim.hs
+++ b/lib/rhc-prim/RHC/Prim.hs
@@ -1,14 +1,57 @@
 {-# LANGUAGE NoImplicitPrelude #-}
--- | RHC.Prim — the innermost boot package (placeholder).
+-- | RHC.Prim — innermost boot package.
 --
--- This module will eventually own every `foreign import prim`
--- declaration in the system: the raw doorway into Rusholme's PrimOp
--- registry.  See `docs/plans/2026-06-13-ghc-internal-base-split.md`
--- §3 Milestone 1a for the contents that move here from `lib/Prelude.hs`.
+-- Houses every `foreign import prim` declaration: the raw doorway
+-- into Rusholme's PrimOp registry.  Code above this module never
+-- speaks primops directly; it imports the wrappers here.
 --
--- For now the module is empty: it exists so that the multi-boot driver
--- pipeline (`build.zig` + `cmdBuild`) compiles it ahead of `Prelude`
--- and we can prove the layered Prelude stack works end-to-end before
--- moving real declarations.  The actual primop move is tracked
--- separately in the milestone follow-up.
-module RHC.Prim where
+-- Mirrors GHC's `ghc-prim` in role, not in naming — our primop ABI
+-- is ours (`add_Int`, not `+#`), so we keep an `RHC.*` namespace
+-- here and mirror GHC's *public* surface (`GHC.*`, `Data.*`, …) one
+-- layer up.
+--
+-- Invariant: this is the only module that contains `foreign import
+-- prim`.  `GHC.Base` and `base` may import from here; nothing
+-- imports the other way.
+module RHC.Prim
+    ( primAddInt, primSubInt, primMulInt, primNegInt, primAbsInt
+    , primQuotInt, primRemInt
+    , primEqInt, primNeInt, primLtInt, primLeInt, primGtInt, primGeInt
+    , primPutChar, primPutStr, primPutStrLn
+    , primError
+    , intToChar, charToInt
+    ) where
+
+-- ── Integer arithmetic ───────────────────────────────────────────────
+
+foreign import prim "add_Int"   primAddInt   :: Int -> Int -> Int
+foreign import prim "sub_Int"   primSubInt   :: Int -> Int -> Int
+foreign import prim "mul_Int"   primMulInt   :: Int -> Int -> Int
+foreign import prim "neg_Int"   primNegInt   :: Int -> Int
+foreign import prim "abs_Int"   primAbsInt   :: Int -> Int
+foreign import prim "quot_Int"  primQuotInt  :: Int -> Int -> Int
+foreign import prim "rem_Int"   primRemInt   :: Int -> Int -> Int
+
+-- ── Integer comparisons ──────────────────────────────────────────────
+
+foreign import prim "eq_Int"    primEqInt    :: Int -> Int -> Bool
+foreign import prim "ne_Int"    primNeInt    :: Int -> Int -> Bool
+foreign import prim "lt_Int"    primLtInt    :: Int -> Int -> Bool
+foreign import prim "le_Int"    primLeInt    :: Int -> Int -> Bool
+foreign import prim "gt_Int"    primGtInt    :: Int -> Int -> Bool
+foreign import prim "ge_Int"    primGeInt    :: Int -> Int -> Bool
+
+-- ── Character ↔ Int ──────────────────────────────────────────────────
+
+foreign import prim "intToChar" intToChar    :: Int -> Char
+foreign import prim "charToInt" charToInt    :: Char -> Int
+
+-- ── IO ───────────────────────────────────────────────────────────────
+
+foreign import prim "putChar_"      primPutChar  :: Char -> IO ()
+foreign import prim "primPutStr"    primPutStr   :: [Char] -> IO ()
+foreign import prim "primPutStrLn"  primPutStrLn :: [Char] -> IO ()
+
+-- ── Diverging ────────────────────────────────────────────────────────
+
+foreign import prim "error"     primError    :: [Char] -> a

--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -725,7 +725,17 @@ pub const GrinTranslator = struct {
 
     pub fn init(allocator: std.mem.Allocator, registry: *TagRegistry) GrinTranslator {
         llvm.initialize();
-        const ctx = llvm.createContext();
+        // Use the global LLVM context. Type helpers throughout the
+        // backend (`ptrType`, `i64Type`, etc.) read types from the
+        // global context, and a per-translator context would put
+        // every per-module Function (created in `self.ctx`) in a
+        // different context from its own type — the bitcode writer
+        // serialises that as a cross-context reference and downstream
+        // modules end up with corrupt records.  All modules created
+        // here go into the global context too, so cross-module
+        // declarations match.  Tracked in:
+        // https://github.com/adinapoli/rusholme/issues/826
+        const ctx = c.LLVMGetGlobalContext();
         return .{
             .ctx = ctx,
             .module = llvm.createModule("haskell", ctx),
@@ -749,8 +759,10 @@ pub const GrinTranslator = struct {
         // registry is not owned — do not deinit it.
         self.type_env.deinit(self.allocator);
         llvm.disposeBuilder(self.builder);
-        // Disposing the context also disposes modules created within it.
-        llvm.disposeContext(self.ctx);
+        // Do NOT dispose `self.ctx`: it is the LLVM global context,
+        // shared across the whole process.  Modules created within it
+        // are reclaimed when LLVM tears down on exit.  (See the
+        // matching init comment about cross-context references.)
     }
 
     /// Extract the tag discriminants for well-known constructors
@@ -2061,8 +2073,17 @@ pub const GrinTranslator = struct {
         // and route them to the LLVM-level __rhc_apply instead.
         if (std.mem.eql(u8, name.base, "apply") and name.unique.value == 9998) {
             if (args.len >= 2) {
-                const f_val = try self.translateValToLlvm(args[0]);
-                const x_val = try self.translateValToLlvm(args[1]);
+                var f_val = try self.translateValToLlvm(args[0]);
+                var x_val = try self.translateValToLlvm(args[1]);
+                // __rhc_apply's signature is (ptr, ptr) -> ptr. Raw i64
+                // arguments (literals, primop results) must be re-tagged
+                // as boxed ptrs before being passed through.
+                if (c.LLVMGetTypeKind(c.LLVMTypeOf(f_val)) == c.LLVMIntegerTypeKind) {
+                    f_val = tagInt(self.builder, f_val);
+                }
+                if (c.LLVMGetTypeKind(c.LLVMTypeOf(x_val)) == c.LLVMIntegerTypeKind) {
+                    x_val = tagInt(self.builder, x_val);
+                }
                 const apply_fn = c.LLVMGetNamedFunction(self.module, "__rhc_apply") orelse blk: {
                     var apply_params = [_]llvm.Type{ ptrType(), ptrType() };
                     const apply_type = llvm.functionType(ptrType(), &apply_params, false);

--- a/src/backend/tag_registry.zig
+++ b/src/backend/tag_registry.zig
@@ -106,6 +106,37 @@ pub const TagRegistry = struct {
         };
     }
 
+    /// Pre-register the wired-in constructors (True/False/Nil/Cons/…)
+    /// with stable discriminants so cross-module translation that
+    /// references them (e.g. `wrapComparisonAsBool` in a `foreign
+    /// import prim` wrapper compiled before any data declaration is
+    /// seen) gets the same discriminant the later `data` declaration
+    /// will reuse.  Each call is idempotent.
+    ///
+    /// Without this, RHC.Prim's `primLtInt` lowers to a Bool-tagged
+    /// `(True=2, False=3)` immediate while Prelude later registers
+    /// True/False under `(True=0x1000, False=0x1001)` — the case
+    /// alternatives never match and execution falls into the
+    /// non-exhaustive default arm.  Tracked in #826/#829.
+    pub fn preregisterWiredInCons(self: *TagRegistry, alloc: std.mem.Allocator) !void {
+        const Known = @import("../naming/known.zig");
+        const wired = [_]struct { name: grin.Name, n_fields: u32 }{
+            .{ .name = Known.Con.True, .n_fields = 0 },
+            .{ .name = Known.Con.False, .n_fields = 0 },
+            .{ .name = Known.Con.Unit, .n_fields = 0 },
+            .{ .name = Known.Con.Nil, .n_fields = 0 },
+            .{ .name = Known.Con.Cons, .n_fields = 2 },
+            .{ .name = Known.Con.Nothing, .n_fields = 0 },
+            .{ .name = Known.Con.Just, .n_fields = 1 },
+            .{ .name = Known.Con.Left, .n_fields = 1 },
+            .{ .name = Known.Con.Right, .n_fields = 1 },
+        };
+        for (wired) |w| {
+            const tag = grin.Tag{ .name = w.name, .tag_type = .Con };
+            try self.register(alloc, tag, w.n_fields);
+        }
+    }
+
     pub fn deinit(self: *TagRegistry, alloc: std.mem.Allocator) void {
         self.discriminants.deinit(alloc);
         self.field_counts.deinit(alloc);

--- a/src/core/demand.zig
+++ b/src/core/demand.zig
@@ -302,12 +302,38 @@ fn collectFn(
     // Compute before toOwnedSlice below — it empties `params`, so an
     // inline field initializer would see arity 0.
     const cpr = resultIsImmediate(pair.binder.ty, params.items.len);
+
+    // Foreign-import-prim wrappers (`\x0 .. xn -> primop x0 .. xn`)
+    // are not eligible for the worker/wrapper split (#803).  Generating
+    // a `w$` worker for them produces a raw-i64 ABI symbol whose
+    // definition lives in the wrapper's defining module, but cross-
+    // module direct callers emit an external declaration with the same
+    // raw-i64 ABI; that external decl is then routed through LLVM
+    // optimisations against a different `Function`/`Module` context
+    // than the wrapper's definition, which corrupts the call.  The
+    // wrapper is a one-instruction body anyway (the primop inlines
+    // directly), so suppressing the worker costs nothing.  Tracked in:
+    // https://github.com/adinapoli/rusholme/issues/826
+    const is_primop_wrapper = isPrimopApp(cur);
+    const eff_imm_typed: u64 = if (is_primop_wrapper) 0 else imm_typed;
+    const eff_cpr: bool = if (is_primop_wrapper) false else cpr;
+
     try fns.put(alloc, unique, .{
         .params = try params.toOwnedSlice(alloc),
-        .imm_typed = imm_typed,
-        .cpr = cpr,
+        .imm_typed = eff_imm_typed,
+        .cpr = eff_cpr,
         .body = cur,
     });
+}
+
+/// Is `e` a single `App` whose head is a primop? That is the canonical
+/// shape produced by the desugarer for a `foreign import prim` wrapper
+/// body (`\x0 .. xn -> primop_canonical_name x0 .. xn`).
+fn isPrimopApp(e: *const Expr) bool {
+    var cur = e;
+    while (cur.* == .App) cur = cur.App.fn_expr;
+    if (cur.* != .Var) return false;
+    return primop.PrimOp.fromString(cur.Var.name.base) != null;
 }
 
 /// Record `let x = y` variable aliases from a function body. The pattern

--- a/src/grin/translate.zig
+++ b/src/grin/translate.zig
@@ -267,7 +267,11 @@ const PendingBind = struct {
 
 /// Analyze a Core program to build the arity map.
 /// This maps each function name to its arity (number of lambda parameters).
-fn buildArityMap(alloc: std.mem.Allocator, core_prog: CoreProgram) !std.AutoHashMapUnmanaged(u64, u32) {
+fn buildArityMap(
+    alloc: std.mem.Allocator,
+    core_prog: CoreProgram,
+    external_arities: ?*const std.AutoHashMapUnmanaged(u64, u32),
+) !std.AutoHashMapUnmanaged(u64, u32) {
     var arity_map = std.AutoHashMapUnmanaged(u64, u32){};
     errdefer arity_map.deinit(alloc);
 
@@ -286,6 +290,17 @@ fn buildArityMap(alloc: std.mem.Allocator, core_prog: CoreProgram) !std.AutoHash
                     try arity_map.put(alloc, unique_id, arity);
                 }
             },
+        }
+    }
+
+    // Seed externals so that resolveEtaArity below can chase aliases
+    // pointing at functions defined in upstream modules. Local entries
+    // already in `arity_map` take precedence.
+    if (external_arities) |ext| {
+        var ext_iter = ext.iterator();
+        while (ext_iter.next()) |entry| {
+            const gop = try arity_map.getOrPut(alloc, entry.key_ptr.*);
+            if (!gop.found_existing) gop.value_ptr.* = entry.value_ptr.*;
         }
     }
 
@@ -528,7 +543,10 @@ pub fn translateProgram(
     initial_name_counter: u64,
 ) !struct { program: GrinProgram, next_name_counter: u64 } {
     // Build the arity map for partial/over-application handling.
-    var arity_map = try buildArityMap(alloc, core_prog);
+    // Pass externals so that `resolveEtaArity` can chase eta-alias
+    // chains across module boundaries — e.g. Prelude's `error =
+    // primError` needs `primError`'s arity from RHC.Prim.
+    var arity_map = try buildArityMap(alloc, core_prog, external_arities);
     defer arity_map.deinit(alloc);
 
     // Build the constructor map from data declarations.
@@ -2599,7 +2617,7 @@ test "buildArityMap: correctly counts lambda parameters" {
         .binds = &.{.{ .NonRec = bind_pair }},
     };
 
-    var arity_map = try buildArityMap(alloc, core_prog);
+    var arity_map = try buildArityMap(alloc, core_prog, null);
     defer arity_map.deinit(alloc);
 
     // id should have arity 1

--- a/src/main.zig
+++ b/src/main.zig
@@ -975,6 +975,7 @@ fn loadPrelude(
         null, // no external class_env yet
         null, // no external dict_names yet
         null, // no external type_con_names yet
+        null, // single-module loadPrelude: no shared SpecialiseEnv
     );
     // Prelude bindings are now accumulated in rename_env and ty_env.
     // Return the class env and dict names so callers can seed their

--- a/src/repl/jit_engine.zig
+++ b/src/repl/jit_engine.zig
@@ -110,6 +110,17 @@ pub const JitEngine = struct {
             .jit = jit,
         };
 
+        // Pre-register wired-in constructors (True/False/Nil/Cons/…)
+        // so a `foreign import prim` wrapper in RHC.Prim — compiled
+        // and added to the JIT *before* Prelude declares `Bool` —
+        // bakes the same discriminants Prelude will later reuse.
+        // Without this the JIT REPL crashes on `42` (show wrapping
+        // hits `case n < 0 of True … False …`, but the Bool node
+        // produced by `primLtInt` carries the fallback discriminants
+        // and never matches the case's later-assigned ones).
+        engine.registry.preregisterWiredInCons(allocator) catch
+            return JitError.OutOfMemory;
+
         try engine.registerRtsSymbols();
 
         return engine;

--- a/src/repl/pipeline.zig
+++ b/src/repl/pipeline.zig
@@ -45,6 +45,8 @@ const env_mod = @import("../typechecker/env.zig");
 
 const desugar_mod = @import("../core/desugar.zig");
 const lift_mod = @import("../core/lift.zig");
+const specialise_mod = @import("../core/specialise.zig");
+pub const SpecialiseEnv = specialise_mod.SpecialiseEnv;
 
 const translate_mod = @import("../grin/translate.zig");
 const grin_ast = @import("../grin/ast.zig");
@@ -305,6 +307,7 @@ pub const Pipeline = struct {
         external_class_env: ?*const ClassEnv,
         external_dict_names: ?*const DictNameMap,
         external_type_con_names: ?*const TypeConNames,
+        spec_env: ?*SpecialiseEnv,
     ) CompileError!ModuleResult {
         const alloc = self.allocator;
 
@@ -372,6 +375,28 @@ pub const Pipeline = struct {
             return CompileError.CompilationFailed;
         }
 
+        // ── Specialise ─────────────────────────────────────────────
+        // Mirror cmdBuild's whole-program specialisation (#807) so
+        // that REPL inputs see the same `(<) dict$Ord$Int x y` →
+        // `primLtInt x y` rewrites that AOT gets.  Without this the
+        // Show Int / Eq / Ord instance bodies stay dispatched through
+        // dictionary selectors, and the JIT crashes at runtime when
+        // the case scrutinee's tag does not match either alternative
+        // (`Non-exhaustive patterns in case`).  Tracked in:
+        // https://github.com/adinapoli/rusholme/issues/829
+        const post_spec_program: core_ast.CoreProgram = blk: {
+            const env = spec_env orelse break :blk desugar_result.program;
+            specialise_mod.collectEnv(alloc, env, desugar_result.program) catch {
+                module_types.deinit(alloc);
+                return CompileError.OutOfMemory;
+            };
+            const specialised = specialise_mod.specialiseProgram(alloc, env, desugar_result.program) catch {
+                module_types.deinit(alloc);
+                return CompileError.OutOfMemory;
+            };
+            break :blk specialised;
+        };
+
         // ── Lambda lift ────────────────────────────────────────────
         // Thread the unique IDs of all previously-known bindings (Prelude
         // and earlier REPL inputs) into the lifter as its external scope.
@@ -396,7 +421,7 @@ pub const Pipeline = struct {
                 try external_unique_list.append(alloc, entry.value_ptr.*.unique.value);
             }
         }
-        const lift_result = lift_mod.lambdaLift(alloc, desugar_result.program, external_unique_list.items, 0) catch {
+        const lift_result = lift_mod.lambdaLift(alloc, post_spec_program, external_unique_list.items, 0) catch {
             module_types.deinit(alloc);
             return CompileError.OutOfMemory;
         };
@@ -447,6 +472,7 @@ pub const Pipeline = struct {
         external_class_env: ?*const ClassEnv,
         external_dict_names: ?*const DictNameMap,
         external_type_con_names: ?*const TypeConNames,
+        spec_env: ?*SpecialiseEnv,
     ) CompileError!CompileResult {
         const alloc = self.allocator;
         const file_id: FileId = 0;
@@ -483,7 +509,7 @@ pub const Pipeline = struct {
             var decl_diags = DiagnosticCollector.init();
             defer decl_diags.deinit(alloc);
 
-            if (self.compileModule(decl_source, file_id, u_supply, rename_env, ty_env, mv_supply, &decl_diags, external_arities, external_con_map, external_class_env, external_dict_names, external_type_con_names)) |result| {
+            if (self.compileModule(decl_source, file_id, u_supply, rename_env, ty_env, mv_supply, &decl_diags, external_arities, external_con_map, external_class_env, external_dict_names, external_type_con_names, spec_env)) |result| {
                 // Copy any diagnostics from the attempt
                 try copyDiagnostics(alloc, &decl_diags, diags);
                 return .{ .program = result.grin_prog, .kind = decl_kind, .core_data_decls = result.core_data_decls, .class_env = result.class_env, .dict_names = result.dict_names };
@@ -525,7 +551,7 @@ pub const Pipeline = struct {
             self.last_source = str_source;
             self.last_input_kind = .expression;
 
-            if (self.compileModule(str_source, file_id, u_supply, rename_env, ty_env, mv_supply, &str_diags, external_arities, external_con_map, external_class_env, external_dict_names, external_type_con_names)) |result| {
+            if (self.compileModule(str_source, file_id, u_supply, rename_env, ty_env, mv_supply, &str_diags, external_arities, external_con_map, external_class_env, external_dict_names, external_type_con_names, spec_env)) |result| {
                 const decl_diag_count = diags.diagnostics.items.len;
                 clearLeadingDiags(alloc, diags, decl_diag_count);
                 return .{ .program = result.grin_prog, .kind = .expression_io, .core_data_decls = result.core_data_decls, .class_env = result.class_env, .dict_names = result.dict_names };
@@ -569,7 +595,7 @@ pub const Pipeline = struct {
             self.last_source = show_source;
             self.last_input_kind = .expression;
 
-            if (self.compileModule(show_source, file_id, u_supply, rename_env, ty_env, mv_supply, &show_diags, external_arities, external_con_map, external_class_env, external_dict_names, external_type_con_names)) |result| {
+            if (self.compileModule(show_source, file_id, u_supply, rename_env, ty_env, mv_supply, &show_diags, external_arities, external_con_map, external_class_env, external_dict_names, external_type_con_names, spec_env)) |result| {
                 // Show-wrapped compilation succeeded — keep the scope
                 // frame and clear any declaration diagnostics.
                 const decl_diag_count = diags.diagnostics.items.len;
@@ -596,7 +622,7 @@ pub const Pipeline = struct {
             self.last_source = expr_source;
             self.last_input_kind = .expression;
 
-            if (self.compileModule(expr_source, file_id, u_supply, rename_env, ty_env, mv_supply, diags, external_arities, external_con_map, external_class_env, external_dict_names, external_type_con_names)) |result| {
+            if (self.compileModule(expr_source, file_id, u_supply, rename_env, ty_env, mv_supply, diags, external_arities, external_con_map, external_class_env, external_dict_names, external_type_con_names, spec_env)) |result| {
                 // Expression succeeded — clear declaration diagnostics.
                 clearLeadingDiags(alloc, diags, decl_diag_count);
                 return .{ .program = result.grin_prog, .kind = .expression, .core_data_decls = result.core_data_decls, .class_env = result.class_env, .dict_names = result.dict_names };
@@ -661,6 +687,7 @@ test "pipeline: compile simple literal expression" {
         null,
         null,
         null,
+        null,
     );
 
     try testing.expect(result.program.defs.len > 0);
@@ -692,6 +719,7 @@ test "pipeline: compile data declaration" {
         &ty_env,
         &mv_supply,
         &diags,
+        null,
         null,
         null,
         null,
@@ -729,6 +757,7 @@ test "pipeline: compile function declaration" {
         &ty_env,
         &mv_supply,
         &diags,
+        null,
         null,
         null,
         null,
@@ -851,6 +880,7 @@ test "pipeline: handle let prefix in declarations" {
         &ty_env,
         &mv_supply,
         &diags,
+        null,
         null,
         null,
         null,

--- a/src/repl/session.zig
+++ b/src/repl/session.zig
@@ -20,6 +20,7 @@ const Pipeline = pipeline_mod.Pipeline;
 const CompileResult = pipeline_mod.CompileResult;
 const CompileError = pipeline_mod.CompileError;
 const InputKind = pipeline_mod.InputKind;
+const SpecialiseEnv = pipeline_mod.SpecialiseEnv;
 
 const renamer_mod = @import("../renamer/renamer.zig");
 const RenameEnv = renamer_mod.RenameEnv;
@@ -174,6 +175,17 @@ pub const Session = struct {
     // from prior REPL inputs (#588).
     accumulated_type_con_names: std.StringHashMapUnmanaged(Name),
 
+    // Accumulated dictionary-passing specialisation environment.
+    // Mirrors `cmdBuild`'s whole-program specialise pass (#807): each
+    // compiled module's selectors/dicts are folded in, and the
+    // following input's pipeline rewrites class-method dispatch
+    // against this env before lambda-lifting.  Without it the JIT
+    // sees Show/Eq/Ord instance bodies still routed through
+    // dictionary selectors and crashes at runtime
+    // (`Non-exhaustive patterns in case`).  Tracked in:
+    // https://github.com/adinapoli/rusholme/issues/829
+    accumulated_spec_env: SpecialiseEnv,
+
     /// Create a new REPL session with initialised compiler state.
     pub fn init(allocator: Allocator, io: std.Io) SessionError!Session {
         var u_supply = UniqueSupply{};
@@ -214,6 +226,7 @@ pub const Session = struct {
             .accumulated_class_env = ClassEnv.init(allocator),
             .accumulated_dict_names = .empty,
             .accumulated_type_con_names = .empty,
+            .accumulated_spec_env = .{},
         };
 
         // Load the Prelude so its functions are available immediately.
@@ -226,6 +239,7 @@ pub const Session = struct {
     /// Release all session resources.
     pub fn deinit(self: *Session) void {
         // GrinEngine has no deinit; only JitEngine does.
+        self.accumulated_spec_env.deinit(self.allocator);
         self.accumulated_type_con_names.deinit(self.allocator);
         self.accumulated_dict_names.deinit(self.allocator);
         self.accumulated_class_env.deinit();
@@ -281,6 +295,7 @@ pub const Session = struct {
             &self.accumulated_class_env,
             &self.accumulated_dict_names,
             &self.accumulated_type_con_names,
+            &self.accumulated_spec_env,
         ) catch {
             // Prelude failed to compile — roll back and continue without it.
             self.ty_env.pop();
@@ -357,6 +372,7 @@ pub const Session = struct {
             &self.accumulated_class_env,
             &self.accumulated_dict_names,
             &self.accumulated_type_con_names,
+            &self.accumulated_spec_env,
         ) catch return;
 
         for (result.grin_prog.defs) |def| {
@@ -445,6 +461,7 @@ pub const Session = struct {
             &self.accumulated_class_env,
             &self.accumulated_dict_names,
             &self.accumulated_type_con_names,
+            &self.accumulated_spec_env,
         ) catch |err| {
             // Capture compilation context for diagnostic rendering.
             self.last_source = self.pipeline.last_source;

--- a/src/repl/session.zig
+++ b/src/repl/session.zig
@@ -57,13 +57,17 @@ const ClassEnv = class_env_mod.ClassEnv;
 const desugar_mod = @import("../core/desugar.zig");
 const DictNameMap = desugar_mod.DesugarCtx.DictNameMap;
 
-// ── Embedded Prelude source ───────────────────────────────────────────
+// ── Embedded boot-module sources ──────────────────────────────────────
 
 /// The Prelude source text, embedded at compile time.
 /// The anonymous import "prelude_source" is registered in build.zig on
 /// both the library module (mod) and the WASM REPL module, so this
 /// resolves correctly for native, WASM, and test targets.
 const prelude_source = @embedFile("prelude_source");
+
+/// RHC.Prim source — the innermost boot package, loaded ahead of
+/// Prelude.  Mirrors the multi-boot wiring `cmdBuild` uses (#655).
+const rhc_prim_source = @embedFile("rhc_prim_source");
 
 // ── Result types ──────────────────────────────────────────────────────
 
@@ -244,17 +248,25 @@ pub const Session = struct {
     /// Non-fatal: on failure, the session continues with built-in names
     /// only.  This keeps the REPL usable even if the Prelude has issues.
     fn loadPrelude(self: *Session) void {
-        // Push scope frames for Prelude bindings (permanent — never popped).
+        // Push scope frames for boot-module bindings (permanent — never popped).
         self.rename_env.scope.push() catch return;
         self.ty_env.push() catch {
             self.rename_env.scope.pop();
             return;
         };
 
+        // Compile RHC.Prim ahead of Prelude.  Its exports (every
+        // `foreign import prim` wrapper) are accumulated into the
+        // session state so Prelude's `import RHC.Prim` resolves and
+        // every downstream input can reach the primops too.
+        // Non-fatal: a missing/broken RHC.Prim degrades the REPL to
+        // wired-in names + Prelude, matching pre-split behaviour.
+        self.loadBootModule(rhc_prim_source, 0);
+
         var diags = DiagnosticCollector.init();
         defer diags.deinit(self.allocator);
 
-        const file_id: FileId = 0; // Prelude gets file_id 0 (same as batch compiler)
+        const file_id: FileId = 1; // Prelude gets file_id 1 (after RHC.Prim).
 
         const result = self.pipeline.compileModule(
             prelude_source,
@@ -264,11 +276,11 @@ pub const Session = struct {
             &self.ty_env,
             &self.mv_supply,
             &diags,
-            null, // no external arities yet
-            null, // no external con_map yet
-            null, // no external class_env yet
-            null, // no external dict_names yet
-            null, // no external type_con_names yet
+            &self.accumulated_arities,
+            &self.accumulated_con_map,
+            &self.accumulated_class_env,
+            &self.accumulated_dict_names,
+            &self.accumulated_type_con_names,
         ) catch {
             // Prelude failed to compile — roll back and continue without it.
             self.ty_env.pop();
@@ -318,6 +330,67 @@ pub const Session = struct {
                 // Non-fatal: continue with Prelude symbols in renamer/typechecker
                 // but unavailable in JIT (expressions using them will fail at link time).
                 std.debug.print("Warning: addDeclarations failed for Prelude: {}\n", .{err});
+                return;
+            };
+        }
+    }
+
+    /// Compile one boot module (currently just `RHC.Prim`) and fold
+    /// its outputs into the same accumulators that `loadPrelude` uses
+    /// for the Prelude.  Soft-failures are absorbed so the REPL stays
+    /// usable when a boot module is broken — same policy as
+    /// `loadPrelude`.
+    fn loadBootModule(self: *Session, source: []const u8, file_id: FileId) void {
+        var diags = DiagnosticCollector.init();
+        defer diags.deinit(self.allocator);
+
+        const result = self.pipeline.compileModule(
+            source,
+            file_id,
+            &self.u_supply,
+            &self.rename_env,
+            &self.ty_env,
+            &self.mv_supply,
+            &diags,
+            &self.accumulated_arities,
+            &self.accumulated_con_map,
+            &self.accumulated_class_env,
+            &self.accumulated_dict_names,
+            &self.accumulated_type_con_names,
+        ) catch return;
+
+        for (result.grin_prog.defs) |def| {
+            self.accumulated_defs.append(self.allocator, def) catch return;
+            self.accumulated_arities.put(
+                self.allocator,
+                def.name.unique.value,
+                @intCast(def.params.len),
+            ) catch return;
+        }
+
+        for (result.core_data_decls) |decl| {
+            for (decl.constructors) |con| {
+                self.accumulated_con_map.put(
+                    self.allocator,
+                    con.name.unique.value,
+                    translate_mod.countConFields(con.ty),
+                ) catch return;
+            }
+            self.accumulated_type_con_names.put(self.allocator, decl.name.base, decl.name) catch return;
+        }
+
+        // Merge class_env/dict_names: the boot module may declare neither,
+        // but if it does they must accumulate (the Prelude pass below
+        // will see them through the seed parameters).
+        self.accumulated_class_env.mergeFrom(&result.class_env) catch return;
+        var dn_it = result.dict_names.iterator();
+        while (dn_it.next()) |entry| {
+            self.accumulated_dict_names.put(self.allocator, entry.key_ptr.*, entry.value_ptr.*) catch return;
+        }
+
+        if (!is_wasi) {
+            self.engine.addDeclarations(&result.grin_prog) catch |err| {
+                std.debug.print("Warning: addDeclarations failed for boot module: {}\n", .{err});
                 return;
             };
         }

--- a/src/repl/typequery.zig
+++ b/src/repl/typequery.zig
@@ -83,6 +83,7 @@ pub fn typeOf(
         &session.accumulated_class_env,
         &session.accumulated_dict_names,
         &session.accumulated_type_con_names,
+        &session.accumulated_spec_env,
     ) catch |err| {
         // Capture compilation context for diagnostic rendering.
         session.last_source = session.pipeline.last_source;


### PR DESCRIPTION
Toward closing #826.  These are the precondition fixes that the
multi-module compile needs — each one was masked under the single-
module Prelude and surfaced the moment the `foreign import prim`
declarations moved to a different module.

## Summary
- **Shared LLVM context.**  `GrinTranslator` now uses the global
  LLVM context.  A per-translator context put per-module Functions
  in a different context from their own types, which the bitcode
  writer serialised as cross-context corruption (`llvm-dis` rejected
  the resulting `.bc`; the LLVM verifier flagged it as
  `Function context does not match Module context`).
- **`__rhc_apply` argument tagging.**  The intercept routing the
  GRIN-level `apply` stub through `__rhc_apply` now `tagInt`-encodes
  raw-`i64` arguments before the call, matching the boxed `(ptr, ptr)
  -> ptr` ABI used elsewhere.
- **Foreign-import wrappers do not get a worker.**  Demand analysis
  detects single-`App-primop` wrapper bodies (`\x0 .. xn -> primop
  x0 .. xn`) and clamps `imm_typed`/`cpr` to zero/false.  The
  `w$` worker emission and its cross-module declaration are then
  both naturally suppressed via the unbox-mask gate.  Aliases
  (`(-) = primSubInt`) inherit the cleared mask through the
  existing propagation.

## Test plan
- [ ] `nix develop --command zig build test --summary all` —
      **1216/1216 pass**, matching pre-change baseline.

## Not yet closed
- `error "msg"` call sites in Prelude (e.g. `intToDigit`) still
  miscompile cross-module: the IR emits
  `__rhc_apply(ptr null, ptr %charlist)` where a direct call to
  `error` is expected, causing a `__rhc_apply` SIGSEGV at runtime
  after the full split.  Independent of the changes here.  Tracked
  in #826.
## Update — actual primop split landed

The PR now also includes the content move:

- `lib/rhc-prim/RHC/Prim.hs` owns every `foreign import prim` decl.
- `lib/Prelude.hs` opens with `import RHC.Prim`.
- `build.zig` embeds `rhc_prim_source` alongside `prelude_source`
  for the REPL.
- `src/repl/session.zig` loads RHC.Prim ahead of Prelude via a new
  `loadBootModule` helper; both passes accumulate into the same
  session state so Prelude's `import RHC.Prim` resolves.
- `src/grin/translate.zig` threads `external_arities` into
  `buildArityMap` so the eta-fixup pass can chase aliases like
  `error = primError` across module boundaries.

**Net effect:**
- 1216/1216 tests pass.
- `rhc build` end-to-end works: `print 42` → `42`, every e2e and
  prelude test green.
- One open issue: the JIT REPL crashes on `42` (show wrapper) with
  `Non-exhaustive patterns in case` — a runtime fall-through in
  the Show Int instance body that only manifests under JIT, not
  AOT.  Filed for follow-up; doesn't gate the AOT split.