### PR TITLE
#851: Fix derived Eq/Ord for constructors with fields

### DIFF
--- a/src/deriving/builder.zig
+++ b/src/deriving/builder.zig
@@ -9,7 +9,39 @@ const ast = @import("../frontend/ast.zig");
 const span_mod = @import("../diagnostics/span.zig");
 
 pub const SourceSpan = span_mod.SourceSpan;
+pub const SourcePos = span_mod.SourcePos;
 pub const Allocator = std.mem.Allocator;
+
+/// Monotonic counter giving every synthesised *expression* occurrence of a
+/// variable or operator a distinct column.
+///
+/// The desugarer's dictionary-evidence map is keyed by
+/// `(var_unique, span_start_line, span_start_col, class_unique)`.  All nodes a
+/// deriving builder emits share one source span — the `deriving (...)` clause.
+/// Without distinct spans the many class-method call sites in a single derived
+/// instance collapse onto one key, so e.g. the field comparison `x == y`
+/// (needing `Eq Int`) and `(/=)`'s own `x == y` (needing `Eq <T>`) overwrite
+/// each other; the field comparison is then handed the instance's *own*
+/// dictionary and dispatches on the wrong constructor, crashing at runtime with
+/// "Non-exhaustive patterns in case".  Giving each occurrence a unique column
+/// keeps the evidence keys distinct.  See #851.
+var occ_seq: u32 = 0;
+
+/// Reset the occurrence-span counter. Called at the start of each deriving
+/// pass so span assignment is deterministic per compile / REPL input.
+pub fn resetOccurrenceSpans() void {
+    occ_seq = 0;
+}
+
+/// Derive a distinct span from `span`, preserving file + line (so diagnostics
+/// still point at the user's `deriving` clause) but assigning a fresh column.
+fn freshOccSpan(span: SourceSpan) SourceSpan {
+    occ_seq += 1;
+    const line = if (span.start.line > 0) span.start.line else 1;
+    const start = SourcePos.init(span.start.file_id, line, occ_seq);
+    const end = SourcePos.init(span.start.file_id, line, occ_seq + 1);
+    return SourceSpan.init(start, end);
+}
 
 pub fn alloc(arena: Allocator, comptime T: type, value: T) Allocator.Error!*const T {
     const ptr = try arena.create(T);
@@ -22,7 +54,9 @@ pub fn mkQName(name: []const u8, span: SourceSpan) ast.QName {
 }
 
 pub fn mkVar(name: []const u8, span: SourceSpan) ast.Expr {
-    return .{ .Var = mkQName(name, span) };
+    // A variable *occurrence* may carry a class-method constraint, so it needs
+    // a unique span for evidence keying (see `occ_seq`).
+    return .{ .Var = mkQName(name, freshOccSpan(span)) };
 }
 
 pub fn mkVarPat(name: []const u8, span: SourceSpan) ast.Pattern {
@@ -88,7 +122,9 @@ pub fn mkInfix(
 ) Allocator.Error!ast.Expr {
     return .{ .InfixApp = .{
         .left = try alloc(arena, ast.Expr, left),
-        .op = mkQName(op, span),
+        // The operator occurrence carries the class-method constraint, so it
+        // needs a unique span for evidence keying (see `occ_seq`).
+        .op = mkQName(op, freshOccSpan(span)),
         .right = try alloc(arena, ast.Expr, right),
     } };
 }

--- a/src/deriving/deriving.zig
+++ b/src/deriving/deriving.zig
@@ -48,6 +48,11 @@ pub fn derive(
 ) DeriveError!void {
     var out: std.ArrayListUnmanaged(ast.Decl) = .empty;
 
+    // Reset the occurrence-span counter so each synthesised class-method call
+    // site gets a distinct span (required for correct dictionary-evidence
+    // keying in the desugarer — see builder.occ_seq / #851).
+    builder.resetOccurrenceSpans();
+
     // Synthesise instances inline, placing the helpers + instance
     // immediately after the data/newtype declaration that triggered them.
     // This keeps each type with its derived machinery together and matches

--- a/tests/e2e/e2e_851_deriving_fields.hs
+++ b/tests/e2e/e2e_851_deriving_fields.hs
@@ -1,0 +1,36 @@
+-- e2e_851: Derived Eq/Ord for constructors with fields.
+--
+-- Regression test for #851: deriving Eq/Ord on a constructor carrying
+-- fields used to crash at runtime ("Non-exhaustive patterns in case").
+-- The cause was that every node a deriving builder emits shares the one
+-- `deriving (...)` source span, and the desugarer's dictionary-evidence
+-- map is keyed by span — so the field comparison `x == y` (needing the
+-- field's instance) and `(/=)`'s own `x == y` (needing the data type's
+-- instance) collided, and the field comparison was handed the wrong
+-- dictionary, dispatching on the wrong constructor.
+--
+-- Covers single-field, multi-field, and multi-constructor-with-fields.
+
+data Age = Age Int deriving (Eq, Ord)
+
+data Point = Point Int Int deriving (Eq, Ord)
+
+data Mix = Nil | Cons Int deriving (Eq, Ord)
+
+main :: IO ()
+main = do
+  -- single-field Eq
+  putStrLn (case Age 1 == Age 1 of True -> "T"; False -> "F")  -- T
+  putStrLn (case Age 1 == Age 2 of True -> "T"; False -> "F")  -- F
+  -- multi-field Eq
+  putStrLn (case Point 1 2 == Point 1 2 of True -> "T"; False -> "F")  -- T
+  putStrLn (case Point 1 2 == Point 1 3 of True -> "T"; False -> "F")  -- F
+  -- single-field Ord
+  putStrLn (case compare (Age 1) (Age 2) of LT -> "LT"; EQ -> "EQ"; GT -> "GT")  -- LT
+  -- multi-field Ord (lexicographic)
+  putStrLn (case compare (Point 1 2) (Point 1 3) of LT -> "LT"; EQ -> "EQ"; GT -> "GT")  -- LT
+  putStrLn (case compare (Point 2 0) (Point 1 9) of LT -> "LT"; EQ -> "EQ"; GT -> "GT")  -- GT
+  -- multi-constructor with a field
+  putStrLn (case Cons 5 == Cons 5 of True -> "T"; False -> "F")  -- T
+  putStrLn (case Cons 5 == Nil of True -> "T"; False -> "F")     -- F
+  putStrLn (case compare Nil (Cons 0) of LT -> "LT"; EQ -> "EQ"; GT -> "GT")  -- LT

--- a/tests/e2e/e2e_851_deriving_fields.stdout
+++ b/tests/e2e/e2e_851_deriving_fields.stdout
@@ -1,0 +1,10 @@
+T
+F
+T
+F
+LT
+LT
+GT
+T
+F
+LT

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -232,6 +232,10 @@ test "e2e: e2e_679_deriving_eq (#679)" {
     try testE2e(std.testing.allocator, "e2e_679_deriving_eq");
 }
 
+test "e2e: e2e_851_deriving_fields (#851)" {
+    try testE2e(std.testing.allocator, "e2e_851_deriving_fields");
+}
+
 test "e2e: e2e_605_zero_field_thunk (#605)" {
     try testE2e(std.testing.allocator, "e2e_605_zero_field_thunk");
 }


### PR DESCRIPTION
Addresses #851 (derived `Eq`/`Ord`). Derived `Show` is split to #863.

## Summary

Deriving `Eq` or `Ord` on **any** constructor carrying at least one field
crashed at runtime with "Non-exhaustive patterns in case". Only nullary
enumerations worked (e.g. `data Day = Mon | Tue`), which is why it went
unnoticed — the issue title said "single-field" but it reproduces for
2-field, multi-constructor-with-fields, etc.

## Root cause

Every AST node a deriving builder emits carries the same source span — the
`deriving (...)` clause. The desugarer's dictionary-evidence map is keyed by
`(var_unique, span_start_line, span_start_col, class_unique)`, so the several
class-method call sites in one derived instance collapse onto a single key.

For derived `Eq`, the field comparison `x == y` (needing the **field's** `Eq`,
e.g. `Eq Int`) and `(/=)`'s own `x == y` (needing the **data type's** `Eq`)
share `(==, deriving-span, Eq)`. The evidence map (`ArrayHashMap.put`)
overwrites on duplicate keys, so the field comparison was handed the wrong
dictionary and dispatched `case x0 of <DataCon> -> …` on an `Int`, falling
through to a non-exhaustive default.

## Fix

Give every synthesised variable/operator *occurrence* a distinct column
(anchored to the deriving-clause line so diagnostics still point at the right
place) via a counter in `src/deriving/builder.zig`, reset at the start of each
deriving pass. Distinct spans keep the evidence-map keys distinct, so each call
site resolves to its own dictionary. Touches only `src/deriving/` —
`mkVar`/`mkInfix` and a `resetOccurrenceSpans()` call in `derive()`.

## Deliverables

- [x] Derived `Eq`/`Ord` for single-field, multi-field and
      multi-constructor-with-fields constructors no longer crash.
- [x] e2e test (`tests/e2e/e2e_851_deriving_fields.hs`).

## Testing

`tests/e2e/e2e_851_deriving_fields.hs` covers single-field, multi-field and
multi-constructor-with-fields `deriving (Eq, Ord)` → `T/F/T/F/LT/LT/GT/T/F/LT`.

Full suite green: 940 unit, 75 e2e (incl. the new test), 35 repl, plus
golden / parser / rts / prelude / pkg.

## Scope

Derived `Show` for field constructors is **not** fixed here — its field method
is a prefix call (`show x0`) whose evidence resolves through a different
desugarer path that remains wrong even with distinct spans. Split to #863 with
a full analysis. `data Day = Mon | Tue deriving Show` (nullary) is unaffected
and still works.

## Benchmarks

Skipped — the change is confined to `src/deriving/` (instance synthesis), which
is not part of the benchmarked perf surface (backend/GRIN/core/typecheck/
desugar/parser/modules/RTS/Prelude). Codegen for non-deriving programs is
byte-identical.
