### PR TITLE
#655: extract Data.{List,Maybe,Either}; slim Prelude to thin re-exporter

### DIFF
--- a/bench/results.json
+++ b/bench/results.json
@@ -1616,6 +1616,203 @@
           "ghc_stddev_ms": 0.09085811940026264
         }
       }
+    },
+    {
+      "commit": "9efa20c425bb0cbfe5d71e8c0979220b5126fff9",
+      "date": "2026-06-13T17:21:47Z",
+      "host": {
+        "os": "Linux 7.0.0-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "binary_trees": {
+          "rhc_mean_ms": 3.773409857142857,
+          "rhc_stddev_ms": 0.5873003115863947,
+          "rhc_immix_mean_ms": 99.38866585714285,
+          "rhc_immix_stddev_ms": 15.617685825806848,
+          "ghc_mean_ms": 1.7315627142857144,
+          "ghc_stddev_ms": 0.16985576455109822
+        },
+        "build_list": {
+          "rhc_mean_ms": 0.8458211428571428,
+          "rhc_stddev_ms": 0.0573070555790721,
+          "rhc_immix_mean_ms": 0.9687832857142857,
+          "rhc_immix_stddev_ms": 0.03978420087888443,
+          "ghc_mean_ms": 1.156772857142857,
+          "ghc_stddev_ms": 0.043826075584551906
+        },
+        "fannkuch": {
+          "rhc_mean_ms": 1.4550682857142858,
+          "rhc_stddev_ms": 0.10746254545455095,
+          "rhc_immix_mean_ms": 2.081650428571429,
+          "rhc_immix_stddev_ms": 0.11881188056876178,
+          "ghc_mean_ms": 1.0202021428571428,
+          "ghc_stddev_ms": 0.08759379561823728
+        },
+        "fasta": {
+          "rhc_mean_ms": 0.8823162857142859,
+          "rhc_stddev_ms": 0.10759640629952018,
+          "rhc_immix_mean_ms": 1.02637,
+          "rhc_immix_stddev_ms": 0.12243652064913751,
+          "ghc_mean_ms": 1.184531142857143,
+          "ghc_stddev_ms": 0.06243003844685819
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 5.843676714285714,
+          "rhc_stddev_ms": 0.528129523320973,
+          "rhc_immix_mean_ms": 7.151429285714285,
+          "rhc_immix_stddev_ms": 1.089323370342605,
+          "ghc_mean_ms": 5.431815571428572,
+          "ghc_stddev_ms": 1.168129076132408
+        },
+        "hanoi": {
+          "rhc_mean_ms": 87.29080400000001,
+          "rhc_stddev_ms": 9.82193605049775,
+          "rhc_immix_mean_ms": 141.58829371428575,
+          "rhc_immix_stddev_ms": 7.461748997995682,
+          "ghc_mean_ms": 102.09039214285716,
+          "ghc_stddev_ms": 7.734113995542915
+        },
+        "hof_chain": {
+          "rhc_mean_ms": 23.718733142857143,
+          "rhc_stddev_ms": 4.456186063250292,
+          "rhc_immix_mean_ms": 7343.645258714285,
+          "rhc_immix_stddev_ms": 172.35734367194866,
+          "ghc_mean_ms": 9.277399857142859,
+          "ghc_stddev_ms": 2.1442027094107674
+        },
+        "knucleotide": {
+          "rhc_mean_ms": 15.451103714285717,
+          "rhc_stddev_ms": 3.0007601159691593,
+          "rhc_immix_mean_ms": 22.868263142857142,
+          "rhc_immix_stddev_ms": 3.1397737987331413,
+          "ghc_mean_ms": 6.789327714285714,
+          "ghc_stddev_ms": 0.5627046848657871
+        },
+        "lazy": {
+          "rhc_mean_ms": 0.7307650000000001,
+          "rhc_stddev_ms": 0.08855444917299937,
+          "rhc_immix_mean_ms": 0.8396232857142858,
+          "rhc_immix_stddev_ms": 0.2144442368237132,
+          "ghc_mean_ms": 1.125440142857143,
+          "ghc_stddev_ms": 0.09302950020007736
+        },
+        "mandelbrot": {
+          "rhc_mean_ms": 0.6067278571428572,
+          "rhc_stddev_ms": 0.08640906716201446,
+          "rhc_immix_mean_ms": 0.9736385714285716,
+          "rhc_immix_stddev_ms": 0.06539247844326124,
+          "ghc_mean_ms": 1.4727138571428573,
+          "ghc_stddev_ms": 0.07753240504122254
+        },
+        "matmul": {
+          "rhc_mean_ms": 133.8928691428571,
+          "rhc_stddev_ms": 11.30367241839171,
+          "rhc_immix_mean_ms": 181.31403100000003,
+          "rhc_immix_stddev_ms": 16.28377621707227,
+          "ghc_mean_ms": 52.1985502857143,
+          "ghc_stddev_ms": 6.668086750379595
+        },
+        "mergesort": {
+          "rhc_mean_ms": 0.8966125714285715,
+          "rhc_stddev_ms": 0.06331076039889044,
+          "rhc_immix_mean_ms": 1.0459794285714286,
+          "rhc_immix_stddev_ms": 0.13334205284137626,
+          "ghc_mean_ms": 1.0214645714285715,
+          "ghc_stddev_ms": 0.057093467483467074
+        },
+        "nbody_simple": {
+          "rhc_mean_ms": 13.896196571428574,
+          "rhc_stddev_ms": 4.592223105157598,
+          "rhc_immix_mean_ms": 68.43171485714286,
+          "rhc_immix_stddev_ms": 6.351454141664215,
+          "ghc_mean_ms": 11.965592142857144,
+          "ghc_stddev_ms": 2.458149121477881
+        },
+        "nsieve": {
+          "rhc_mean_ms": 5.580838428571429,
+          "rhc_stddev_ms": 0.7339076926357648,
+          "rhc_immix_mean_ms": 10.321444285714286,
+          "rhc_immix_stddev_ms": 1.3536997591619933,
+          "ghc_mean_ms": 3.4960695714285714,
+          "ghc_stddev_ms": 0.32001751090883396
+        },
+        "pidigits": {
+          "rhc_mean_ms": 0.8298255714285715,
+          "rhc_stddev_ms": 0.05797755694478437,
+          "rhc_immix_mean_ms": 1.2112268571428573,
+          "rhc_immix_stddev_ms": 0.03959212727057648,
+          "ghc_mean_ms": 1.2521900000000001,
+          "ghc_stddev_ms": 0.057619924331779565
+        },
+        "queens": {
+          "rhc_mean_ms": 517.8826062857142,
+          "rhc_stddev_ms": 35.50534438412162,
+          "rhc_immix_mean_ms": 499.1241628571429,
+          "rhc_immix_stddev_ms": 33.682603209655035,
+          "ghc_mean_ms": 119.51187142857144,
+          "ghc_stddev_ms": 15.907618688532711
+        },
+        "regex_dna": {
+          "rhc_mean_ms": 84.60468357142858,
+          "rhc_stddev_ms": 7.476292427688893,
+          "rhc_immix_mean_ms": 558.5921162857143,
+          "rhc_immix_stddev_ms": 28.45622358666859,
+          "ghc_mean_ms": 82.50141057142856,
+          "ghc_stddev_ms": 13.802638334277795
+        },
+        "reverse_complement": {
+          "rhc_mean_ms": 0.6812158571428573,
+          "rhc_stddev_ms": 0.05437436598688936,
+          "rhc_immix_mean_ms": 0.7535095714285714,
+          "rhc_immix_stddev_ms": 0.04057659153525648,
+          "ghc_mean_ms": 1.014584142857143,
+          "ghc_stddev_ms": 0.050129613308664084
+        },
+        "rose_tree": {
+          "rhc_mean_ms": 0.677705,
+          "rhc_stddev_ms": 0.17382774384526004,
+          "rhc_immix_mean_ms": 0.6062955714285716,
+          "rhc_immix_stddev_ms": 0.0529667576877458,
+          "ghc_mean_ms": 0.9770355714285716,
+          "ghc_stddev_ms": 0.05717262083625092
+        },
+        "spectral_norm": {
+          "rhc_mean_ms": 0.77208,
+          "rhc_stddev_ms": 0.06917126608884165,
+          "rhc_immix_mean_ms": 1.156811142857143,
+          "rhc_immix_stddev_ms": 0.08196124248169288,
+          "ghc_mean_ms": 1.0921952857142858,
+          "ghc_stddev_ms": 0.07469066718074466
+        },
+        "sum_to": {
+          "rhc_mean_ms": 0.624471,
+          "rhc_stddev_ms": 0.06058775029657399,
+          "rhc_immix_mean_ms": 1.5966725714285717,
+          "rhc_immix_stddev_ms": 0.17845015414661983,
+          "ghc_mean_ms": 1.0036654285714288,
+          "ghc_stddev_ms": 0.17183782855050397
+        },
+        "tak": {
+          "rhc_mean_ms": 0.7716477142857143,
+          "rhc_stddev_ms": 0.18335246065680375,
+          "rhc_immix_mean_ms": 0.7892764285714285,
+          "rhc_immix_stddev_ms": 0.10090362151389339,
+          "ghc_mean_ms": 1.1067308571428573,
+          "ghc_stddev_ms": 0.148543700966448
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 2.0964738571428567,
+          "rhc_stddev_ms": 0.14423241417405516,
+          "rhc_immix_mean_ms": 3.021630285714286,
+          "rhc_immix_stddev_ms": 0.15715340539285627,
+          "ghc_mean_ms": 1.6553454285714286,
+          "ghc_stddev_ms": 0.08679910734536606
+        }
+      }
     }
   ]
 }

--- a/build.zig
+++ b/build.zig
@@ -138,6 +138,15 @@ pub fn build(b: *std.Build) void {
     mod.addAnonymousImport("ghc_base_source", .{
         .root_source_file = b.path("lib/ghc-internal/GHC/Base.hs"),
     });
+    mod.addAnonymousImport("data_list_source", .{
+        .root_source_file = b.path("lib/base/Data/List.hs"),
+    });
+    mod.addAnonymousImport("data_maybe_source", .{
+        .root_source_file = b.path("lib/base/Data/Maybe.hs"),
+    });
+    mod.addAnonymousImport("data_either_source", .{
+        .root_source_file = b.path("lib/base/Data/Either.hs"),
+    });
 
     // Runtime module - for LLVM-based runtime tests
     const runtime_mod = b.addModule("runtime", .{
@@ -370,6 +379,33 @@ pub fn build(b: *std.Build) void {
     const ghc_base_path_wf = b.addNamedWriteFiles("ghc_base_path");
     const ghc_base_path_file = ghc_base_path_wf.add("path.txt", ghc_base_path_option);
 
+    // Data.List source path.
+    const data_list_path_option = b.option(
+        []const u8,
+        "data-list-path",
+        "Path to lib/base/Data/List.hs",
+    ) orelse b.getInstallPath(.@"prefix", "lib/base/Data/List.hs");
+    const data_list_path_wf = b.addNamedWriteFiles("data_list_path");
+    const data_list_path_file = data_list_path_wf.add("path.txt", data_list_path_option);
+
+    // Data.Maybe source path.
+    const data_maybe_path_option = b.option(
+        []const u8,
+        "data-maybe-path",
+        "Path to lib/base/Data/Maybe.hs",
+    ) orelse b.getInstallPath(.@"prefix", "lib/base/Data/Maybe.hs");
+    const data_maybe_path_wf = b.addNamedWriteFiles("data_maybe_path");
+    const data_maybe_path_file = data_maybe_path_wf.add("path.txt", data_maybe_path_option);
+
+    // Data.Either source path.
+    const data_either_path_option = b.option(
+        []const u8,
+        "data-either-path",
+        "Path to lib/base/Data/Either.hs",
+    ) orelse b.getInstallPath(.@"prefix", "lib/base/Data/Either.hs");
+    const data_either_path_wf = b.addNamedWriteFiles("data_either_path");
+    const data_either_path_file = data_either_path_wf.add("path.txt", data_either_path_option);
+
     // Here we define an executable. An executable needs to have a root module
     // which needs to expose a `main` function. While we could add a main function
     // to the module defined above, it's sometimes preferable to split business
@@ -441,6 +477,15 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addAnonymousImport("ghc_base_path", .{
         .root_source_file = ghc_base_path_file,
     });
+    exe.root_module.addAnonymousImport("data_list_path", .{
+        .root_source_file = data_list_path_file,
+    });
+    exe.root_module.addAnonymousImport("data_maybe_path", .{
+        .root_source_file = data_maybe_path_file,
+    });
+    exe.root_module.addAnonymousImport("data_either_path", .{
+        .root_source_file = data_either_path_file,
+    });
 
     // This declares intent for the executable to be installed into the
     // install prefix when running `zig build` (i.e. when executing the default
@@ -457,6 +502,10 @@ pub fn build(b: *std.Build) void {
     b.installFile("lib/base/Data/Function.hs", "lib/base/Data/Function.hs");
     // GHC.Base: compiler-magic types + core classes.
     b.installFile("lib/ghc-internal/GHC/Base.hs", "lib/ghc-internal/GHC/Base.hs");
+    // base/Data.{List,Maybe,Either}: pure consumer combinators.
+    b.installFile("lib/base/Data/List.hs", "lib/base/Data/List.hs");
+    b.installFile("lib/base/Data/Maybe.hs", "lib/base/Data/Maybe.hs");
+    b.installFile("lib/base/Data/Either.hs", "lib/base/Data/Either.hs");
 
     // This creates a top level step. Top level steps have a name and can be
     // invoked by name when running `zig build` (e.g. `zig build run`).
@@ -747,6 +796,15 @@ pub fn build(b: *std.Build) void {
     });
     repl_wasm.root_module.addAnonymousImport("ghc_base_source", .{
         .root_source_file = b.path("lib/ghc-internal/GHC/Base.hs"),
+    });
+    repl_wasm.root_module.addAnonymousImport("data_list_source", .{
+        .root_source_file = b.path("lib/base/Data/List.hs"),
+    });
+    repl_wasm.root_module.addAnonymousImport("data_maybe_source", .{
+        .root_source_file = b.path("lib/base/Data/Maybe.hs"),
+    });
+    repl_wasm.root_module.addAnonymousImport("data_either_source", .{
+        .root_source_file = b.path("lib/base/Data/Either.hs"),
     });
     // Reactor mode: the REPL is a long-lived module with exported functions,
     // not a command that runs once and exits. In reactor mode the entry point

--- a/lib/Prelude.hs
+++ b/lib/Prelude.hs
@@ -1,6 +1,14 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+-- | The public Prelude.
+--
+-- Re-exports the layered boot stack:
+--
+--   RHC.Prim → GHC.Base → Data.{Function,List,Maybe,Either} → Prelude
+--
+-- Local definitions are limited to glue that ties the layers together
+-- (`print = putStrLn . show`).
 module Prelude
-    ( -- Re-exported from GHC.Base
+    ( -- GHC.Base
       Bool(..), Maybe(..), Either(..), Ordering(..)
     , String
     , not, (&&), (||), otherwise
@@ -17,118 +25,26 @@ module Prelude
     , Show(..), showString, showLitChar, showListWith, showListTail
     , intToDigit
     , enumFrom, enumFromTo, enumFromThen, enumFromThenTo
-    -- Re-exported from Data.Function
+    -- Data.Function
     , id, const, flip, (.), ($)
-    -- Defined locally
+    -- Data.List
     , map, filter, (++), head, tail, null, length
-    , foldr, foldl, concat, take, drop
-    , maybe, fromMaybe, either
-    , reverse
-    , print
+    , foldr, foldl, concat, take, drop, reverse
     , sum, product, replicate
+    -- Data.Maybe
+    , maybe, fromMaybe
+    -- Data.Either
+    , either
+    -- Defined locally
+    , print
     ) where
 
-import RHC.Prim
-import Data.Function
 import GHC.Base
+import Data.Function
+import Data.List
+import Data.Maybe
+import Data.Either
 
--- ========================================================================
 -- print depends on Show (in GHC.Base) and putStrLn (in GHC.Base).
--- ========================================================================
-
 print :: Show a => a -> IO ()
 print x = putStrLn (show x)
-
--- ========================================================================
--- List functions
--- ========================================================================
-
-map :: (a -> b) -> [a] -> [b]
-map f []     = []
-map f (x:xs) = f x : map f xs
-
-filter :: (a -> Bool) -> [a] -> [a]
-filter p []     = []
-filter p (x:xs) = case p x of
-    True  -> x : filter p xs
-    False -> filter p xs
-
-(++) :: [a] -> [a] -> [a]
-(++) []     ys = ys
-(++) (x:xs) ys = x : (++) xs ys
-
-head :: [a] -> a
-head (x:xs) = x
-head []     = error "Prelude.head: empty list"
-
-tail :: [a] -> [a]
-tail (x:xs) = xs
-tail []     = error "Prelude.tail: empty list"
-
-null :: [a] -> Bool
-null []    = True
-null (x:xs) = False
-
-length :: [a] -> Int
-length []     = 0
-length (x:xs) = 1 + length xs
-
-foldr :: (a -> b -> b) -> b -> [a] -> b
-foldr f z []     = z
-foldr f z (x:xs) = f x (foldr f z xs)
-
-foldl :: (b -> a -> b) -> b -> [a] -> b
-foldl f z []     = z
-foldl f z (x:xs) = foldl f (f z x) xs
-
-concat :: [[a]] -> [a]
-concat []     = []
-concat (x:xs) = (++) x (concat xs)
-
-take :: Int -> [a] -> [a]
-take n []     = []
-take n (x:xs) = case n <= 0 of
-    True  -> []
-    False -> x : take (n - 1) xs
-
-drop :: Int -> [a] -> [a]
-drop n []     = []
-drop n (x:xs) = case n <= 0 of
-    True  -> x : xs
-    False -> drop (n - 1) xs
-
--- ========================================================================
--- More numeric and list utilities
--- ========================================================================
-
-sum :: [Int] -> Int
-sum []     = 0
-sum (x:xs) = x + sum xs
-
-product :: [Int] -> Int
-product []     = 1
-product (x:xs) = x * product xs
-
-replicate :: Int -> a -> [a]
-replicate n x = case n <= 0 of
-    True  -> []
-    False -> x : replicate (n - 1) x
-
-reverse :: [a] -> [a]
-reverse = foldl (flip (:)) []
-
--- ========================================================================
--- Maybe / Either
--- ========================================================================
-
-maybe :: b -> (a -> b) -> Maybe a -> b
-maybe n f Nothing  = n
-maybe n f (Just x) = f x
-
-fromMaybe :: a -> Maybe a -> a
-fromMaybe d Nothing  = d
-fromMaybe d (Just x) = x
-
-either :: (a -> c) -> (b -> c) -> Either a b -> c
-either f g (Left x)  = f x
-either f g (Right y) = g y

--- a/lib/base/Data/Either.hs
+++ b/lib/base/Data/Either.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+-- | Data.Either — Either combinator.
+--
+-- Mirrors GHC's `base:Data.Either`.  `Either` itself lives in GHC.Base.
+module Data.Either
+    ( either
+    ) where
+
+import GHC.Base
+
+either :: (a -> c) -> (b -> c) -> Either a b -> c
+either f g (Left x)  = f x
+either f g (Right y) = g y

--- a/lib/base/Data/List.hs
+++ b/lib/base/Data/List.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+-- | Data.List — pure list combinators.
+--
+-- Mirrors GHC's `base:Data.List`.  Imports from GHC.Base
+-- (Bool/Int/Show, the comparison operators) and RHC.Prim is
+-- transitive via GHC.Base.  No primops, no foreign decls.
+module Data.List
+    ( map, filter, (++), head, tail, null, length
+    , foldr, foldl, concat, take, drop
+    , reverse
+    , sum, product, replicate
+    ) where
+
+import GHC.Base
+import Data.Function
+
+infixr 5 ++
+
+map :: (a -> b) -> [a] -> [b]
+map f []     = []
+map f (x:xs) = f x : map f xs
+
+filter :: (a -> Bool) -> [a] -> [a]
+filter p []     = []
+filter p (x:xs) = case p x of
+    True  -> x : filter p xs
+    False -> filter p xs
+
+(++) :: [a] -> [a] -> [a]
+(++) []     ys = ys
+(++) (x:xs) ys = x : (++) xs ys
+
+head :: [a] -> a
+head (x:xs) = x
+head []     = error "Data.List.head: empty list"
+
+tail :: [a] -> [a]
+tail (x:xs) = xs
+tail []     = error "Data.List.tail: empty list"
+
+null :: [a] -> Bool
+null []    = True
+null (x:xs) = False
+
+length :: [a] -> Int
+length []     = 0
+length (x:xs) = 1 + length xs
+
+foldr :: (a -> b -> b) -> b -> [a] -> b
+foldr f z []     = z
+foldr f z (x:xs) = f x (foldr f z xs)
+
+foldl :: (b -> a -> b) -> b -> [a] -> b
+foldl f z []     = z
+foldl f z (x:xs) = foldl f (f z x) xs
+
+concat :: [[a]] -> [a]
+concat []     = []
+concat (x:xs) = (++) x (concat xs)
+
+take :: Int -> [a] -> [a]
+take n []     = []
+take n (x:xs) = case n <= 0 of
+    True  -> []
+    False -> x : take (n - 1) xs
+
+drop :: Int -> [a] -> [a]
+drop n []     = []
+drop n (x:xs) = case n <= 0 of
+    True  -> x : xs
+    False -> drop (n - 1) xs
+
+sum :: [Int] -> Int
+sum []     = 0
+sum (x:xs) = x + sum xs
+
+product :: [Int] -> Int
+product []     = 1
+product (x:xs) = x * product xs
+
+replicate :: Int -> a -> [a]
+replicate n x = case n <= 0 of
+    True  -> []
+    False -> x : replicate (n - 1) x
+
+reverse :: [a] -> [a]
+reverse = foldl (flip (:)) []

--- a/lib/base/Data/Maybe.hs
+++ b/lib/base/Data/Maybe.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+-- | Data.Maybe — Maybe combinators.
+--
+-- Mirrors GHC's `base:Data.Maybe`.  `Maybe` itself lives in GHC.Base
+-- (it's a wired-in compiler-magic type); this module adds the
+-- consumer functions.
+module Data.Maybe
+    ( maybe
+    , fromMaybe
+    ) where
+
+import GHC.Base
+
+maybe :: b -> (a -> b) -> Maybe a -> b
+maybe n f Nothing  = n
+maybe n f (Just x) = f x
+
+fromMaybe :: a -> Maybe a -> a
+fromMaybe d Nothing  = d
+fromMaybe d (Just x) = x

--- a/src/main.zig
+++ b/src/main.zig
@@ -114,13 +114,24 @@ fn getGhcBasePath() []const u8 {
     return @embedFile("ghc_base_path");
 }
 
+fn getDataListPath() []const u8 {
+    return @embedFile("data_list_path");
+}
+
+fn getDataMaybePath() []const u8 {
+    return @embedFile("data_maybe_path");
+}
+
+fn getDataEitherPath() []const u8 {
+    return @embedFile("data_either_path");
+}
+
 /// Boot modules that the driver auto-prepends, in dependency order.
 ///
 /// Mirror the layered Prelude per `docs/plans/2026-06-13-ghc-internal-base-split.md`:
-/// `RHC.Prim` (foreign-prim wrappers) → `Data.Function` (combinators)
-/// → `GHC.Base` (compiler-magic types + core classes) → `Prelude`
-/// (re-export shell + list/Maybe/Either helpers).  More boot modules
-/// (`Data.List`, …) follow.
+///
+///   RHC.Prim → Data.Function → GHC.Base
+///     → Data.{List, Maybe, Either} → Prelude
 ///
 /// Each entry pairs a declared module name with a callable that returns
 /// the baked-in source path.  We use a callable rather than a path string
@@ -133,6 +144,9 @@ const boot_modules = [_]BootModule{
     .{ .module_name = "RHC.Prim", .pathFn = getRhcPrimPath },
     .{ .module_name = "Data.Function", .pathFn = getDataFunctionPath },
     .{ .module_name = "GHC.Base", .pathFn = getGhcBasePath },
+    .{ .module_name = "Data.List", .pathFn = getDataListPath },
+    .{ .module_name = "Data.Maybe", .pathFn = getDataMaybePath },
+    .{ .module_name = "Data.Either", .pathFn = getDataEitherPath },
     .{ .module_name = "Prelude", .pathFn = getPreludePath },
 };
 

--- a/src/repl/session.zig
+++ b/src/repl/session.zig
@@ -79,6 +79,10 @@ const data_function_source = @embedFile("data_function_source");
 /// between `Data.Function` and Prelude.
 const ghc_base_source = @embedFile("ghc_base_source");
 
+const data_list_source = @embedFile("data_list_source");
+const data_maybe_source = @embedFile("data_maybe_source");
+const data_either_source = @embedFile("data_either_source");
+
 // ── Result types ──────────────────────────────────────────────────────
 
 /// Result of processing a REPL input.
@@ -287,11 +291,14 @@ pub const Session = struct {
         self.loadBootModule(rhc_prim_source, 0);
         self.loadBootModule(data_function_source, 1);
         self.loadBootModule(ghc_base_source, 2);
+        self.loadBootModule(data_list_source, 3);
+        self.loadBootModule(data_maybe_source, 4);
+        self.loadBootModule(data_either_source, 5);
 
         var diags = DiagnosticCollector.init();
         defer diags.deinit(self.allocator);
 
-        const file_id: FileId = 3; // Prelude is the fourth boot module.
+        const file_id: FileId = 6; // Prelude is the seventh boot module.
 
         const result = self.pipeline.compileModule(
             prelude_source,


### PR DESCRIPTION
Closes Milestone 1a's content layer (`#655`).  Moves the remaining
pure combinators out of `lib/Prelude.hs` into the `base` package.

## Summary
- New: `lib/base/Data/List.hs`, `lib/base/Data/Maybe.hs`,
  `lib/base/Data/Either.hs`.
- `lib/Prelude.hs` shrinks to ~50 lines: explicit re-export list +
  `print = putStrLn . show` (glue between Show and putStrLn in
  GHC.Base).
- Driver/REPL wiring extends `boot_modules` to the full chain:
  RHC.Prim → Data.Function → GHC.Base → Data.List → Data.Maybe →
  Data.Either → Prelude.

## Test plan
- [ ] `nix develop --command zig build test --summary all` —
      1216/1216 pass.
- [ ] Bench refresh: no ≥10 ms program above +10 % regression
      threshold.  Several long-running programs slightly improved
      (nbody -17 %, lazy -12 %, mandelbrot -15 %).
