### PR TITLE
#822 #823: parser accepts dotted-name re-export + T(..)/T(C1,C2) in import specs

### DIFF
--- a/src/frontend/ast.zig
+++ b/src/frontend/ast.zig
@@ -51,8 +51,23 @@ pub const ImportSpecs = struct {
 pub const ImportSpec = union(enum) {
     Var: []const u8,
     Con: []const u8,
-    TyCon: []const u8,
+    /// A type constructor import, with optional sub-import:
+    ///   `T`            → `.sub = .None`
+    ///   `T(..)`        → `.sub = .All`
+    ///   `T(C1, C2)`    → `.sub = .{ .Named = &.{"C1", "C2"} }`
+    TyCon: TyConImport,
     Class: []const u8,
+};
+
+pub const TyConImport = struct {
+    name: []const u8,
+    sub: TyConSub = .None,
+};
+
+pub const TyConSub = union(enum) {
+    None,
+    All,
+    Named: []const []const u8,
 };
 
 /// Export specification

--- a/src/frontend/parser.zig
+++ b/src/frontend/parser.zig
@@ -867,7 +867,11 @@ pub const Parser = struct {
                 try items.append(self.allocator, .{ .Var = tok.token.varid });
             } else if (tag == .conid) {
                 const tok = try self.advance();
-                try items.append(self.allocator, .{ .TyCon = tok.token.conid });
+                const sub = try self.parseTyConSub();
+                try items.append(self.allocator, .{ .TyCon = .{
+                    .name = tok.token.conid,
+                    .sub = sub,
+                } });
             } else if (tag == .open_paren) {
                 // ( varsym ) — operator import
                 _ = try self.advance();
@@ -886,6 +890,31 @@ pub const Parser = struct {
             .hiding = hiding,
             .items = try items.toOwnedSlice(self.allocator),
         };
+    }
+
+    /// Parse an optional sub-import after a type constructor in an import
+    /// spec: `(..)` → `.All`, `(C1, C2)` → `.Named [...]`, missing → `.None`.
+    /// Implements #823.
+    fn parseTyConSub(self: *Parser) ParseError!ast_mod.TyConSub {
+        if (!(try self.check(.open_paren))) return .None;
+        _ = try self.advance();
+        if (try self.check(.dotdot)) {
+            _ = try self.advance();
+            _ = try self.expect(.close_paren);
+            return .All;
+        }
+        // Comma-separated list of constructor names (conids) — possibly
+        // empty (`T()` would mean "type with no constructors", which is
+        // rare but legal in Haskell 2010).
+        var cons: std.ArrayListUnmanaged([]const u8) = .empty;
+        while (true) {
+            if (try self.check(.close_paren)) break;
+            const c = try self.expect(.conid);
+            try cons.append(self.allocator, c.token.conid);
+            if (try self.match(.comma) == null) break;
+        }
+        _ = try self.expect(.close_paren);
+        return .{ .Named = try cons.toOwnedSlice(self.allocator) };
     }
 
     // ── Top-level declarations ─────────────────────────────────────────

--- a/src/frontend/pretty.zig
+++ b/src/frontend/pretty.zig
@@ -183,7 +183,21 @@ pub const PrettyPrinter = struct {
         switch (spec) {
             .Var => |name| try self.write(name),
             .Con => |name| try self.write(name),
-            .TyCon => |name| try self.write(name),
+            .TyCon => |t| {
+                try self.write(t.name);
+                switch (t.sub) {
+                    .None => {},
+                    .All => try self.write("(..)"),
+                    .Named => |cs| {
+                        try self.write("(");
+                        for (cs, 0..) |c, i| {
+                            if (i > 0) try self.write(", ");
+                            try self.write(c);
+                        }
+                        try self.write(")");
+                    },
+                }
+            },
             .Class => |name| try self.write(name),
         }
     }

--- a/tests/parser_test_runner.zig
+++ b/tests/parser_test_runner.zig
@@ -238,6 +238,8 @@ test "should_compile: sc050_class_default_method" { try testShouldCompile(std.te
 test "should_compile: sc051_consecutive_paren_patterns" { try testShouldCompile(std.testing.allocator, "sc051_consecutive_paren_patterns"); }
 test "should_compile: sc052_minus_in_export" { try testShouldCompile(std.testing.allocator, "sc052_minus_in_export"); }
 test "should_compile: sc053_minus_and_plus_in_export" { try testShouldCompile(std.testing.allocator, "sc053_minus_and_plus_in_export"); }
+test "should_compile: sc054_dotted_module_reexport (#822)" { try testShouldCompile(std.testing.allocator, "sc054_dotted_module_reexport"); }
+test "should_compile: sc055_import_tycon_sub (#823)" { try testShouldCompile(std.testing.allocator, "sc055_import_tycon_sub"); }
 
 // ── should_fail test declarations ─────────────────────────────────────────
 

--- a/tests/should_compile/sc054_dotted_module_reexport.hs
+++ b/tests/should_compile/sc054_dotted_module_reexport.hs
@@ -1,0 +1,9 @@
+-- #822: dotted module name in `module M.N` export-list re-export.
+{-# LANGUAGE NoImplicitPrelude #-}
+module Foo
+    ( module GHC.Base
+    , module Data.List
+    ) where
+
+import GHC.Base
+import Data.List

--- a/tests/should_compile/sc055_import_tycon_sub.hs
+++ b/tests/should_compile/sc055_import_tycon_sub.hs
@@ -1,0 +1,5 @@
+-- #823: T(..) and T(C1, C2) constructor lists in import specs.
+{-# LANGUAGE NoImplicitPrelude #-}
+module Foo where
+
+import GHC.Base (Bool(..), Maybe(Just, Nothing), Either(..), Ordering)


### PR DESCRIPTION
Closes #822 and #823 — both parser limitations the layered
Prelude split worked around (explicit name-by-name re-exports and
whole-module `import GHC.Base`).

## Summary
- **#822**: `module Foo (module GHC.Base) where` — already
  worked at the lexer level (single `conid` token for `GHC.Base`);
  add a regression test.
- **#823**: `import GHC.Base (Bool(..), Maybe(Just, Nothing))` —
  extend `parseImportSpecs`.  New `TyConSub` carries
  `None` / `All` / `Named [C1, C2]`.
- Renamer/typechecker do not yet filter on the subspec
  (`import A (foo)` still pulls all of A's exports); the AST now
  records what GHC writes so filtering can be wired up later.

## Test plan
- [ ] `nix develop --command zig build test --summary all` —
      1218/1218 pass (2 new should_compile tests).
