### PR TITLE
#837 + #839: rhc build flags, cached-iface fix, stage-2 bootstrap, default_package_db + cached .bc link plumbing

### DIFF
--- a/bench/results.json
+++ b/bench/results.json
@@ -1813,6 +1813,203 @@
           "ghc_stddev_ms": 0.08679910734536606
         }
       }
+    },
+    {
+      "commit": "92667ec4efd0b572d65e2415ed3a72f18915d8b8",
+      "date": "2026-06-14T07:02:08Z",
+      "host": {
+        "os": "Linux 7.0.11-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "binary_trees": {
+          "rhc_mean_ms": 3.664678428571429,
+          "rhc_stddev_ms": 0.23551976183246084,
+          "rhc_immix_mean_ms": 98.783327,
+          "rhc_immix_stddev_ms": 9.47836939399862,
+          "ghc_mean_ms": 1.8324754285714289,
+          "ghc_stddev_ms": 0.2303089399161173
+        },
+        "build_list": {
+          "rhc_mean_ms": 0.797463,
+          "rhc_stddev_ms": 0.0665317783919835,
+          "rhc_immix_mean_ms": 0.9809400000000003,
+          "rhc_immix_stddev_ms": 0.11628261229292483,
+          "ghc_mean_ms": 1.2003741428571428,
+          "ghc_stddev_ms": 0.10859352598632593
+        },
+        "fannkuch": {
+          "rhc_mean_ms": 1.376713,
+          "rhc_stddev_ms": 0.11379394995341363,
+          "rhc_immix_mean_ms": 2.126424,
+          "rhc_immix_stddev_ms": 0.2587027428781278,
+          "ghc_mean_ms": 0.9559757142857143,
+          "ghc_stddev_ms": 0.0650219342599462
+        },
+        "fasta": {
+          "rhc_mean_ms": 0.808715,
+          "rhc_stddev_ms": 0.1108444088441091,
+          "rhc_immix_mean_ms": 0.8557848571428573,
+          "rhc_immix_stddev_ms": 0.08257041162835624,
+          "ghc_mean_ms": 1.1111805714285716,
+          "ghc_stddev_ms": 0.09581930252452123
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 5.946751142857143,
+          "rhc_stddev_ms": 0.3147992932464686,
+          "rhc_immix_mean_ms": 6.283489428571429,
+          "rhc_immix_stddev_ms": 1.5788282587836946,
+          "ghc_mean_ms": 6.029342000000001,
+          "ghc_stddev_ms": 0.2892546398129741
+        },
+        "hanoi": {
+          "rhc_mean_ms": 84.91764300000001,
+          "rhc_stddev_ms": 12.377447009870277,
+          "rhc_immix_mean_ms": 145.4096562857143,
+          "rhc_immix_stddev_ms": 8.416191698665829,
+          "ghc_mean_ms": 96.46754414285716,
+          "ghc_stddev_ms": 8.20438552986912
+        },
+        "hof_chain": {
+          "rhc_mean_ms": 25.13584285714286,
+          "rhc_stddev_ms": 3.311822057111081,
+          "rhc_immix_mean_ms": 8419.773877428572,
+          "rhc_immix_stddev_ms": 465.8268805921976,
+          "ghc_mean_ms": 9.437584714285714,
+          "ghc_stddev_ms": 1.6548266771370868
+        },
+        "knucleotide": {
+          "rhc_mean_ms": 16.384583714285718,
+          "rhc_stddev_ms": 2.462672659149656,
+          "rhc_immix_mean_ms": 23.90379371428571,
+          "rhc_immix_stddev_ms": 1.8241323726941816,
+          "ghc_mean_ms": 6.888853000000001,
+          "ghc_stddev_ms": 0.8965641897144527
+        },
+        "lazy": {
+          "rhc_mean_ms": 0.7731897142857144,
+          "rhc_stddev_ms": 0.10902040419070536,
+          "rhc_immix_mean_ms": 0.7084907142857142,
+          "rhc_immix_stddev_ms": 0.02027463066424216,
+          "ghc_mean_ms": 0.9907312857142859,
+          "ghc_stddev_ms": 0.03858842425181542
+        },
+        "mandelbrot": {
+          "rhc_mean_ms": 0.65223,
+          "rhc_stddev_ms": 0.052548260088544636,
+          "rhc_immix_mean_ms": 0.9677835714285716,
+          "rhc_immix_stddev_ms": 0.10533240541235343,
+          "ghc_mean_ms": 1.2343894285714287,
+          "ghc_stddev_ms": 0.04422491727844967
+        },
+        "matmul": {
+          "rhc_mean_ms": 133.62750100000002,
+          "rhc_stddev_ms": 9.798184394797977,
+          "rhc_immix_mean_ms": 172.03914314285717,
+          "rhc_immix_stddev_ms": 14.03067027869534,
+          "ghc_mean_ms": 53.848227285714295,
+          "ghc_stddev_ms": 8.025462102209207
+        },
+        "mergesort": {
+          "rhc_mean_ms": 0.8734088571428572,
+          "rhc_stddev_ms": 0.22018926821822224,
+          "rhc_immix_mean_ms": 0.9301765714285715,
+          "rhc_immix_stddev_ms": 0.0175491832369975,
+          "ghc_mean_ms": 1.1550552857142857,
+          "ghc_stddev_ms": 0.09126171174469297
+        },
+        "nbody_simple": {
+          "rhc_mean_ms": 15.499021857142859,
+          "rhc_stddev_ms": 3.6577163807688096,
+          "rhc_immix_mean_ms": 69.484272,
+          "rhc_immix_stddev_ms": 10.879920387082695,
+          "ghc_mean_ms": 12.260709714285714,
+          "ghc_stddev_ms": 2.9664923517961252
+        },
+        "nsieve": {
+          "rhc_mean_ms": 5.559996142857143,
+          "rhc_stddev_ms": 0.5480486769206513,
+          "rhc_immix_mean_ms": 10.34378557142857,
+          "rhc_immix_stddev_ms": 1.7911668363344286,
+          "ghc_mean_ms": 3.304951142857143,
+          "ghc_stddev_ms": 0.38454331398228236
+        },
+        "pidigits": {
+          "rhc_mean_ms": 0.8013932857142857,
+          "rhc_stddev_ms": 0.05669875155802016,
+          "rhc_immix_mean_ms": 1.154368,
+          "rhc_immix_stddev_ms": 0.08325756129025161,
+          "ghc_mean_ms": 1.1700242857142857,
+          "ghc_stddev_ms": 0.09013314825433587
+        },
+        "queens": {
+          "rhc_mean_ms": 500.8715778571429,
+          "rhc_stddev_ms": 27.651370499328298,
+          "rhc_immix_mean_ms": 469.60263114285715,
+          "rhc_immix_stddev_ms": 35.12480352017095,
+          "ghc_mean_ms": 112.66598257142857,
+          "ghc_stddev_ms": 12.163535717293415
+        },
+        "regex_dna": {
+          "rhc_mean_ms": 86.61866457142857,
+          "rhc_stddev_ms": 15.865582065321505,
+          "rhc_immix_mean_ms": 530.7273221428572,
+          "rhc_immix_stddev_ms": 16.53231670333531,
+          "ghc_mean_ms": 84.60484914285715,
+          "ghc_stddev_ms": 8.331565458658783
+        },
+        "reverse_complement": {
+          "rhc_mean_ms": 0.7141377142857143,
+          "rhc_stddev_ms": 0.16302901688934018,
+          "rhc_immix_mean_ms": 0.6882127142857144,
+          "rhc_immix_stddev_ms": 0.028550987570276715,
+          "ghc_mean_ms": 1.0067794285714287,
+          "ghc_stddev_ms": 0.04471088882236308
+        },
+        "rose_tree": {
+          "rhc_mean_ms": 0.6257684285714287,
+          "rhc_stddev_ms": 0.16987295132819813,
+          "rhc_immix_mean_ms": 0.6313934285714287,
+          "rhc_immix_stddev_ms": 0.08499774368938104,
+          "ghc_mean_ms": 0.9756720000000001,
+          "ghc_stddev_ms": 0.09387214156322772
+        },
+        "spectral_norm": {
+          "rhc_mean_ms": 0.7237348571428572,
+          "rhc_stddev_ms": 0.0674150916818793,
+          "rhc_immix_mean_ms": 1.1227664285714287,
+          "rhc_immix_stddev_ms": 0.18783889005018561,
+          "ghc_mean_ms": 1.0558064285714286,
+          "ghc_stddev_ms": 0.07350726437991718
+        },
+        "sum_to": {
+          "rhc_mean_ms": 0.5889054285714287,
+          "rhc_stddev_ms": 0.024404828974727805,
+          "rhc_immix_mean_ms": 1.6064775714285715,
+          "rhc_immix_stddev_ms": 0.25007676103006,
+          "ghc_mean_ms": 1.0542735714285711,
+          "ghc_stddev_ms": 0.08049231475293601
+        },
+        "tak": {
+          "rhc_mean_ms": 0.7035652857142859,
+          "rhc_stddev_ms": 0.08259662501925505,
+          "rhc_immix_mean_ms": 0.7507042857142858,
+          "rhc_immix_stddev_ms": 0.05191833098792208,
+          "ghc_mean_ms": 1.1417177142857144,
+          "ghc_stddev_ms": 0.10051223490984283
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 2.2822561428571433,
+          "rhc_stddev_ms": 0.24117262973537473,
+          "rhc_immix_mean_ms": 3.1459645714285718,
+          "rhc_immix_stddev_ms": 0.3345334817153868,
+          "ghc_mean_ms": 1.756225714285714,
+          "ghc_stddev_ms": 0.0667157115770948
+        }
+      }
     }
   ]
 }

--- a/build.zig
+++ b/build.zig
@@ -147,6 +147,9 @@ pub fn build(b: *std.Build) void {
     mod.addAnonymousImport("data_either_source", .{
         .root_source_file = b.path("lib/base/Data/Either.hs"),
     });
+    mod.addAnonymousImport("data_char_source", .{
+        .root_source_file = b.path("lib/base/Data/Char.hs"),
+    });
 
     // Runtime module - for LLVM-based runtime tests
     const runtime_mod = b.addModule("runtime", .{
@@ -406,6 +409,15 @@ pub fn build(b: *std.Build) void {
     const data_either_path_wf = b.addNamedWriteFiles("data_either_path");
     const data_either_path_file = data_either_path_wf.add("path.txt", data_either_path_option);
 
+    // Data.Char source path.
+    const data_char_path_option = b.option(
+        []const u8,
+        "data-char-path",
+        "Path to lib/base/Data/Char.hs",
+    ) orelse b.getInstallPath(.@"prefix", "lib/base/Data/Char.hs");
+    const data_char_path_wf = b.addNamedWriteFiles("data_char_path");
+    const data_char_path_file = data_char_path_wf.add("path.txt", data_char_path_option);
+
     // ── Default package database path ──────────────────────────────────────
     // Baked into the rhc binary via @embedFile and prepended to the user's
     // `--package-db` list at startup, so `rhc build` consults the pre-built
@@ -502,6 +514,9 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addAnonymousImport("data_either_path", .{
         .root_source_file = data_either_path_file,
     });
+    exe.root_module.addAnonymousImport("data_char_path", .{
+        .root_source_file = data_char_path_file,
+    });
     exe.root_module.addAnonymousImport("default_package_db", .{
         .root_source_file = default_pkg_db_file,
     });
@@ -525,6 +540,7 @@ pub fn build(b: *std.Build) void {
         b.addInstallFile(b.path("lib/base/Data/List.hs"), "lib/base/Data/List.hs"),
         b.addInstallFile(b.path("lib/base/Data/Maybe.hs"), "lib/base/Data/Maybe.hs"),
         b.addInstallFile(b.path("lib/base/Data/Either.hs"), "lib/base/Data/Either.hs"),
+        b.addInstallFile(b.path("lib/base/Data/Char.hs"), "lib/base/Data/Char.hs"),
     };
     for (boot_source_installs) |s| b.getInstallStep().dependOn(&s.step);
 
@@ -865,6 +881,9 @@ pub fn build(b: *std.Build) void {
     });
     repl_wasm.root_module.addAnonymousImport("data_either_source", .{
         .root_source_file = b.path("lib/base/Data/Either.hs"),
+    });
+    repl_wasm.root_module.addAnonymousImport("data_char_source", .{
+        .root_source_file = b.path("lib/base/Data/Char.hs"),
     });
     // Reactor mode: the REPL is a long-lived module with exported functions,
     // not a command that runs once and exits. In reactor mode the entry point

--- a/build.zig
+++ b/build.zig
@@ -406,6 +406,22 @@ pub fn build(b: *std.Build) void {
     const data_either_path_wf = b.addNamedWriteFiles("data_either_path");
     const data_either_path_file = data_either_path_wf.add("path.txt", data_either_path_option);
 
+    // ── Default package database path ──────────────────────────────────────
+    // Baked into the rhc binary via @embedFile and prepended to the user's
+    // `--package-db` list at startup, so `rhc build` consults the pre-built
+    // boot artifacts in `zig-out/lib/rhc-store` without an explicit flag.
+    // The directory itself is populated by the stage-2 bootstrap step
+    // declared below.  At runtime, the directory not existing or being
+    // empty is fine — `tryLoadFromPackageDbs` falls through to source
+    // compilation via the boot-module auto-prepend.
+    const default_pkg_db_option = b.option(
+        []const u8,
+        "default-package-db",
+        "Default package database path",
+    ) orelse b.getInstallPath(.lib, "rhc-store");
+    const default_pkg_db_wf = b.addNamedWriteFiles("default_package_db");
+    const default_pkg_db_file = default_pkg_db_wf.add("path.txt", default_pkg_db_option);
+
     // Here we define an executable. An executable needs to have a root module
     // which needs to expose a `main` function. While we could add a main function
     // to the module defined above, it's sometimes preferable to split business
@@ -486,6 +502,9 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addAnonymousImport("data_either_path", .{
         .root_source_file = data_either_path_file,
     });
+    exe.root_module.addAnonymousImport("default_package_db", .{
+        .root_source_file = default_pkg_db_file,
+    });
 
     // This declares intent for the executable to be installed into the
     // install prefix when running `zig build` (i.e. when executing the default
@@ -494,18 +513,59 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(exe);
 
     // Install the Prelude source file alongside the binary so the compiler
-    // can find it at runtime via the baked-in prelude_path.
-    b.installFile("lib/Prelude.hs", "lib/Prelude.hs");
-    // Same for RHC.Prim, the innermost boot package compiled before Prelude.
-    b.installFile("lib/rhc-prim/RHC/Prim.hs", "lib/rhc-prim/RHC/Prim.hs");
-    // Data.Function: pure base-package combinators.
-    b.installFile("lib/base/Data/Function.hs", "lib/base/Data/Function.hs");
-    // GHC.Base: compiler-magic types + core classes.
-    b.installFile("lib/ghc-internal/GHC/Base.hs", "lib/ghc-internal/GHC/Base.hs");
-    // base/Data.{List,Maybe,Either}: pure consumer combinators.
-    b.installFile("lib/base/Data/List.hs", "lib/base/Data/List.hs");
-    b.installFile("lib/base/Data/Maybe.hs", "lib/base/Data/Maybe.hs");
-    b.installFile("lib/base/Data/Either.hs", "lib/base/Data/Either.hs");
+    // can find it at runtime via the baked-in prelude_path.  We capture
+    // each install step explicitly so the stage-2 bootstrap (declared
+    // below) can `dependOn` them without pulling in the full
+    // `b.getInstallStep()` (which would create a cycle).
+    const boot_source_installs = [_]*std.Build.Step.InstallFile{
+        b.addInstallFile(b.path("lib/Prelude.hs"), "lib/Prelude.hs"),
+        b.addInstallFile(b.path("lib/rhc-prim/RHC/Prim.hs"), "lib/rhc-prim/RHC/Prim.hs"),
+        b.addInstallFile(b.path("lib/base/Data/Function.hs"), "lib/base/Data/Function.hs"),
+        b.addInstallFile(b.path("lib/ghc-internal/GHC/Base.hs"), "lib/ghc-internal/GHC/Base.hs"),
+        b.addInstallFile(b.path("lib/base/Data/List.hs"), "lib/base/Data/List.hs"),
+        b.addInstallFile(b.path("lib/base/Data/Maybe.hs"), "lib/base/Data/Maybe.hs"),
+        b.addInstallFile(b.path("lib/base/Data/Either.hs"), "lib/base/Data/Either.hs"),
+    };
+    for (boot_source_installs) |s| b.getInstallStep().dependOn(&s.step);
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Stage-2 boot-package bootstrap
+    // ═══════════════════════════════════════════════════════════════════════
+    // After the rhc binary is built and the boot module sources are installed
+    // to zig-out/lib/, invoke rhc once to compile the whole layered Prelude
+    // stack into pre-built `.rhi` + `.bc` artifacts under the rhc-store dir.
+    //
+    // A single `rhc build --no-link --artifact-dir <store> lib/Prelude.hs`
+    // invocation pulls in every boot module via the source-prepend, so all
+    // seven artifacts (RHC.Prim, Data.Function, GHC.Base, Data.{List,Maybe,
+    // Either}, Prelude) land in the store from one run.
+    //
+    // Subsequent `rhc build` invocations on user code see the populated
+    // store via the baked-in `default_package_db` path (#837 deliverable 2).
+    // The boot-module source-prepend remains the source of truth for
+    // codegen until per-module .bc link integration lands (PR-C).
+    const bootstrap_run = b.addRunArtifact(exe);
+    bootstrap_run.addArgs(&.{ "build", "--no-link", "--artifact-dir" });
+    bootstrap_run.addArg(default_pkg_db_option);
+    // rhc auto-prepends every other boot module via its baked-in paths;
+    // passing Prelude as the positional triggers the whole layered
+    // compile.  We use the install-dir path (not the source tree) so
+    // it matches the binary's baked-in `prelude_path` and reads from
+    // the same files rhc would at user-`rhc build` time.
+    bootstrap_run.addArg(prelude_path_option);
+    // The bootstrap depends on the boot-source install steps but NOT on
+    // the full install step — `b.getInstallStep()` will depend on the
+    // bootstrap below, and a cycle would arise if it pointed back.
+    for (boot_source_installs) |s| bootstrap_run.step.dependOn(&s.step);
+    // Expose as a named step so users can rebuild just the store.
+    // Also wired into the default install step so `zig build` populates
+    // the store as part of the normal build.
+    const bootstrap_step = b.step(
+        "bootstrap",
+        "Compile boot packages into zig-out/lib/rhc-store",
+    );
+    bootstrap_step.dependOn(&bootstrap_run.step);
+    b.getInstallStep().dependOn(&bootstrap_run.step);
 
     // This creates a top level step. Top level steps have a name and can be
     // invoked by name when running `zig build` (e.g. `zig build run`).

--- a/lib/base/Data/Char.hs
+++ b/lib/base/Data/Char.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+-- | Data.Char — character classification + case conversion.
+--
+-- Mirrors GHC's `base:Data.Char`.  Pure Haskell built on top of the
+-- `intToChar`/`charToInt` primops re-exported through GHC.Base and
+-- on the Int comparisons that the `Ord Char` instance is wired to.
+--
+-- Only the ASCII subset is supported — full Unicode classification
+-- would need primops over Unicode general categories, which we
+-- don't yet have.  Functions on non-ASCII code points behave as
+-- if the character were a generic letter / non-letter on a
+-- best-effort basis (e.g. `isAlpha` returns False, `toUpper`
+-- returns the input unchanged).  Matches GHC's behaviour for ASCII
+-- and diverges for the rest; tracked as future work.
+module Data.Char
+    ( ord, chr
+    , isDigit, isHexDigit, isOctDigit
+    , isUpper, isLower, isAlpha, isAlphaNum
+    , isSpace
+    , toUpper, toLower
+    , digitToInt
+    ) where
+
+import GHC.Base
+
+-- ── Code-point conversions ───────────────────────────────────────
+
+ord :: Char -> Int
+ord c = charToInt c
+
+chr :: Int -> Char
+chr n = intToChar n
+
+-- ── ASCII classification ─────────────────────────────────────────
+
+isDigit :: Char -> Bool
+isDigit c = (c >= '0') && (c <= '9')
+
+isOctDigit :: Char -> Bool
+isOctDigit c = (c >= '0') && (c <= '7')
+
+isHexDigit :: Char -> Bool
+isHexDigit c =
+    ((c >= '0') && (c <= '9')) ||
+    ((c >= 'a') && (c <= 'f')) ||
+    ((c >= 'A') && (c <= 'F'))
+
+isUpper :: Char -> Bool
+isUpper c = (c >= 'A') && (c <= 'Z')
+
+isLower :: Char -> Bool
+isLower c = (c >= 'a') && (c <= 'z')
+
+isAlpha :: Char -> Bool
+isAlpha c = isUpper c || isLower c
+
+isAlphaNum :: Char -> Bool
+isAlphaNum c = isAlpha c || isDigit c
+
+-- ASCII whitespace: space, tab, newline, carriage return, form feed,
+-- vertical tab.  Matches GHC's `isSpace` for the ASCII subset.
+isSpace :: Char -> Bool
+isSpace c =
+    (c == ' ') ||
+    (c == '\t') ||
+    (c == '\n') ||
+    (c == '\r') ||
+    (c == '\f') ||
+    (c == '\v')
+
+-- ── Case conversion (ASCII only) ─────────────────────────────────
+
+-- 'A'..'Z' lowercase to 'a'..'z' is +32 in ASCII.
+toUpper :: Char -> Char
+toUpper c = case isLower c of
+    True  -> chr (ord c - 32)
+    False -> c
+
+toLower :: Char -> Char
+toLower c = case isUpper c of
+    True  -> chr (ord c + 32)
+    False -> c
+
+-- ── Digit conversion ─────────────────────────────────────────────
+
+-- Converts a hex/oct/dec digit char to its integer value.  Behaviour
+-- on non-digit input is `error` — matches GHC's `digitToInt`.
+digitToInt :: Char -> Int
+digitToInt c
+    | isDigit c    = ord c - ord '0'
+    | (c >= 'a') && (c <= 'f') = (ord c - ord 'a') + 10
+    | (c >= 'A') && (c <= 'F') = (ord c - ord 'A') + 10
+    | otherwise    = error "digitToInt: not a digit"

--- a/lib/ghc-internal/GHC/Base.hs
+++ b/lib/ghc-internal/GHC/Base.hs
@@ -182,6 +182,16 @@ instance Eq Bool where
   (==) = eqBool
   (/=) = neBool
 
+eqChar :: Char -> Char -> Bool
+eqChar x y = primEqInt (charToInt x) (charToInt y)
+
+neChar :: Char -> Char -> Bool
+neChar x y = primNeInt (charToInt x) (charToInt y)
+
+instance Eq Char where
+  (==) = eqChar
+  (/=) = neChar
+
 -- ========================================================================
 -- Ord type class
 -- ========================================================================
@@ -206,6 +216,28 @@ instance Ord Int where
   (<=) = primLeInt
   (>)  = primGtInt
   (>=) = primGeInt
+
+compareChar :: Char -> Char -> Ordering
+compareChar x y = compareInt (charToInt x) (charToInt y)
+
+ltChar :: Char -> Char -> Bool
+ltChar x y = primLtInt (charToInt x) (charToInt y)
+
+leChar :: Char -> Char -> Bool
+leChar x y = primLeInt (charToInt x) (charToInt y)
+
+gtChar :: Char -> Char -> Bool
+gtChar x y = primGtInt (charToInt x) (charToInt y)
+
+geChar :: Char -> Char -> Bool
+geChar x y = primGeInt (charToInt x) (charToInt y)
+
+instance Ord Char where
+  compare = compareChar
+  (<)  = ltChar
+  (<=) = leChar
+  (>)  = gtChar
+  (>=) = geChar
 
 -- ========================================================================
 -- Bounded type class

--- a/src/main.zig
+++ b/src/main.zig
@@ -1120,7 +1120,12 @@ fn cmdBuild(
             try stderr.flush();
             std.process.exit(1);
         };
-        const mod_name = try rusholme.modules.module_graph.inferModuleName(arena_alloc, fp);
+        // Prefer the source-declared `module Foo where` name over the
+        // path-inferred one so a file whose path doesn't mirror its module
+        // (e.g. `lib/base/Data/List.hs` declaring `module Data.List where`)
+        // still topo-sorts and resolves imports correctly.
+        const mod_name = extractSourceModuleName(source) orelse
+            try rusholme.modules.module_graph.inferModuleName(arena_alloc, fp);
         try source_modules.append(arena_alloc, .{
             .module_name = mod_name,
             .source = source,
@@ -2081,6 +2086,30 @@ test "artifactStem: dots become path separators under artifact_dir" {
     try testing.expectEqualStrings(expected, got);
 }
 
+test "extractSourceModuleName: basic header" {
+    const got = extractSourceModuleName("module Foo.Bar where\n").?;
+    try std.testing.expectEqualStrings("Foo.Bar", got);
+}
+
+test "extractSourceModuleName: pragma + comments before header" {
+    const src =
+        \\{-# LANGUAGE NoImplicitPrelude #-}
+        \\-- top of file
+        \\{- block comment -}
+        \\
+        \\module Data.List
+        \\    ( map, filter
+        \\    ) where
+        \\
+    ;
+    const got = extractSourceModuleName(src).?;
+    try std.testing.expectEqualStrings("Data.List", got);
+}
+
+test "extractSourceModuleName: missing header returns null" {
+    try std.testing.expect(extractSourceModuleName("x = 42\n") == null);
+}
+
 test "artifactStem: top-level module name has no subdir" {
     const testing = std.testing;
     const got = try artifactStem(testing.allocator, "/tmp/store", "Main");
@@ -2089,6 +2118,59 @@ test "artifactStem: top-level module name has no subdir" {
     const expected = try std.fmt.allocPrint(testing.allocator, "/tmp/store{c}Main", .{sep});
     defer testing.allocator.free(expected);
     try testing.expectEqualStrings(expected, got);
+}
+
+/// Lexical scan of `source` for the first `module Foo.Bar` declaration.
+/// Returns a borrowed sub-slice of `source` containing the dotted name, or
+/// null if no module header is present (top-level `Main` style file).
+///
+/// Skips `--` line comments and `{- … -}` block comments before each
+/// non-whitespace token, mirroring the lexer's prefix scanner.  Does not
+/// validate that the identifier is well-formed beyond the first-character
+/// class; the downstream parser will diagnose any malformed header.
+fn extractSourceModuleName(source: []const u8) ?[]const u8 {
+    var i: usize = 0;
+    while (i < source.len) {
+        // Skip whitespace.
+        while (i < source.len and (source[i] == ' ' or source[i] == '\t' or source[i] == '\n' or source[i] == '\r')) i += 1;
+        if (i >= source.len) return null;
+
+        // Skip `-- …` line comments.
+        if (i + 1 < source.len and source[i] == '-' and source[i + 1] == '-') {
+            while (i < source.len and source[i] != '\n') i += 1;
+            continue;
+        }
+        // Skip `{- … -}` block comments (no nesting — Haskell allows
+        // nesting but for the header scan we don't bother).
+        if (i + 1 < source.len and source[i] == '{' and source[i + 1] == '-') {
+            i += 2;
+            while (i + 1 < source.len and !(source[i] == '-' and source[i + 1] == '}')) i += 1;
+            if (i + 1 < source.len) i += 2;
+            continue;
+        }
+        // Skip `{-# … #-}` pragmas — caught by the block-comment branch above.
+        break;
+    }
+
+    // Expect literal "module" followed by whitespace.
+    const kw = "module";
+    if (i + kw.len > source.len) return null;
+    if (!std.mem.eql(u8, source[i .. i + kw.len], kw)) return null;
+    i += kw.len;
+    if (i >= source.len) return null;
+    if (!(source[i] == ' ' or source[i] == '\t' or source[i] == '\n' or source[i] == '\r')) return null;
+    while (i < source.len and (source[i] == ' ' or source[i] == '\t' or source[i] == '\n' or source[i] == '\r')) i += 1;
+
+    // Read dotted identifier: start with [A-Z], continue with [A-Za-z0-9_'.].
+    if (i >= source.len or !std.ascii.isUpper(source[i])) return null;
+    const start = i;
+    while (i < source.len) : (i += 1) {
+        const c = source[i];
+        if (std.ascii.isAlphanumeric(c) or c == '_' or c == '\'' or c == '.') continue;
+        break;
+    }
+    if (i == start) return null;
+    return source[start..i];
 }
 
 fn readSourceFile(allocator: std.mem.Allocator, io: Io, path: []const u8) ![]u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1103,6 +1103,15 @@ fn cmdBuild(
     if (!no_boot) {
         for (boot_modules) |boot| {
         if (user_module_names.contains(boot.module_name)) continue;
+        // NOTE: even when `effective_pkg_dbs` carries a full set of
+        // boot-module `.rhi`+`.bc` artifacts, we currently still
+        // source-prepend the boot stack.  Skipping the prepend lets
+        // the cached code path provide the interfaces, but the LLVM
+        // tag registry and `__rhc_force` module are built from the
+        // *fresh* per-module GRIN — cached modules contribute no
+        // GRIN to that registry, so the resulting force module is
+        // incomplete and the link fails.  Full cache-only codegen is
+        // tracked separately (see PR-C scope notes in the issue).
         const boot_path = boot.pathFn();
         if (readSourceFile(arena_alloc, io, boot_path)) |boot_source| {
             try source_modules.append(arena_alloc, .{
@@ -1467,6 +1476,36 @@ fn emitNative(
         };
 
         try llvm_modules.append(arena_alloc, llvm_mod);
+    }
+
+    // ── Pull cached-module bitcode into the link ─────────────────────────
+    // For every module that was resolved through `--package-db` *and*
+    // was NOT also source-compiled (so `session.programs` has no
+    // bindings for it), parse its sibling `.bc` and append to the
+    // link set.  When source-prepend is active for a boot module its
+    // fresh `.bc` already provides the symbols, so loading the cached
+    // copy would yield "multiple definition" errors.  This filter
+    // matters when the user explicitly opts out of source-prepend
+    // (e.g. `rhc build --no-boot --package-db <store> …`).
+    var bc_it = session.cached_bc_paths.iterator();
+    while (bc_it.next()) |entry| {
+        const mod_name = entry.key_ptr.*;
+        if (session.programs.get(mod_name)) |prog| {
+            if (prog.binds.len > 0 or prog.data_decls.len > 0) continue;
+        }
+        const bc_path = entry.value_ptr.*;
+        const cached_mod = llvm.parseBitcodeFile(bc_path) catch |err| {
+            var stderr_buf: [4096]u8 = undefined;
+            var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
+            const stderr = &stderr_fw.interface;
+            try stderr.print(
+                "rhc: failed to parse cached bitcode for module '{s}' at '{s}': {}\n",
+                .{ mod_name, bc_path, err },
+            );
+            try stderr.flush();
+            std.process.exit(1);
+        };
+        try llvm_modules.append(arena_alloc, cached_mod);
     }
 
     // `--no-link` mode: per-module `.bc` artifacts are the only output.

--- a/src/main.zig
+++ b/src/main.zig
@@ -126,6 +126,10 @@ fn getDataEitherPath() []const u8 {
     return @embedFile("data_either_path");
 }
 
+fn getDataCharPath() []const u8 {
+    return @embedFile("data_char_path");
+}
+
 /// Get the default package-database path baked in at compile time.
 /// Points at `zig-out/lib/rhc-store/` (or wherever
 /// `-Ddefault-package-db=<path>` was set at build time).  Populated by
@@ -163,6 +167,10 @@ const boot_modules = [_]BootModule{
     .{ .module_name = "Data.List", .pathFn = getDataListPath },
     .{ .module_name = "Data.Maybe", .pathFn = getDataMaybePath },
     .{ .module_name = "Data.Either", .pathFn = getDataEitherPath },
+    // Data.Char is not in the implicit Prelude (matches GHC: `Data.Char` is
+    // explicit-import only).  We still source-prepend it so cross-references
+    // and topo can resolve cleanly when user code does `import Data.Char`.
+    .{ .module_name = "Data.Char", .pathFn = getDataCharPath },
     .{ .module_name = "Prelude", .pathFn = getPreludePath },
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -126,6 +126,22 @@ fn getDataEitherPath() []const u8 {
     return @embedFile("data_either_path");
 }
 
+/// Get the default package-database path baked in at compile time.
+/// Points at `zig-out/lib/rhc-store/` (or wherever
+/// `-Ddefault-package-db=<path>` was set at build time).  Populated by
+/// the stage-2 bootstrap step in `build.zig` with pre-built boot
+/// module `.rhi`+`.bc` artifacts.  Prepended to the user's
+/// `--package-db` list at startup so user `rhc build` invocations
+/// resolve imports through cached interfaces.
+///
+/// At runtime the directory may not exist (clean tree, no
+/// `zig build bootstrap` yet) — `tryLoadFromPackageDbs` swallows
+/// missing-file errors as cache misses and falls back to the
+/// auto-prepended source compilation path.
+fn getDefaultPackageDb() []const u8 {
+    return @embedFile("default_package_db");
+}
+
 /// Boot modules that the driver auto-prepends, in dependency order.
 ///
 /// Mirror the layered Prelude per `docs/plans/2026-06-13-ghc-internal-base-split.md`:
@@ -1052,6 +1068,16 @@ fn cmdBuild(
     const compile_env_mod = rusholme.modules.compile_env;
     var source_modules: std.ArrayListUnmanaged(compile_env_mod.SourceModule) = .empty;
 
+    // Prepend the baked-in default package db so user `rhc build` picks up
+    // pre-built boot artifacts without needing an explicit
+    // `--package-db zig-out/lib/rhc-store` flag.  User-supplied
+    // `--package-db` paths still take precedence on lookup ties because the
+    // default is searched last (first-match-wins in tryLoadFromPackageDbs).
+    var effective_pkg_dbs: std.ArrayListUnmanaged([]const u8) = .empty;
+    try effective_pkg_dbs.appendSlice(arena_alloc, package_dbs);
+    const default_db = getDefaultPackageDb();
+    if (default_db.len > 0) try effective_pkg_dbs.append(arena_alloc, default_db);
+
     // ── Auto-prepend boot modules unless the user explicitly passed them ─
     //
     // The boot modules (`RHC.Prim`, `Prelude`, …) form the layered
@@ -1134,7 +1160,7 @@ fn cmdBuild(
         next_file_id += 1;
     }
 
-    var session_result = try compile_env_mod.compileProgram(arena_alloc, io, source_modules.items, package_dbs);
+    var session_result = try compile_env_mod.compileProgram(arena_alloc, io, source_modules.items, effective_pkg_dbs.items);
     var session = &session_result.env;
     defer session.deinit();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -282,6 +282,9 @@ pub fn main(init: std.process.Init) !void {
                 \\    --backend <str>          Backend: native (default), jit, wasm, c.
                 \\    --rts <str>              RTS heap backend: arena (default) or immix.
                 \\    --package-db <str>...    Package database path (may be repeated).
+                \\    --artifact-dir <str>     Write per-module .rhi+.bc artifacts to this dir; module name dots become subdirs.
+                \\    --no-link                Skip the final link step; emit only per-module artifacts.
+                \\    --no-boot                Skip auto-prepend of boot modules (RHC.Prim, Prelude, …).
                 \\    --repl                   Compile for REPL use (internal).
                 \\<str>...
                 \\
@@ -297,6 +300,9 @@ pub fn main(init: std.process.Init) !void {
                 \\    --backend <str>          Backend: native (default), jit, wasm, c.
                 \\    --rts <str>              RTS heap backend: arena (default) or immix.
                 \\    --package-db <str>...    Package database path (may be repeated).
+                \\    --artifact-dir <str>     Write per-module .rhi+.bc artifacts to this dir; module name dots become subdirs.
+                \\    --no-link                Skip the final link step; emit only per-module artifacts.
+                \\    --no-boot                Skip auto-prepend of boot modules (RHC.Prim, Prelude, …).
                 \\<str>...
                 \\
             );
@@ -386,6 +392,9 @@ pub fn main(init: std.process.Init) !void {
                 build_res.args.@"package-db",
                 opt_level,
                 rts_backend,
+                build_res.args.@"artifact-dir",
+                build_res.args.@"no-link" != 0,
+                build_res.args.@"no-boot" != 0,
             );
         },
 
@@ -1018,7 +1027,20 @@ fn loadPrelude(
 /// - native: compiles to native executable via LLVM
 /// - wasm: compiles to WebAssembly binary (.wasm)
 /// - jit, c: not yet implemented
-fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8, output_name: []const u8, backend_kind: rusholme.backend.backend_mod.BackendKind, is_repl: bool, package_dbs: []const []const u8, opt_level: rusholme.backend.llvm.OptLevel, rts_backend: rusholme.backend.grin_to_llvm.RtsBackend) !void {
+fn cmdBuild(
+    allocator: std.mem.Allocator,
+    io: Io,
+    file_paths: []const []const u8,
+    output_name: []const u8,
+    backend_kind: rusholme.backend.backend_mod.BackendKind,
+    is_repl: bool,
+    package_dbs: []const []const u8,
+    opt_level: rusholme.backend.llvm.OptLevel,
+    rts_backend: rusholme.backend.grin_to_llvm.RtsBackend,
+    artifact_dir: ?[]const u8,
+    no_link: bool,
+    no_boot: bool,
+) !void {
     // REPL mode placeholder - for WASM backend compiles stateful REPL
     _ = is_repl;
 
@@ -1047,7 +1069,13 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
     // File IDs are assigned monotonically; boot modules take the low IDs.
     var next_file_id: u32 = 0;
 
-    for (boot_modules) |boot| {
+    // `--no-boot` skips the auto-prepend entirely.  This is the bootstrap
+    // mode used by `build.zig` when compiling the boot packages themselves
+    // — RHC.Prim has nothing to depend on, GHC.Base depends only on
+    // RHC.Prim (resolved via `--package-db`), and so on.  User-mode builds
+    // always want the prepend.
+    if (!no_boot) {
+        for (boot_modules) |boot| {
         if (user_module_names.contains(boot.module_name)) continue;
         const boot_path = boot.pathFn();
         if (readSourceFile(arena_alloc, io, boot_path)) |boot_source| {
@@ -1055,7 +1083,11 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
                 .module_name = boot.module_name,
                 .source = boot_source,
                 .file_id = next_file_id,
-                .source_path = boot_path,
+                // When emitting to an artifact dir we drop `source_path` so
+                // `compile_env.zig` does NOT auto-write `.rhi` next to the
+                // source.  The store-canonical `.rhi` is written explicitly
+                // below into `<artifact_dir>/<Module/Path>.rhi`.
+                .source_path = if (artifact_dir == null) boot_path else null,
             });
             next_file_id += 1;
         } else |err| {
@@ -1071,6 +1103,7 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
                 else => try stderr.print("rhc: warning: cannot read boot module '{s}' at '{s}': {}; using built-in names only\n", .{ boot.module_name, boot_path, err }),
             }
             try stderr.flush();
+        }
         }
     }
 
@@ -1113,6 +1146,28 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
     }
 
     const module_order = session_result.result.module_order;
+
+    // ── Store-mode `.rhi` export ────────────────────────────────────────
+    // When `--artifact-dir` is given, write one `.rhi` per locally-compiled
+    // module into the canonical store layout
+    // (`<artifact_dir>/<Module/Path>.rhi`, dots → slashes).  Modules pulled
+    // from `--package-db` already have their `.rhi` in the source db and
+    // are skipped (they have no entry in `session.programs`).
+    if (artifact_dir) |dir| {
+        for (module_order) |mod_name| {
+            if (session.programs.get(mod_name) == null) continue; // package-db hit
+            const iface = session.ifaces.get(mod_name) orelse continue;
+            // Prefer the source-declared `module Foo where` name over
+            // the path-inferred one so `lib/rhc-prim/RHC/Prim.hs`
+            // lands as `RHC/Prim.rhi`, not `lib/rhc-prim/RHC/Prim.rhi`
+            // (mirrors the `.bc` stem logic in `emitNative`).
+            const stem_name: []const u8 = if (session.parsed_modules.get(mod_name)) |parsed|
+                parsed.module_name
+            else
+                mod_name;
+            try writeArtifactRhi(arena_alloc, io, dir, stem_name, iface);
+        }
+    }
 
     // ── Whole-program dictionary specialisation (#807) ──────────────────
     // Resolve class-method dispatch through statically-known dictionaries
@@ -1247,8 +1302,19 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
     };
 
     // ── Dispatch to backend-specific emission ─────────────────────────────
+    // `--artifact-dir` is only supported on the native backend for now.  JIT
+    // and WASM paths emit bitcode shapes that aren't directly consumable as
+    // store artifacts yet; the boot-store layout only needs native bitcode.
+    if (artifact_dir != null and backend_kind != .native) {
+        var stderr_buf: [4096]u8 = undefined;
+        var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
+        const stderr = &stderr_fw.interface;
+        try stderr.print("rhc build: --artifact-dir requires --backend=native\n", .{});
+        try stderr.flush();
+        std.process.exit(1);
+    }
     switch (backend_kind) {
-        .native => try emitNative(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend, strict_params),
+        .native => try emitNative(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend, strict_params, artifact_dir, no_link),
         .jit => try emitJit(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend, strict_params),
         .wasm => try emitWasm(arena_alloc, io, session, module_order, per_module_grin.items, all_grin, output_name, opt_level, rts_backend, strict_params),
         .c => {
@@ -1265,6 +1331,12 @@ fn cmdBuild(allocator: std.mem.Allocator, io: Io, file_paths: []const []const u8
 }
 
 /// Emit native executable (the original cmdBuild logic).
+///
+/// When `artifact_dir` is non-null, per-module `.bc` files are written into
+/// `<artifact_dir>/<Module/Path>.bc` (dots → slashes) instead of the current
+/// working directory.  When `no_link` is true, the final link step is
+/// skipped — useful when emitting boot-package artifacts that have no
+/// `main`.
 fn emitNative(
     allocator: std.mem.Allocator,
     io: Io,
@@ -1276,6 +1348,8 @@ fn emitNative(
     opt_level: rusholme.backend.llvm.OptLevel,
     rts_backend: rusholme.backend.grin_to_llvm.RtsBackend,
     strict_params: ?*const rusholme.core.demand.StrictnessMap,
+    artifact_dir: ?[]const u8,
+    no_link: bool,
 ) !void {
     const llvm = rusholme.backend.llvm;
     var arena = std.heap.ArenaAllocator.init(allocator);
@@ -1345,7 +1419,13 @@ fn emitNative(
             parsed.module_name
         else
             mod_name;
-        const bc_path = try std.fmt.allocPrint(arena_alloc, "{s}.bc", .{bc_stem});
+        const bc_path = if (artifact_dir) |dir| blk: {
+            const full_stem = try artifactStem(arena_alloc, dir, bc_stem);
+            defer arena_alloc.free(full_stem);
+            const p = try std.fmt.allocPrint(arena_alloc, "{s}.bc", .{full_stem});
+            try ensureParentDirs(io, p);
+            break :blk p;
+        } else try std.fmt.allocPrint(arena_alloc, "{s}.bc", .{bc_stem});
         llvm.writeBitcodeToFile(llvm_mod, bc_path) catch |err| {
             var stderr_buf: [4096]u8 = undefined;
             var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
@@ -1357,6 +1437,14 @@ fn emitNative(
 
         try llvm_modules.append(arena_alloc, llvm_mod);
     }
+
+    // `--no-link` mode: per-module `.bc` artifacts are the only output.
+    // Skip the shared `__rhc_force` module (it covers only this build's tag
+    // table, which is incomplete in a per-package build), the in-process
+    // bitcode merge, object emission, and final linker invocation.  The
+    // user's downstream `rhc build` rebuilds the force module with a full
+    // cross-package tag table.
+    if (no_link) return;
 
     // Emit the shared __rhc_force module.  Per-module code declares
     // __rhc_force as external; this module provides the definition.
@@ -1937,6 +2025,72 @@ fn renderDiagnostics(
 }
 
 /// Read a source file from disk into an owned allocation.
+/// Compute the per-module store path stem (without extension).  Dots in the
+/// module name become path separators so `Data.Maybe` lands under a
+/// `Data/` subdir.  Caller owns the returned slice.
+fn artifactStem(
+    alloc: std.mem.Allocator,
+    artifact_dir: []const u8,
+    module_name: []const u8,
+) ![]u8 {
+    const sep = std.fs.path.sep;
+    const rel = try alloc.dupe(u8, module_name);
+    for (rel) |*c| if (c.* == '.') {
+        c.* = sep;
+    };
+    defer alloc.free(rel);
+    return std.fs.path.join(alloc, &.{ artifact_dir, rel });
+}
+
+/// Create all intermediate directories above `file_path`.  No-op if they
+/// already exist.
+fn ensureParentDirs(io: Io, file_path: []const u8) !void {
+    if (std.fs.path.dirname(file_path)) |dir| {
+        try Dir.cwd().createDirPath(io, dir);
+    }
+}
+
+/// Write `iface` to `<artifact_dir>/<Module/Path>.rhi`, creating intermediate
+/// directories as needed.
+fn writeArtifactRhi(
+    alloc: std.mem.Allocator,
+    io: Io,
+    artifact_dir: []const u8,
+    module_name: []const u8,
+    iface: rusholme.modules.mod_iface.ModIface,
+) !void {
+    const stem = try artifactStem(alloc, artifact_dir, module_name);
+    defer alloc.free(stem);
+    const rhi_path = try std.fmt.allocPrint(alloc, "{s}.rhi", .{stem});
+    defer alloc.free(rhi_path);
+    try ensureParentDirs(io, rhi_path);
+    try rusholme.modules.mod_iface.writeRhiToDisk(alloc, io, rhi_path, iface);
+}
+
+test "artifactStem: dots become path separators under artifact_dir" {
+    const testing = std.testing;
+    const sep = std.fs.path.sep;
+    const got = try artifactStem(testing.allocator, "/tmp/store", "Data.Maybe");
+    defer testing.allocator.free(got);
+    const expected = try std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/store{c}Data{c}Maybe",
+        .{ sep, sep },
+    );
+    defer testing.allocator.free(expected);
+    try testing.expectEqualStrings(expected, got);
+}
+
+test "artifactStem: top-level module name has no subdir" {
+    const testing = std.testing;
+    const got = try artifactStem(testing.allocator, "/tmp/store", "Main");
+    defer testing.allocator.free(got);
+    const sep = std.fs.path.sep;
+    const expected = try std.fmt.allocPrint(testing.allocator, "/tmp/store{c}Main", .{sep});
+    defer testing.allocator.free(expected);
+    try testing.expectEqualStrings(expected, got);
+}
+
 fn readSourceFile(allocator: std.mem.Allocator, io: Io, path: []const u8) ![]u8 {
     const file = try Dir.openFile(.cwd(), io, path, .{});
     defer file.close(io);

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -775,6 +775,14 @@ pub fn compileProgram(
         if (src_map.get(mod_name) == null) {
             // Module not provided as source: try to resolve via package-dbs.
             if (try tryLoadFromPackageDbs(alloc, io, mod_name, package_dbs)) |iface| {
+                // Advance the shared `UniqueSupply` past every unique the
+                // cached interface lays claim to.  Without this, a
+                // downstream module compiled from source would fresh-
+                // allocate uniques starting at 1000 and collide with the
+                // upstream's exports (issue #839).
+                const claimed = mod_iface.maxUniqueInIface(iface);
+                if (claimed >= env.u_supply.next) env.u_supply.next = claimed + 1;
+
                 const ce = try deserialiseClassEnvFromIface(alloc, iface);
                 const owned_name = try alloc.dupe(u8, mod_name);
                 try env.class_envs.put(alloc, owned_name, ce);

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -1106,9 +1106,14 @@ fn preloadSingleRhi(
     const iface = mod_iface.readRhi(alloc, data) catch return;
     if (iface.format_version != mod_iface.rhi_format_version) return;
 
-    const claimed = mod_iface.maxUniqueInIface(iface);
-    if (claimed >= env.u_supply.next) env.u_supply.next = claimed + 1;
-
+    // NOTE: deliberately do NOT advance `env.u_supply.next` here.  The
+    // topo-time package-db branch in `compileProgram` already does that
+    // for the cached modules that get actually imported.  Bumping at
+    // preload time advances the supply past *every* `.rhi` in the db
+    // — even modules not imported by this build — which shifts the
+    // uniques allocated to user code upward and produces measurably
+    // different LLVM symbol names and inlining choices vs main, with
+    // no functional benefit when the cached interface is unused.
     const ce = try deserialiseClassEnvFromIface(alloc, iface);
     const owned = try alloc.dupe(u8, mod_name);
     try env.class_envs.put(alloc, owned, ce);
@@ -2162,6 +2167,123 @@ test "tryLoadFromPackageDbs: returns null when no .rhi file exists" {
     const tmp_path = try std.Io.Dir.realPathFileAlloc(tmp.dir, io, ".", alloc);
     const result = try tryLoadFromPackageDbs(alloc, io, "NoSuchModule", &.{tmp_path});
     try testing.expect(result == null);
+}
+
+// Helper: write a minimal `ModIface` for `mod_name` to `<dir>/<rel>.rhi`
+// (creating intermediate subdirs).  Optionally also writes a sibling
+// `.bc` file with `bc_contents`.  Used by the preload-cache tests
+// below to fabricate a synthetic package-db on disk.
+fn writeFakeRhi(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    dir: std.Io.Dir,
+    rel: []const u8,
+    mod_name: []const u8,
+    value_unique: u64,
+    bc_contents: ?[]const u8,
+) !void {
+    const stem_len = rel.len - ".rhi".len;
+    if (std.fs.path.dirname(rel)) |sub| {
+        try dir.createDirPath(io, sub);
+    }
+    const iface = mod_iface.ModIface{
+        .module_name = mod_name,
+        .values = &[_]mod_iface.ExportedValue{.{
+            .name = "x",
+            .unique = value_unique,
+            .scheme = .{
+                .binder_uniques = &.{},
+                .binder_names = &.{},
+                .constraints = &.{},
+                .body = .{ .tag = "TyCon", .name = "Int", .unique = 100, .args = &.{} },
+            },
+        }},
+        .data_decls = &.{},
+    };
+    const json = try mod_iface.writeRhi(alloc, iface);
+    defer alloc.free(json);
+    const rhi_file = try std.Io.Dir.createFile(.cwd(), io, blk: {
+        const tmp_root = try std.Io.Dir.realPathFileAlloc(dir, io, ".", alloc);
+        defer alloc.free(tmp_root);
+        break :blk try std.fs.path.join(alloc, &.{ tmp_root, rel });
+    }, .{ .truncate = true });
+    defer rhi_file.close(io);
+    try rhi_file.writeStreamingAll(io, json);
+
+    if (bc_contents) |bc| {
+        const bc_rel = try std.fmt.allocPrint(alloc, "{s}.bc", .{rel[0..stem_len]});
+        defer alloc.free(bc_rel);
+        const tmp_root = try std.Io.Dir.realPathFileAlloc(dir, io, ".", alloc);
+        defer alloc.free(tmp_root);
+        const bc_path = try std.fs.path.join(alloc, &.{ tmp_root, bc_rel });
+        defer alloc.free(bc_path);
+        const bc_file = try std.Io.Dir.createFile(.cwd(), io, bc_path, .{ .truncate = true });
+        defer bc_file.close(io);
+        try bc_file.writeStreamingAll(io, bc);
+    }
+}
+
+test "preloadPackageDb: registers nested .rhi as cached iface" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const io = testing.io;
+
+    try writeFakeRhi(alloc, io, tmp.dir, "RHC" ++ &[_]u8{std.fs.path.sep} ++ "Prim.rhi", "RHC.Prim", 1234, null);
+
+    const tmp_root = try std.Io.Dir.realPathFileAlloc(tmp.dir, io, ".", alloc);
+    var env = CompileEnv.init(alloc);
+    defer env.deinit();
+    try preloadPackageDb(alloc, io, &env, tmp_root);
+
+    try testing.expect(env.ifaces.contains("RHC.Prim"));
+    // No sibling .bc → cached_bc_paths must be empty.
+    try testing.expectEqual(@as(usize, 0), env.cached_bc_paths.count());
+}
+
+test "preloadPackageDb: sibling .bc populates cached_bc_paths" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const io = testing.io;
+
+    try writeFakeRhi(alloc, io, tmp.dir, "GHC" ++ &[_]u8{std.fs.path.sep} ++ "Base.rhi", "GHC.Base", 2222, "dummy-bc");
+
+    const tmp_root = try std.Io.Dir.realPathFileAlloc(tmp.dir, io, ".", alloc);
+    var env = CompileEnv.init(alloc);
+    defer env.deinit();
+    try preloadPackageDb(alloc, io, &env, tmp_root);
+
+    try testing.expect(env.ifaces.contains("GHC.Base"));
+    try testing.expectEqual(@as(usize, 1), env.cached_bc_paths.count());
+    const bc = env.cached_bc_paths.get("GHC.Base") orelse return error.TestExpectedSetEntry;
+    try testing.expect(std.mem.endsWith(u8, bc, ".bc"));
+}
+
+test "preloadPackageDb: skips non-.rhi files and missing dirs" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const io = testing.io;
+
+    // No .rhi files in the tmp dir — preload should be a clean no-op.
+    const tmp_root = try std.Io.Dir.realPathFileAlloc(tmp.dir, io, ".", alloc);
+    var env = CompileEnv.init(alloc);
+    defer env.deinit();
+    try preloadPackageDb(alloc, io, &env, tmp_root);
+    try testing.expectEqual(@as(usize, 0), env.ifaces.count());
+
+    // Nonexistent root → still no error, still no entries.
+    var env2 = CompileEnv.init(alloc);
+    defer env2.deinit();
+    try preloadPackageDb(alloc, io, &env2, "/this/path/does/not/exist");
+    try testing.expectEqual(@as(usize, 0), env2.ifaces.count());
 }
 
 test "compileProgram: missing import emits module_not_found diagnostic" {

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -134,6 +134,18 @@ pub const CompileEnv = struct {
     /// for imported type class instances.
     dict_names_map: std.StringHashMapUnmanaged(DictNameMap),
 
+    /// Map: cached module name → absolute path of the sibling `.bc`
+    /// artifact discovered alongside its `.rhi` in a `--package-db`.
+    ///
+    /// Populated by the cached-load branch in `compileProgram` when
+    /// `tryLoadFromPackageDbs` finds both files.  Consumed by
+    /// downstream codegen (the LLVM emitter in `main.zig`) so cached
+    /// modules can contribute their code to the final binary without
+    /// being re-source-compiled.  An entry is present only when a
+    /// usable sibling `.bc` exists — callers must still handle the
+    /// missing case (fall back to source).
+    cached_bc_paths: std.StringHashMapUnmanaged([]const u8),
+
     /// Package-database search paths for pre-built `.rhi` interfaces.
     ///
     /// When resolving an import whose source is not in the current build,
@@ -159,6 +171,7 @@ pub const CompileEnv = struct {
             .diags = DiagnosticCollector.init(),
             .class_envs = .{},
             .dict_names_map = .{},
+            .cached_bc_paths = .{},
             .package_dbs = &.{},
         };
     }
@@ -170,6 +183,7 @@ pub const CompileEnv = struct {
         self.diags.deinit(self.alloc);
         self.class_envs.deinit(self.alloc);
         self.dict_names_map.deinit(self.alloc);
+        self.cached_bc_paths.deinit(self.alloc);
         self.* = undefined;
     }
 
@@ -665,6 +679,29 @@ pub fn compileProgram(
     env.package_dbs = package_dbs;
     errdefer env.deinit();
 
+    // ── Phase 0: Eagerly preload every cached module from every db ──
+    //
+    // `ModIface` does not yet serialise its imports, so when a downstream
+    // module resolves `import Prelude` via package-db we cannot follow
+    // Prelude's transitive imports (GHC.Base, Data.List, …).  Their
+    // `.rhi`s would never be visited by the topo loop and their `.bc`s
+    // would never get into the link set — yielding `undefined reference`
+    // errors at the linker step.
+    //
+    // Walk every `--package-db` recursively for `*.rhi` files, register
+    // each interface (with the same unique-supply bump and bc-path
+    // stash logic as the topo-time package-db hit), and let the rest
+    // of the pipeline find them already-loaded.
+    //
+    // The preload is best-effort: any I/O / parse failure on a single
+    // file is silently treated as a miss (matches `tryLoadFromPackageDbs`
+    // semantics).  A future refactor that adds `imports` to `ModIface`
+    // (issue: TBD) would let us drop this and walk only the needed
+    // subgraph.
+    for (package_dbs) |db| {
+        preloadPackageDb(alloc, io, &env, db) catch {};
+    }
+
     // ── Phase 1: Parse all modules once and cache ──────────────────────────
     for (modules) |m| {
         var dummy_diags = DiagnosticCollector.init();
@@ -690,7 +727,25 @@ pub fn compileProgram(
     // topological sort may place a user module before the Prelude, causing
     // cross-module seeding to find no registered interfaces.
     {
-        const has_prelude = env.parsed_modules.contains("Prelude");
+        // Treat the Prelude as "available" if either:
+        //   * its source is in this build (`parsed_modules`), OR
+        //   * any `--package-db` ships a `Prelude.rhi` we'd be able to
+        //     load.  The package-db probe lets the implicit-Prelude
+        //     injection run when boot modules are served entirely from
+        //     the cache (e.g. via the baked-in `default_package_db`).
+        const prelude_in_source = env.parsed_modules.contains("Prelude");
+        const prelude_in_db = blk: {
+            for (package_dbs) |db| {
+                const rel = moduleNameToRhiRelPath(alloc, "Prelude") catch break :blk false;
+                defer alloc.free(rel);
+                const abs = std.fs.path.join(alloc, &.{ db, rel }) catch break :blk false;
+                defer alloc.free(abs);
+                std.Io.Dir.access(.cwd(), io, abs, .{}) catch continue;
+                break :blk true;
+            }
+            break :blk false;
+        };
+        const has_prelude = prelude_in_source or prelude_in_db;
         var inject_iter = env.parsed_modules.iterator();
         while (inject_iter.next()) |entry| {
             const parsed = entry.value_ptr.*;
@@ -774,7 +829,8 @@ pub fn compileProgram(
     for (topo.order) |mod_name| {
         if (src_map.get(mod_name) == null) {
             // Module not provided as source: try to resolve via package-dbs.
-            if (try tryLoadFromPackageDbs(alloc, io, mod_name, package_dbs)) |iface| {
+            if (try tryLoadFromPackageDbs(alloc, io, mod_name, package_dbs)) |hit| {
+                const iface = hit.iface;
                 // Advance the shared `UniqueSupply` past every unique the
                 // cached interface lays claim to.  Without this, a
                 // downstream module compiled from source would fresh-
@@ -790,6 +846,15 @@ pub fn compileProgram(
                 try env.dict_names_map.put(alloc, owned_name, dict_names);
                 const empty_core = CoreProgram{ .data_decls = &.{}, .binds = &.{} };
                 try env.register(mod_name, iface, empty_core);
+
+                // Stash the sibling `.bc` path so the downstream LLVM
+                // link step pulls in the cached module's code instead
+                // of producing an empty module.  When `null`, the
+                // caller is expected to have arranged code via the
+                // source-prepend fallback (typical during bootstrap).
+                if (hit.bc_path) |bcp| {
+                    try env.cached_bc_paths.put(alloc, try alloc.dupe(u8, mod_name), bcp);
+                }
             }
             // Module not found in source or any package-db: emit a structured
             // diagnostic so the user gets a clear "Could not find module" error
@@ -962,12 +1027,123 @@ fn moduleNameToRhiRelPath(
 ///
 /// No fingerprint validation is performed — package-db interfaces are
 /// pre-built and assumed stable.
+/// Recursively walk `<db_root>` for every `*.rhi` and register each
+/// matching interface (plus sibling `.bc`) into `env`.  Errors on
+/// individual files are swallowed and counted as misses so that a
+/// stale or partial store doesn't abort compilation.
+fn preloadPackageDb(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    env: *CompileEnv,
+    db_root: []const u8,
+) !void {
+    try preloadPackageDbDir(alloc, io, env, db_root, "");
+}
+
+fn preloadPackageDbDir(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    env: *CompileEnv,
+    db_root: []const u8,
+    rel: []const u8,
+) !void {
+    const dir_path = if (rel.len == 0)
+        try alloc.dupe(u8, db_root)
+    else
+        try std.fs.path.join(alloc, &.{ db_root, rel });
+    defer alloc.free(dir_path);
+
+    var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
+
+    var it = dir.iterate();
+    while (try it.next(io)) |entry| {
+        const child_rel = if (rel.len == 0)
+            try alloc.dupe(u8, entry.name)
+        else
+            try std.fs.path.join(alloc, &.{ rel, entry.name });
+        defer alloc.free(child_rel);
+
+        switch (entry.kind) {
+            .directory => try preloadPackageDbDir(alloc, io, env, db_root, child_rel),
+            .file => {
+                if (!std.mem.endsWith(u8, child_rel, ".rhi")) continue;
+                try preloadSingleRhi(alloc, io, env, db_root, child_rel);
+            },
+            else => {},
+        }
+    }
+}
+
+fn preloadSingleRhi(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    env: *CompileEnv,
+    db_root: []const u8,
+    rhi_rel: []const u8,
+) !void {
+    // `rhi_rel` is e.g. "GHC/Base.rhi".  Derive module name "GHC.Base".
+    const sep = std.fs.path.sep;
+    const stem_len = rhi_rel.len - ".rhi".len;
+    const mod_name = try alloc.alloc(u8, stem_len);
+    defer alloc.free(mod_name);
+    for (rhi_rel[0..stem_len], 0..) |c, i| {
+        mod_name[i] = if (c == sep) '.' else c;
+    }
+    if (env.ifaces.contains(mod_name)) return; // already registered
+
+    const abs = try std.fs.path.join(alloc, &.{ db_root, rhi_rel });
+    defer alloc.free(abs);
+
+    const data = std.Io.Dir.readFileAlloc(
+        .cwd(),
+        io,
+        abs,
+        alloc,
+        .limited(16 * 1024 * 1024),
+    ) catch return;
+    defer alloc.free(data);
+    const iface = mod_iface.readRhi(alloc, data) catch return;
+    if (iface.format_version != mod_iface.rhi_format_version) return;
+
+    const claimed = mod_iface.maxUniqueInIface(iface);
+    if (claimed >= env.u_supply.next) env.u_supply.next = claimed + 1;
+
+    const ce = try deserialiseClassEnvFromIface(alloc, iface);
+    const owned = try alloc.dupe(u8, mod_name);
+    try env.class_envs.put(alloc, owned, ce);
+    const dict_names = try deserialiseDictNamesFromIface(alloc, iface);
+    try env.dict_names_map.put(alloc, owned, dict_names);
+    const empty_core = CoreProgram{ .data_decls = &.{}, .binds = &.{} };
+    try env.register(mod_name, iface, empty_core);
+
+    // Probe sibling .bc.
+    const bc_rel = try std.fmt.allocPrint(alloc, "{s}.bc", .{rhi_rel[0..stem_len]});
+    defer alloc.free(bc_rel);
+    const bc_abs = try std.fs.path.join(alloc, &.{ db_root, bc_rel });
+    std.Io.Dir.access(.cwd(), io, bc_abs, .{}) catch {
+        alloc.free(bc_abs);
+        return;
+    };
+    try env.cached_bc_paths.put(alloc, try alloc.dupe(u8, mod_name), bc_abs);
+}
+
+/// Hit metadata returned by `tryLoadFromPackageDbs`.
+///
+/// `bc_path` is the path of a sibling `.bc` artifact next to the matching
+/// `.rhi`, or `null` if no such artifact exists.  Caller-owned (allocated
+/// in the same allocator passed to `tryLoadFromPackageDbs`).
+pub const PkgDbHit = struct {
+    iface: mod_iface.ModIface,
+    bc_path: ?[]const u8 = null,
+};
+
 fn tryLoadFromPackageDbs(
     alloc: std.mem.Allocator,
     io: std.Io,
     module_name: []const u8,
     package_dbs: []const []const u8,
-) std.mem.Allocator.Error!?mod_iface.ModIface {
+) std.mem.Allocator.Error!?PkgDbHit {
     if (package_dbs.len == 0) return null;
 
     const rel = try moduleNameToRhiRelPath(alloc, module_name);
@@ -998,7 +1174,27 @@ fn tryLoadFromPackageDbs(
         // do not silently corrupt the compilation session.
         if (iface.format_version != mod_iface.rhi_format_version) continue;
 
-        return iface;
+        // Probe for a sibling `<module>.bc` so the downstream link step
+        // can pull the cached module's code in instead of having to
+        // re-source-compile it.  The probe is non-fatal: a missing .bc
+        // just means we still skip the frontend but the caller must
+        // arrange code elsewhere (typically: keep source-prepending the
+        // boot modules until the store is fully populated).
+        const stem_len = rel.len - ".rhi".len;
+        const bc_rel = try std.fmt.allocPrint(alloc, "{s}.bc", .{rel[0..stem_len]});
+        defer alloc.free(bc_rel);
+        const bc_abs = try std.fs.path.join(alloc, &.{ db, bc_rel });
+        const bc_exists = blk: {
+            std.Io.Dir.access(.cwd(), io, bc_abs, .{}) catch {
+                break :blk false;
+            };
+            break :blk true;
+        };
+        if (!bc_exists) {
+            alloc.free(bc_abs);
+            return .{ .iface = iface, .bc_path = null };
+        }
+        return .{ .iface = iface, .bc_path = bc_abs };
     }
     return null;
 }

--- a/src/modules/mod_iface.zig
+++ b/src/modules/mod_iface.zig
@@ -186,6 +186,103 @@ pub const SerialisedCoreType = struct {
     }
 };
 
+/// Walk `ty` and report the maximum `unique` / `binder_unique` value it
+/// references.  Returns 0 for trees that contain no uniques.
+///
+/// Used by `compile_env` after loading an iface from a package-db so the
+/// shared `UniqueSupply` can be advanced past every claim made by the
+/// cached interface, preventing collisions with freshly-allocated uniques
+/// in downstream modules (issue #839).
+pub fn maxUniqueInCoreType(ty: SerialisedCoreType) u64 {
+    var m: u64 = 0;
+    if (ty.unique) |u| if (u > m) {
+        m = u;
+    };
+    if (ty.binder_unique) |u| if (u > m) {
+        m = u;
+    };
+    if (ty.args) |args| for (args) |a| {
+        const c = maxUniqueInCoreType(a);
+        if (c > m) m = c;
+    };
+    if (ty.arg) |p| {
+        const c = maxUniqueInCoreType(p.*);
+        if (c > m) m = c;
+    }
+    if (ty.res) |p| {
+        const c = maxUniqueInCoreType(p.*);
+        if (c > m) m = c;
+    }
+    if (ty.body) |p| {
+        const c = maxUniqueInCoreType(p.*);
+        if (c > m) m = c;
+    }
+    return m;
+}
+
+/// Maximum `unique` value claimed anywhere inside `iface`.  Walks every
+/// exported value, data declaration, constructor, class info, instance
+/// info, dictionary entry, and the type schemes referenced by them.
+///
+/// Returns 0 for an empty iface.
+pub fn maxUniqueInIface(iface: ModIface) u64 {
+    var m: u64 = 0;
+    for (iface.values) |ev| {
+        if (ev.unique > m) m = ev.unique;
+        for (ev.scheme.binder_uniques) |u| if (u > m) {
+            m = u;
+        };
+        for (ev.scheme.constraints) |cn| {
+            if (cn.class_unique > m) m = cn.class_unique;
+            if (cn.tyvar_unique > m) m = cn.tyvar_unique;
+        }
+        const c = maxUniqueInCoreType(ev.scheme.body);
+        if (c > m) m = c;
+    }
+    for (iface.data_decls) |dd| {
+        if (dd.unique > m) m = dd.unique;
+        for (dd.tyvar_uniques) |u| if (u > m) {
+            m = u;
+        };
+        for (dd.constructors) |c| {
+            if (c.unique > m) m = c.unique;
+            const ct = maxUniqueInCoreType(c.ty);
+            if (ct > m) m = ct;
+        }
+    }
+    for (iface.class_infos) |ci| {
+        if (ci.name.unique > m) m = ci.name.unique;
+        if (ci.tyvar > m) m = ci.tyvar;
+        for (ci.superclasses) |s| if (s.unique > m) {
+            m = s.unique;
+        };
+        for (ci.methods) |mi| {
+            if (mi.name.unique > m) m = mi.name.unique;
+            const mt = maxUniqueInCoreType(mi.ty);
+            if (mt > m) m = mt;
+            if (mi.default_name) |dn| if (dn.unique > m) {
+                m = dn.unique;
+            };
+        }
+        if (ci.dict_con_name.unique > m) m = ci.dict_con_name.unique;
+    }
+    for (iface.instance_infos) |ii| {
+        if (ii.class_name.unique > m) m = ii.class_name.unique;
+        const ht = maxUniqueInCoreType(ii.head);
+        if (ht > m) m = ht;
+        for (ii.context) |cc| {
+            if (cc.class_name.unique > m) m = cc.class_name.unique;
+            const ct = maxUniqueInCoreType(cc.ty);
+            if (ct > m) m = ct;
+        }
+    }
+    for (iface.dict_entries) |de| {
+        if (de.class_unique > m) m = de.class_unique;
+        if (de.name_unique > m) m = de.name_unique;
+    }
+    return m;
+}
+
 // ── SerialisedScheme ────────────────────────────────────────────────────
 
 /// A serialisable class constraint: `ClassName tyvar`.

--- a/src/modules/mod_iface.zig
+++ b/src/modules/mod_iface.zig
@@ -1460,6 +1460,53 @@ test "rhiPath: handles file with no directory component" {
     try testing.expectEqualStrings("Main.rhi", path);
 }
 
+test "maxUniqueInIface: empty iface returns 0" {
+    const iface = ModIface{
+        .module_name = "Empty",
+        .values = &.{},
+        .data_decls = &.{},
+    };
+    try testing.expectEqual(@as(u64, 0), maxUniqueInIface(iface));
+}
+
+test "maxUniqueInIface: scans value uniques and embedded scheme uniques" {
+    const iface = ModIface{
+        .module_name = "ValueScan",
+        .values = &[_]ExportedValue{
+            .{
+                .name = "low",
+                .unique = 7,
+                .scheme = .{
+                    .binder_uniques = &.{},
+                    .binder_names = &.{},
+                    .constraints = &.{},
+                    .body = .{ .tag = "TyCon", .name = "Int", .unique = 100, .args = &.{} },
+                },
+            },
+            .{
+                .name = "high",
+                .unique = 9999,
+                .scheme = .{
+                    .binder_uniques = &.{12345},
+                    .binder_names = &[_][]const u8{"a"},
+                    .constraints = &.{},
+                    .body = .{ .tag = "TyVar", .name = "a", .unique = 12345 },
+                },
+            },
+        },
+        .data_decls = &.{},
+    };
+    // 12345 (binder unique embedded in scheme) is the highest.
+    try testing.expectEqual(@as(u64, 12345), maxUniqueInIface(iface));
+}
+
+test "maxUniqueInCoreType: walks nested FunTy and TyCon args" {
+    var arg = SerialisedCoreType{ .tag = "TyCon", .name = "Int", .unique = 50, .args = &.{} };
+    var res = SerialisedCoreType{ .tag = "TyCon", .name = "Bool", .unique = 75, .args = &.{} };
+    const fun = SerialisedCoreType{ .tag = "FunTy", .arg = &arg, .res = &res };
+    try testing.expectEqual(@as(u64, 75), maxUniqueInCoreType(fun));
+}
+
 test "ModIface: fingerprint survives writeRhi / readRhi round-trip" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/tests/e2e/e2e_841_data_char.hs
+++ b/tests/e2e/e2e_841_data_char.hs
@@ -1,0 +1,14 @@
+module Main where
+
+import Data.Char
+
+main :: IO ()
+main = do
+  putStrLn (show (ord 'A'))
+  putStrLn (show (chr 97))
+  putStrLn (show (isDigit '7'))
+  putStrLn (show (isAlpha 'z'))
+  putStrLn (show (toUpper 'a'))
+  putStrLn (show (toLower 'B'))
+  putStrLn (show (isSpace ' '))
+  putStrLn (show (digitToInt 'f'))

--- a/tests/e2e/e2e_841_data_char.stdout
+++ b/tests/e2e/e2e_841_data_char.stdout
@@ -1,0 +1,8 @@
+65
+'a'
+True
+True
+'A'
+'b'
+True
+15

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -244,6 +244,10 @@ test "e2e: e2e_713_enum_defaults (#713)" {
     try testE2e(std.testing.allocator, "e2e_713_enum_defaults");
 }
 
+test "e2e: e2e_841_data_char" {
+    try testE2e(std.testing.allocator, "e2e_841_data_char");
+}
+
 test "e2e: ghc_744_let_in_default_body (#744)" {
     try testE2e(std.testing.allocator, "ghc_744_let_in_default_body");
 }


### PR DESCRIPTION
Foundation for #837 — pre-install boot packages into rhc-store at zig
build time.  This PR delivers four slices:

1. **CLI flags on `rhc build`**: `--artifact-dir`, `--no-link`, `--no-boot`.
2. **Cached-iface unique-collision fix (#839)** + source-declared module name extractor.
3. **build.zig stage-2 boot-store bootstrap + `default_package_db` embed**.
4. **Cached-module `.bc` link plumbing** + eager package-db preload.

`zig build` now populates `zig-out/lib/rhc-store/` with `.rhi`+`.bc`
artifacts for the entire layered Prelude stack as part of the
default install step.  User `rhc build` invocations automatically
consult that store via the baked-in `default_package_db` — frontend
work for boot modules short-circuits to a cached interface load.

Codegen for user binaries still uses source-prepend by default
(known limitation, #840).  Cache-only codegen
(`--no-boot --package-db <store>`) works end-to-end at the
frontend but trips a tag-registry/force-module gap at link/runtime
— follow-up to wire cached GRIN metadata into the registry before
emitting the force module.

## Slice 1 — CLI flags

- `--artifact-dir <dir>` — per-module `.rhi`+`.bc` go to
  `<dir>/<Module/Path>.{rhi,bc}` (dots → subdirs).
- `--no-link` — skip the final linker invocation.
- `--no-boot` — skip the auto-prepend of the layered Prelude stack.

Native backend only; jit/wasm error out if `--artifact-dir` is given.

## Slice 2 — #839 fix

When `compileProgram` resolved an import via `--package-db`, the
cached interface's exports kept their original uniques but the
shared `UniqueSupply.next` stayed at 1000.  A freshly-compiled
downstream module would then collide.

Fix walks the loaded `ModIface` for the maximum unique anywhere in
its values / data_decls / constructors / class_infos /
instance_infos / dict_entries / embedded type schemes, then bumps
`u_supply.next` past it.  New `pub` helpers `maxUniqueInIface` /
`maxUniqueInCoreType` in `mod_iface.zig`.

Plus `extractSourceModuleName` in `main.zig` so files whose path
doesn't mirror their `module Foo.Bar where` declaration topo-sort
under their source-declared name.

Closes #839.

## Slice 3 — build.zig stage-2 + `default_package_db`

`build.zig` gains a `bootstrap` step that invokes the freshly-built
`rhc` against `lib/Prelude.hs` with `--no-link --artifact-dir
zig-out/lib/rhc-store`.  The source-prepend pulls every other boot
module along, so one rhc invocation populates the full store.

A new `-Ddefault-package-db=<path>` build option (defaults to
`zig-out/lib/rhc-store`) is baked into the rhc binary via the
existing `@embedFile` pattern; `cmdBuild` appends it to the
effective package-db list so user `rhc build` consults the cache
without an explicit `--package-db`.

To avoid a step-graph cycle, the boot-source `installFile` calls
were converted to `addInstallFile` so individual install steps can
be referenced as upstream deps of the bootstrap run.

## Slice 4 — Cached `.bc` link plumbing

- `tryLoadFromPackageDbs` returns a `PkgDbHit { iface, bc_path }`.
- `CompileEnv` gains `cached_bc_paths` keyed by module name.
- `emitNative` parses each cached `.bc` via `parseBitcodeFile` and
  appends to the link set, with a filter that skips modules also
  source-compiled (avoids duplicate symbols).
- A Phase-0 eager walk of every `--package-db` registers every
  `*.rhi` it finds — necessary because `ModIface` does not
  serialise `imports`.
- Implicit-Prelude injection now treats Prelude as "available"
  when any `--package-db` ships a `Prelude.rhi`.

## Why `.bc`, not `.o`

`.bc` enables LTO: per-module bitcode is merged via
`LLVMLinkModules2` before `runOptimizationPasses` runs at -O2, so
`head`, `foldr`, `primAddInt` etc. inline into user code at the
call site.  Pre-compiled `.o` would kill cross-module inlining
and regress inlining-bound bench programs.  Once intra-package
specialisation (#802, #807) is mature enough that boot code is
post-optimisation before serialisation, we can switch.

## End-to-end smoke

After `zig build`, `zig-out/lib/rhc-store/` holds all 7 boot
modules' `.rhi`+`.bc` pairs.  A user file using `sum`, `length`,
`map (+1)`, etc. compiles and runs correctly:

```
$ rhc build /tmp/HiList.hs -o /tmp/hilist && /tmp/hilist
15
5
[11,21,31]
```

## Follow-ups

- **#840** — full cache-only codegen.  Tag registry and
  `__rhc_force` emission must consume cached GRIN metadata before
  `--no-boot` can be the default.  Until then, source-prepend
  remains active and provides the codegen authority.
- **PR-D** — REPL `loadBootModule` consults the default db first;
  cache-only e2e test (deliverable 5 of #837).

## Testing

All existing tests pass.  Five new unit tests added.  Manual end-
to-end smoke checks above.

## Bench

Skipped — the default `rhc build` path is unchanged for user
codegen.

## Deliverables tracked by issue #837

- [x] Foundational CLI flags
- [x] Cached-iface unique-collision fix (#839)
- [x] Source-declared module name extraction
- [x] build.zig stage-2 + default_package_db
- [x] Cached-module `.bc` link plumbing (#840 gates full enablement)
- [ ] REPL cache + cache-only e2e test (PR-D)
