### PR TITLE
#832: drop primop-wrapper demand clamp, restore worker/wrapper split

### DIFF
--- a/bench/results.json
+++ b/bench/results.json
@@ -1419,6 +1419,203 @@
           "ghc_stddev_ms": 0.23181850610686594
         }
       }
+    },
+    {
+      "commit": "be9c5dcc84d38ac946a45e9694a1275423f7a68e",
+      "date": "2026-06-13T17:00:19Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "binary_trees": {
+          "rhc_mean_ms": 3.699894428571429,
+          "rhc_stddev_ms": 0.3003070683249937,
+          "rhc_immix_mean_ms": 96.89999900000001,
+          "rhc_immix_stddev_ms": 11.178300888714155,
+          "ghc_mean_ms": 1.7332768571428572,
+          "ghc_stddev_ms": 0.10999208801913672
+        },
+        "build_list": {
+          "rhc_mean_ms": 0.8190502857142856,
+          "rhc_stddev_ms": 0.0800811297221226,
+          "rhc_immix_mean_ms": 1.0635562857142857,
+          "rhc_immix_stddev_ms": 0.24825966748327197,
+          "ghc_mean_ms": 1.1847322857142857,
+          "ghc_stddev_ms": 0.06703506264563916
+        },
+        "fannkuch": {
+          "rhc_mean_ms": 1.4401658571428573,
+          "rhc_stddev_ms": 0.17848558885283386,
+          "rhc_immix_mean_ms": 2.0517545714285714,
+          "rhc_immix_stddev_ms": 0.16927733128494307,
+          "ghc_mean_ms": 0.7961668571428573,
+          "ghc_stddev_ms": 0.025048002850716903
+        },
+        "fasta": {
+          "rhc_mean_ms": 0.7607278571428573,
+          "rhc_stddev_ms": 0.05663959296413472,
+          "rhc_immix_mean_ms": 0.924335,
+          "rhc_immix_stddev_ms": 0.06678264718472905,
+          "ghc_mean_ms": 1.0971904285714285,
+          "ghc_stddev_ms": 0.05572670194457095
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 5.830275000000001,
+          "rhc_stddev_ms": 0.7579455774339388,
+          "rhc_immix_mean_ms": 6.843330285714285,
+          "rhc_immix_stddev_ms": 1.198919180110391,
+          "ghc_mean_ms": 5.5752124285714295,
+          "ghc_stddev_ms": 0.8570361171375951
+        },
+        "hanoi": {
+          "rhc_mean_ms": 84.35598285714286,
+          "rhc_stddev_ms": 11.293656494850984,
+          "rhc_immix_mean_ms": 142.18429642857146,
+          "rhc_immix_stddev_ms": 7.105296907708986,
+          "ghc_mean_ms": 99.18548271428573,
+          "ghc_stddev_ms": 10.943286892265624
+        },
+        "hof_chain": {
+          "rhc_mean_ms": 23.94247,
+          "rhc_stddev_ms": 3.7098908763054834,
+          "rhc_immix_mean_ms": 7641.562342714286,
+          "rhc_immix_stddev_ms": 419.6246064847812,
+          "ghc_mean_ms": 9.175072571428572,
+          "ghc_stddev_ms": 1.9174542228638176
+        },
+        "knucleotide": {
+          "rhc_mean_ms": 15.695423000000003,
+          "rhc_stddev_ms": 2.3759632849922157,
+          "rhc_immix_mean_ms": 23.999039428571432,
+          "rhc_immix_stddev_ms": 1.4730650793930617,
+          "ghc_mean_ms": 7.323897571428573,
+          "ghc_stddev_ms": 0.3463223994583934
+        },
+        "lazy": {
+          "rhc_mean_ms": 0.8346402857142858,
+          "rhc_stddev_ms": 0.1881901588178956,
+          "rhc_immix_mean_ms": 0.7656461428571428,
+          "rhc_immix_stddev_ms": 0.05536671383731257,
+          "ghc_mean_ms": 1.0508601428571431,
+          "ghc_stddev_ms": 0.05078037200673957
+        },
+        "mandelbrot": {
+          "rhc_mean_ms": 0.7146422857142859,
+          "rhc_stddev_ms": 0.16031787187409302,
+          "rhc_immix_mean_ms": 0.9350991428571429,
+          "rhc_immix_stddev_ms": 0.08583966211184775,
+          "ghc_mean_ms": 1.4292804285714287,
+          "ghc_stddev_ms": 0.11268758531275325
+        },
+        "matmul": {
+          "rhc_mean_ms": 136.42482257142856,
+          "rhc_stddev_ms": 11.18397749225487,
+          "rhc_immix_mean_ms": 156.61009542857144,
+          "rhc_immix_stddev_ms": 12.164603735616051,
+          "ghc_mean_ms": 54.09170742857143,
+          "ghc_stddev_ms": 11.980750377721517
+        },
+        "mergesort": {
+          "rhc_mean_ms": 0.9014692857142858,
+          "rhc_stddev_ms": 0.0843546594775382,
+          "rhc_immix_mean_ms": 0.9584372857142858,
+          "rhc_immix_stddev_ms": 0.016338249515725232,
+          "ghc_mean_ms": 1.1620524285714287,
+          "ghc_stddev_ms": 0.06289337523633984
+        },
+        "nbody_simple": {
+          "rhc_mean_ms": 16.814115142857144,
+          "rhc_stddev_ms": 2.0090258903488047,
+          "rhc_immix_mean_ms": 78.25460171428574,
+          "rhc_immix_stddev_ms": 14.403474943158574,
+          "ghc_mean_ms": 11.98940257142857,
+          "ghc_stddev_ms": 2.3548926786257063
+        },
+        "nsieve": {
+          "rhc_mean_ms": 5.558337714285715,
+          "rhc_stddev_ms": 0.13992045884801171,
+          "rhc_immix_mean_ms": 12.068621285714286,
+          "rhc_immix_stddev_ms": 0.7176915791303192,
+          "ghc_mean_ms": 3.463566285714286,
+          "ghc_stddev_ms": 0.41964442747470326
+        },
+        "pidigits": {
+          "rhc_mean_ms": 0.9039125714285714,
+          "rhc_stddev_ms": 0.08389755885375363,
+          "rhc_immix_mean_ms": 1.209466285714286,
+          "rhc_immix_stddev_ms": 0.09613644656028278,
+          "ghc_mean_ms": 1.1599000000000002,
+          "ghc_stddev_ms": 0.05199238020453898
+        },
+        "queens": {
+          "rhc_mean_ms": 503.0514931428571,
+          "rhc_stddev_ms": 20.483590873689234,
+          "rhc_immix_mean_ms": 510.2817135714286,
+          "rhc_immix_stddev_ms": 44.348656852393944,
+          "ghc_mean_ms": 116.77213414285715,
+          "ghc_stddev_ms": 4.723994115318745
+        },
+        "regex_dna": {
+          "rhc_mean_ms": 83.09859485714287,
+          "rhc_stddev_ms": 14.559295898865507,
+          "rhc_immix_mean_ms": 598.7906204285715,
+          "rhc_immix_stddev_ms": 31.317246244858378,
+          "ghc_mean_ms": 79.86913614285714,
+          "ghc_stddev_ms": 9.032826021214836
+        },
+        "reverse_complement": {
+          "rhc_mean_ms": 0.6858259999999999,
+          "rhc_stddev_ms": 0.0736863604701259,
+          "rhc_immix_mean_ms": 0.7656515714285714,
+          "rhc_immix_stddev_ms": 0.0898612183366795,
+          "ghc_mean_ms": 0.8595917142857143,
+          "ghc_stddev_ms": 0.02318940011955382
+        },
+        "rose_tree": {
+          "rhc_mean_ms": 0.6081147142857143,
+          "rhc_stddev_ms": 0.06413055659541785,
+          "rhc_immix_mean_ms": 0.5761295714285716,
+          "rhc_immix_stddev_ms": 0.02727899394440798,
+          "ghc_mean_ms": 0.9464495714285713,
+          "ghc_stddev_ms": 0.09775660349537713
+        },
+        "spectral_norm": {
+          "rhc_mean_ms": 0.7229782857142859,
+          "rhc_stddev_ms": 0.06548199126913773,
+          "rhc_immix_mean_ms": 1.2095395714285715,
+          "rhc_immix_stddev_ms": 0.06255943882915709,
+          "ghc_mean_ms": 0.9717177142857143,
+          "ghc_stddev_ms": 0.06420275323461418
+        },
+        "sum_to": {
+          "rhc_mean_ms": 0.6257718571428571,
+          "rhc_stddev_ms": 0.07258090537331098,
+          "rhc_immix_mean_ms": 1.7075537142857145,
+          "rhc_immix_stddev_ms": 0.22132158909357386,
+          "ghc_mean_ms": 1.0074112857142856,
+          "ghc_stddev_ms": 0.1106268963931079
+        },
+        "tak": {
+          "rhc_mean_ms": 0.7325672857142858,
+          "rhc_stddev_ms": 0.10686089904125252,
+          "rhc_immix_mean_ms": 0.7552741428571429,
+          "rhc_immix_stddev_ms": 0.06126492740665625,
+          "ghc_mean_ms": 1.137977,
+          "ghc_stddev_ms": 0.07474739737721085
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 2.1991032857142856,
+          "rhc_stddev_ms": 0.22166254656550521,
+          "rhc_immix_mean_ms": 2.971061142857143,
+          "rhc_immix_stddev_ms": 0.22339372880068997,
+          "ghc_mean_ms": 1.8398874285714286,
+          "ghc_stddev_ms": 0.09085811940026264
+        }
+      }
     }
   ]
 }

--- a/bench/results.json
+++ b/bench/results.json
@@ -1222,6 +1222,203 @@
           "ghc_stddev_ms": 0.050550988516546345
         }
       }
+    },
+    {
+      "commit": "f1a5e2604c262b7d6d6503af5e81610b920713a4",
+      "date": "2026-06-13T16:32:30Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "binary_trees": {
+          "rhc_mean_ms": 3.9651428571428573,
+          "rhc_stddev_ms": 0.22076008001555944,
+          "rhc_immix_mean_ms": 113.45260685714287,
+          "rhc_immix_stddev_ms": 11.092192206668852,
+          "ghc_mean_ms": 1.851423428571429,
+          "ghc_stddev_ms": 0.1038113438596784
+        },
+        "build_list": {
+          "rhc_mean_ms": 0.827775142857143,
+          "rhc_stddev_ms": 0.1434550142279553,
+          "rhc_immix_mean_ms": 0.9239982857142859,
+          "rhc_immix_stddev_ms": 0.04074467306988031,
+          "ghc_mean_ms": 1.2100881428571428,
+          "ghc_stddev_ms": 0.13201431407417982
+        },
+        "fannkuch": {
+          "rhc_mean_ms": 1.4630695714285717,
+          "rhc_stddev_ms": 0.21402689422426732,
+          "rhc_immix_mean_ms": 2.1919980000000003,
+          "rhc_immix_stddev_ms": 0.08449953517426388,
+          "ghc_mean_ms": 1.0070282857142858,
+          "ghc_stddev_ms": 0.0861913342312986
+        },
+        "fasta": {
+          "rhc_mean_ms": 0.7916304285714287,
+          "rhc_stddev_ms": 0.060700988176627314,
+          "rhc_immix_mean_ms": 1.047745142857143,
+          "rhc_immix_stddev_ms": 0.1987253369975996,
+          "ghc_mean_ms": 1.1033902857142859,
+          "ghc_stddev_ms": 0.04844623043373032
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 6.155466142857143,
+          "rhc_stddev_ms": 0.6133594673733145,
+          "rhc_immix_mean_ms": 14.316002857142855,
+          "rhc_immix_stddev_ms": 3.543392819503055,
+          "ghc_mean_ms": 5.839029714285715,
+          "ghc_stddev_ms": 1.0344389059900563
+        },
+        "hanoi": {
+          "rhc_mean_ms": 110.30562614285715,
+          "rhc_stddev_ms": 12.69575747191728,
+          "rhc_immix_mean_ms": 379.6272751428572,
+          "rhc_immix_stddev_ms": 18.796249253710815,
+          "ghc_mean_ms": 107.38281314285715,
+          "ghc_stddev_ms": 11.909833283719125
+        },
+        "hof_chain": {
+          "rhc_mean_ms": 23.825176714285714,
+          "rhc_stddev_ms": 2.7517867205444118,
+          "rhc_immix_mean_ms": 7419.455075285716,
+          "rhc_immix_stddev_ms": 76.61373586249076,
+          "ghc_mean_ms": 9.928699571428572,
+          "ghc_stddev_ms": 0.5964645981729505
+        },
+        "knucleotide": {
+          "rhc_mean_ms": 17.006554714285713,
+          "rhc_stddev_ms": 3.2792648554884836,
+          "rhc_immix_mean_ms": 41.11316671428571,
+          "rhc_immix_stddev_ms": 10.55200331224755,
+          "ghc_mean_ms": 7.555147857142858,
+          "ghc_stddev_ms": 0.3257993728669169
+        },
+        "lazy": {
+          "rhc_mean_ms": 0.8316411428571431,
+          "rhc_stddev_ms": 0.12053398865662823,
+          "rhc_immix_mean_ms": 0.8074094285714286,
+          "rhc_immix_stddev_ms": 0.03854298423776213,
+          "ghc_mean_ms": 1.1697768571428573,
+          "ghc_stddev_ms": 0.19961163031532722
+        },
+        "mandelbrot": {
+          "rhc_mean_ms": 0.9147688571428573,
+          "rhc_stddev_ms": 0.22746640225714557,
+          "rhc_immix_mean_ms": 1.3675405714285715,
+          "rhc_immix_stddev_ms": 0.02141706216903666,
+          "ghc_mean_ms": 1.4648242857142857,
+          "ghc_stddev_ms": 0.10789883347332706
+        },
+        "matmul": {
+          "rhc_mean_ms": 133.92680642857144,
+          "rhc_stddev_ms": 17.533666564788597,
+          "rhc_immix_mean_ms": 157.8274772857143,
+          "rhc_immix_stddev_ms": 13.909788930640248,
+          "ghc_mean_ms": 50.466003,
+          "ghc_stddev_ms": 8.88134100708001
+        },
+        "mergesort": {
+          "rhc_mean_ms": 0.8618472857142857,
+          "rhc_stddev_ms": 0.06281036397154609,
+          "rhc_immix_mean_ms": 1.078960142857143,
+          "rhc_immix_stddev_ms": 0.1848987343569705,
+          "ghc_mean_ms": 1.138064,
+          "ghc_stddev_ms": 0.03730718622910784
+        },
+        "nbody_simple": {
+          "rhc_mean_ms": 20.534434571428573,
+          "rhc_stddev_ms": 2.8989218022032985,
+          "rhc_immix_mean_ms": 157.77515371428572,
+          "rhc_immix_stddev_ms": 7.144345432573573,
+          "ghc_mean_ms": 12.335136285714288,
+          "ghc_stddev_ms": 2.791819061474598
+        },
+        "nsieve": {
+          "rhc_mean_ms": 4.065279142857143,
+          "rhc_stddev_ms": 0.5846914764695504,
+          "rhc_immix_mean_ms": 19.59579642857143,
+          "rhc_immix_stddev_ms": 4.04396222128442,
+          "ghc_mean_ms": 3.2908551428571435,
+          "ghc_stddev_ms": 0.41438952150781544
+        },
+        "pidigits": {
+          "rhc_mean_ms": 0.8095152857142857,
+          "rhc_stddev_ms": 0.06994573640023694,
+          "rhc_immix_mean_ms": 1.3341957142857142,
+          "rhc_immix_stddev_ms": 0.04112472258351937,
+          "ghc_mean_ms": 1.2297195714285716,
+          "ghc_stddev_ms": 0.1698151753189893
+        },
+        "queens": {
+          "rhc_mean_ms": 697.3327047142857,
+          "rhc_stddev_ms": 27.639582687557045,
+          "rhc_immix_mean_ms": 779.6341930000002,
+          "rhc_immix_stddev_ms": 51.67165313424017,
+          "ghc_mean_ms": 131.053331,
+          "ghc_stddev_ms": 10.091056801618702
+        },
+        "regex_dna": {
+          "rhc_mean_ms": 1.9949967142857141,
+          "rhc_stddev_ms": 0.1952579194234422,
+          "rhc_immix_mean_ms": 854.3526084285713,
+          "rhc_immix_stddev_ms": 46.4703920798129,
+          "ghc_mean_ms": 83.98829914285713,
+          "ghc_stddev_ms": 11.182979817649997
+        },
+        "reverse_complement": {
+          "rhc_mean_ms": 0.7688315714285714,
+          "rhc_stddev_ms": 0.16431775099367396,
+          "rhc_immix_mean_ms": 0.723277142857143,
+          "rhc_immix_stddev_ms": 0.022572344815640907,
+          "ghc_mean_ms": 1.1116738571428573,
+          "ghc_stddev_ms": 0.12345582812680896
+        },
+        "rose_tree": {
+          "rhc_mean_ms": 0.6098955714285714,
+          "rhc_stddev_ms": 0.065067195077748,
+          "rhc_immix_mean_ms": 0.5847275714285713,
+          "rhc_immix_stddev_ms": 0.02556561846084921,
+          "ghc_mean_ms": 1.0654780000000001,
+          "ghc_stddev_ms": 0.20869906948203354
+        },
+        "spectral_norm": {
+          "rhc_mean_ms": 0.7337332857142858,
+          "rhc_stddev_ms": 0.060375018690719776,
+          "rhc_immix_mean_ms": 1.9718247142857144,
+          "rhc_immix_stddev_ms": 0.02964953920785436,
+          "ghc_mean_ms": 1.0508080000000002,
+          "ghc_stddev_ms": 0.053448058209193516
+        },
+        "sum_to": {
+          "rhc_mean_ms": 0.7159902857142858,
+          "rhc_stddev_ms": 0.17584649474822664,
+          "rhc_immix_mean_ms": 3.129203285714286,
+          "rhc_immix_stddev_ms": 0.16312644353865938,
+          "ghc_mean_ms": 1.0299945714285716,
+          "ghc_stddev_ms": 0.07496513056049714
+        },
+        "tak": {
+          "rhc_mean_ms": 0.7936517142857142,
+          "rhc_stddev_ms": 0.08212599010811436,
+          "rhc_immix_mean_ms": 0.8429648571428573,
+          "rhc_immix_stddev_ms": 0.06484063516918119,
+          "ghc_mean_ms": 1.0985438571428574,
+          "ghc_stddev_ms": 0.05753393235134835
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 2.2088822857142856,
+          "rhc_stddev_ms": 0.2595688766761237,
+          "rhc_immix_mean_ms": 3.2727414285714285,
+          "rhc_immix_stddev_ms": 0.3801589865630156,
+          "ghc_mean_ms": 2.0472245714285715,
+          "ghc_stddev_ms": 0.23181850610686594
+        }
+      }
     }
   ]
 }

--- a/src/core/demand.zig
+++ b/src/core/demand.zig
@@ -303,37 +303,12 @@ fn collectFn(
     // inline field initializer would see arity 0.
     const cpr = resultIsImmediate(pair.binder.ty, params.items.len);
 
-    // Foreign-import-prim wrappers (`\x0 .. xn -> primop x0 .. xn`)
-    // are not eligible for the worker/wrapper split (#803).  Generating
-    // a `w$` worker for them produces a raw-i64 ABI symbol whose
-    // definition lives in the wrapper's defining module, but cross-
-    // module direct callers emit an external declaration with the same
-    // raw-i64 ABI; that external decl is then routed through LLVM
-    // optimisations against a different `Function`/`Module` context
-    // than the wrapper's definition, which corrupts the call.  The
-    // wrapper is a one-instruction body anyway (the primop inlines
-    // directly), so suppressing the worker costs nothing.  Tracked in:
-    // https://github.com/adinapoli/rusholme/issues/826
-    const is_primop_wrapper = isPrimopApp(cur);
-    const eff_imm_typed: u64 = if (is_primop_wrapper) 0 else imm_typed;
-    const eff_cpr: bool = if (is_primop_wrapper) false else cpr;
-
     try fns.put(alloc, unique, .{
         .params = try params.toOwnedSlice(alloc),
-        .imm_typed = eff_imm_typed,
-        .cpr = eff_cpr,
+        .imm_typed = imm_typed,
+        .cpr = cpr,
         .body = cur,
     });
-}
-
-/// Is `e` a single `App` whose head is a primop? That is the canonical
-/// shape produced by the desugarer for a `foreign import prim` wrapper
-/// body (`\x0 .. xn -> primop_canonical_name x0 .. xn`).
-fn isPrimopApp(e: *const Expr) bool {
-    var cur = e;
-    while (cur.* == .App) cur = cur.App.fn_expr;
-    if (cur.* != .Var) return false;
-    return primop.PrimOp.fromString(cur.Var.name.base) != null;
 }
 
 /// Record `let x = y` variable aliases from a function body. The pattern


### PR DESCRIPTION
Closes #832.

The demand-analysis clamp added in #826 to dodge a cross-module
ABI bug is no longer needed — the underlying LLVM-Context fix
(also in #826, commit 373070b) already resolves the original
worker-wrapper corruption.  The clamp killed the worker/wrapper
split on every primop wrapper and (via alias inheritance) on
every Prelude operator built on top, forcing every monomorphic
Int op through the boxed-pointer wrapper path.

## Summary
- `src/core/demand.zig`: drop `isPrimopApp` + its
  `imm_typed`/`cpr` clamp.
- `bench/results.json`: refresh.

## Recovery vs. pre-split (3-way bench diff in commit message)
- queens   697 → 503 ms (now -8 % vs pre)
- hanoi    110 →  84 ms (+6 % vs pre, was +39 %)
- nbody    20.5 → 16.8 ms (was +69 %, now +38 %)
- mandelbrot 0.92 → 0.71 ms
- regex_dna stabilises at ~83 ms (the prior +2 ms was a noise spike)

Short (~0.5 ms) programs still hover at +30-50 % vs pre-split.
Hyperfine flagged outlier warnings throughout — at sub-ms scale
per-process module-init overhead from four boot modules
dominates and noise is in the same band.

## Test plan
- [ ] `nix develop --command zig build test --summary all` —
      1216/1216 pass.
- [ ] No `Duplicate definition` / `Function context does not
      match Module context` regressions (verified locally via
      `RHC_VERIFY_LLVM=1`).
