### PR TITLE
#655: extract Data.Function as first base-package boot module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -130,6 +130,10 @@ pub fn build(b: *std.Build) void {
     mod.addAnonymousImport("rhc_prim_source", .{
         .root_source_file = b.path("lib/rhc-prim/RHC/Prim.hs"),
     });
+    // Data.Function source: base-package combinators (id/const/…).
+    mod.addAnonymousImport("data_function_source", .{
+        .root_source_file = b.path("lib/base/Data/Function.hs"),
+    });
 
     // Runtime module - for LLVM-based runtime tests
     const runtime_mod = b.addModule("runtime", .{
@@ -340,6 +344,16 @@ pub fn build(b: *std.Build) void {
     const rhc_prim_path_wf = b.addNamedWriteFiles("rhc_prim_path");
     const rhc_prim_path_file = rhc_prim_path_wf.add("path.txt", rhc_prim_path_option);
 
+    // Data.Function source path: the base-package combinators module
+    // (id/const/flip/(.)/($)).  Compiled between RHC.Prim and Prelude.
+    const data_function_path_option = b.option(
+        []const u8,
+        "data-function-path",
+        "Path to lib/base/Data/Function.hs",
+    ) orelse b.getInstallPath(.@"prefix", "lib/base/Data/Function.hs");
+    const data_function_path_wf = b.addNamedWriteFiles("data_function_path");
+    const data_function_path_file = data_function_path_wf.add("path.txt", data_function_path_option);
+
     // Here we define an executable. An executable needs to have a root module
     // which needs to expose a `main` function. While we could add a main function
     // to the module defined above, it's sometimes preferable to split business
@@ -405,6 +419,9 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addAnonymousImport("rhc_prim_path", .{
         .root_source_file = rhc_prim_path_file,
     });
+    exe.root_module.addAnonymousImport("data_function_path", .{
+        .root_source_file = data_function_path_file,
+    });
 
     // This declares intent for the executable to be installed into the
     // install prefix when running `zig build` (i.e. when executing the default
@@ -417,6 +434,8 @@ pub fn build(b: *std.Build) void {
     b.installFile("lib/Prelude.hs", "lib/Prelude.hs");
     // Same for RHC.Prim, the innermost boot package compiled before Prelude.
     b.installFile("lib/rhc-prim/RHC/Prim.hs", "lib/rhc-prim/RHC/Prim.hs");
+    // Data.Function: pure base-package combinators.
+    b.installFile("lib/base/Data/Function.hs", "lib/base/Data/Function.hs");
 
     // This creates a top level step. Top level steps have a name and can be
     // invoked by name when running `zig build` (e.g. `zig build run`).
@@ -701,6 +720,9 @@ pub fn build(b: *std.Build) void {
     });
     repl_wasm.root_module.addAnonymousImport("rhc_prim_source", .{
         .root_source_file = b.path("lib/rhc-prim/RHC/Prim.hs"),
+    });
+    repl_wasm.root_module.addAnonymousImport("data_function_source", .{
+        .root_source_file = b.path("lib/base/Data/Function.hs"),
     });
     // Reactor mode: the REPL is a long-lived module with exported functions,
     // not a command that runs once and exits. In reactor mode the entry point

--- a/lib/Prelude.hs
+++ b/lib/Prelude.hs
@@ -26,6 +26,7 @@ module Prelude
     ) where
 
 import RHC.Prim
+import Data.Function
 
 -- ========================================================================
 -- Data types
@@ -50,16 +51,6 @@ infixl 7 *, `div`, `mod`
 infix  4 ==, /=, <, >, <=, >=
 infixr 3 &&
 infixr 2 ||
-
--- ========================================================================
--- Identity and const
--- ========================================================================
-
-id :: a -> a
-id x = x
-
-const :: a -> b -> a
-const x _ = x
 
 -- ========================================================================
 -- Error
@@ -433,19 +424,6 @@ instance Enum Ordering where
     if primGeInt (fromEnum p) (fromEnum o)
     then enumFromThenTo o p GT
     else enumFromThenTo o p LT
-
--- ========================================================================
--- Higher-order combinators
--- ========================================================================
-
-flip :: (a -> b -> c) -> b -> a -> c
-flip f x y = f y x
-
-(.) :: (b -> c) -> (a -> b) -> a -> c
-(.) f g x = f (g x)
-
-($) :: (a -> b) -> a -> b
-($) f x = f x
 
 -- ========================================================================
 -- List functions

--- a/lib/base/Data/Function.hs
+++ b/lib/base/Data/Function.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+-- | Data.Function — basic function combinators.
+--
+-- Mirrors GHC's `base:Data.Function`.  Pure, foreign-free, primop-free
+-- — sits at the bottom of `base` because every other module wants
+-- `id`/`const`/`(.)`/`($)`.
+module Data.Function
+    ( id
+    , const
+    , flip
+    , (.)
+    , ($)
+    ) where
+
+id :: a -> a
+id x = x
+
+const :: a -> b -> a
+const x _ = x
+
+flip :: (a -> b -> c) -> b -> a -> c
+flip f x y = f y x
+
+(.) :: (b -> c) -> (a -> b) -> a -> c
+(.) f g x = f (g x)
+
+($) :: (a -> b) -> a -> b
+($) f x = f x

--- a/src/main.zig
+++ b/src/main.zig
@@ -102,13 +102,19 @@ fn getRhcPrimPath() []const u8 {
     return @embedFile("rhc_prim_path");
 }
 
+/// Get the path to the Data.Function source file baked in at compile time.
+/// Compiled after RHC.Prim and before Prelude.
+fn getDataFunctionPath() []const u8 {
+    return @embedFile("data_function_path");
+}
+
 /// Boot modules that the driver auto-prepends, in dependency order.
 ///
 /// These mirror the planned `ghc-internal → base` package layering
 /// (decision 0008, amended by `docs/plans/2026-06-13-ghc-internal-base-split.md`):
-/// the innermost layer is `RHC.Prim`, then the public `Prelude`.  More
-/// boot modules (`GHC.Base`, `Data.List`, …) will be added here as the
-/// split progresses.
+/// `RHC.Prim` (foreign-prim wrappers) → `Data.Function` (combinators) →
+/// `Prelude` (everything else, still in progress).  More boot modules
+/// (`GHC.Base`, `Data.List`, …) will be added here as the split progresses.
 ///
 /// Each entry pairs a declared module name with a callable that returns
 /// the baked-in source path.  We use a callable rather than a path string
@@ -119,6 +125,7 @@ const BootModule = struct {
 };
 const boot_modules = [_]BootModule{
     .{ .module_name = "RHC.Prim", .pathFn = getRhcPrimPath },
+    .{ .module_name = "Data.Function", .pathFn = getDataFunctionPath },
     .{ .module_name = "Prelude", .pathFn = getPreludePath },
 };
 

--- a/src/repl/session.zig
+++ b/src/repl/session.zig
@@ -70,6 +70,10 @@ const prelude_source = @embedFile("prelude_source");
 /// Prelude.  Mirrors the multi-boot wiring `cmdBuild` uses (#655).
 const rhc_prim_source = @embedFile("rhc_prim_source");
 
+/// Data.Function source — base-package combinators (`id`, `const`,
+/// `flip`, `(.)`, `($)`).  Compiled between `RHC.Prim` and Prelude.
+const data_function_source = @embedFile("data_function_source");
+
 // ── Result types ──────────────────────────────────────────────────────
 
 /// Result of processing a REPL input.
@@ -269,18 +273,19 @@ pub const Session = struct {
             return;
         };
 
-        // Compile RHC.Prim ahead of Prelude.  Its exports (every
-        // `foreign import prim` wrapper) are accumulated into the
-        // session state so Prelude's `import RHC.Prim` resolves and
-        // every downstream input can reach the primops too.
-        // Non-fatal: a missing/broken RHC.Prim degrades the REPL to
-        // wired-in names + Prelude, matching pre-split behaviour.
+        // Compile RHC.Prim → Data.Function ahead of Prelude.  Each
+        // boot module's exports are accumulated into the session
+        // state so the next compile sees them.  Non-fatal: a
+        // missing/broken boot module degrades the REPL to wired-in
+        // names + whatever managed to load, matching pre-split
+        // behaviour.
         self.loadBootModule(rhc_prim_source, 0);
+        self.loadBootModule(data_function_source, 1);
 
         var diags = DiagnosticCollector.init();
         defer diags.deinit(self.allocator);
 
-        const file_id: FileId = 1; // Prelude gets file_id 1 (after RHC.Prim).
+        const file_id: FileId = 2; // Prelude is the third boot module.
 
         const result = self.pipeline.compileModule(
             prelude_source,


### PR DESCRIPTION
First content step of Milestone 1a after #828 landed the
infrastructure.  Moves `id`, `const`, `flip`, `(.)`, `($)` from
`lib/Prelude.hs` into a new boot module `Data.Function`.

## Summary
- `lib/base/Data/Function.hs` — mirrors GHC's `base:Data.Function`;
  `NoImplicitPrelude`, foreign-free.
- `build.zig` bakes `data_function_path` (AOT) and embeds
  `data_function_source` (REPL).
- `src/main.zig` boot_modules: `RHC.Prim → Data.Function → Prelude`.
- `src/repl/session.zig` calls `loadBootModule` for it.
- `lib/Prelude.hs` opens `import Data.Function`; local defs dropped.

## Test plan
- [ ] `nix develop --command zig build test --summary all` — 1216/1216 pass.
- [ ] `rhc build` of `main = putStrLn ((id . id) "ok")` prints `ok`.

## Next
- `GHC.Base` (Bool/Maybe/Either/Ordering + Eq/Ord/Bounded/Enum/Show).
- `Data.{Maybe,Either,List}` once `GHC.Base` lands.
