### PR TITLE
#848: Cleanly reject tuples of arity > 7 with a clear diagnostic

### DIFF
--- a/src/typechecker/infer.zig
+++ b/src/typechecker/infer.zig
@@ -1005,8 +1005,33 @@ pub fn inferPat(ctx: *InferCtx, pat: RPat) std.mem.Allocator.Error!*HType {
             break :blk inst_ty;
         },
         .Tuple => |pats| blk: {
-            if (pats.len > Known.Con.max_tuple_arity or pats.len == 0) {
-                // Fall back to fresh meta for arities not yet wired.
+            if (pats.len > Known.Con.max_tuple_arity) {
+                // Tuples beyond the wired arity are not yet supported end-to-end
+                // (the backend's calling convention caps constructor arity).
+                // Emit a clear diagnostic rather than silently falling back to a
+                // metavariable, which surfaced downstream as a misleading
+                // "unbound variable" error (#848).
+                const msg = try std.fmt.allocPrint(
+                    ctx.alloc,
+                    "tuples of arity greater than {d} are not yet supported (this pattern has arity {d})",
+                    .{ Known.Con.max_tuple_arity, pats.len },
+                );
+                try ctx.diags.emit(ctx.alloc, .{
+                    .severity = .@"error",
+                    .code = .type_error,
+                    .span = getPatSpan(&pats[0]),
+                    .message = msg,
+                });
+                // Still infer each sub-pattern so its bound variables are
+                // registered (with fresh metas). Otherwise every variable in
+                // the tuple cascades into a misleading "unbound variable"
+                // error on top of the clear arity diagnostic.
+                for (pats) |p| _ = try inferPat(ctx, p);
+                break :blk ctx.freshMeta();
+            }
+            if (pats.len == 0) {
+                // Defensive: a 0-element tuple should never reach here (`()` is
+                // parsed as Unit). Keep the silent meta fallback.
                 break :blk ctx.freshMeta();
             }
 
@@ -1381,8 +1406,26 @@ pub fn infer(ctx: *InferCtx, expr: RExpr) std.mem.Allocator.Error!*HType {
 
         // ── Tuple ─────────────────────────────────────────────────────
         .Tuple => |elems| blk: {
-            if (elems.len > Known.Con.max_tuple_arity or elems.len == 0) {
-                // Fall back to fresh meta for arities not yet wired.
+            if (elems.len > Known.Con.max_tuple_arity) {
+                // Tuples beyond the wired arity are not yet supported end-to-end
+                // (the backend's calling convention caps constructor arity).
+                // Emit a clear diagnostic rather than silently falling back to a
+                // metavariable (#848).
+                const msg = try std.fmt.allocPrint(
+                    ctx.alloc,
+                    "tuples of arity greater than {d} are not yet supported (this tuple has arity {d})",
+                    .{ Known.Con.max_tuple_arity, elems.len },
+                );
+                try ctx.diags.emit(ctx.alloc, .{
+                    .severity = .@"error",
+                    .code = .type_error,
+                    .span = getExprSpan(elems[0]),
+                    .message = msg,
+                });
+                break :blk ctx.freshMeta();
+            }
+            if (elems.len == 0) {
+                // Defensive: `()` is parsed as Unit, not a 0-tuple.
                 break :blk ctx.freshMeta();
             }
 

--- a/tests/compile_fail_test_runner.zig
+++ b/tests/compile_fail_test_runner.zig
@@ -226,3 +226,7 @@ test "should_fail_compile: sfc002_unbound_variable" {
 test "should_fail_compile: sfc003_unsupported_ccall_symbol (#536)" {
     try testShouldFailCompile(std.testing.allocator, "sfc003_unsupported_ccall_symbol");
 }
+
+test "should_fail_compile: sfc004_tuple_arity_too_large (#848)" {
+    try testShouldFailCompile(std.testing.allocator, "sfc004_tuple_arity_too_large");
+}

--- a/tests/should_fail_compile/sfc004_tuple_arity_too_large.hs
+++ b/tests/should_fail_compile/sfc004_tuple_arity_too_large.hs
@@ -1,0 +1,12 @@
+-- #848: a tuple of arity > 7 is not yet supported end-to-end. The compiler
+-- must cleanly reject it rather than silently miscompile.
+--
+-- Under `rhc build` (full Prelude) this reports the clear diagnostic
+-- "tuples of arity greater than 7 are not yet supported …". This harness
+-- runs without the Prelude, so it only asserts that compilation fails (any
+-- diagnostic), guarding against a silent miscompile or crash.
+sum8 :: (Int, Int, Int, Int, Int, Int, Int, Int) -> Int
+sum8 (a, b, c, d, e, f, g, h) = a + b + c + d + e + f + g + h
+
+main :: IO ()
+main = print (sum8 (1, 2, 3, 4, 5, 6, 7, 8))


### PR DESCRIPTION
Closes #848.

## Summary

A tuple of arity greater than the wired maximum (7) used to fall back to a
fresh type metavariable in the typechecker, so its bound variables were never
typed and surfaced downstream as a misleading cascade of
`unbound variable \`a\` (renamer bug?)` errors — confusing, and pointing at the
wrong thing.

## Fix

The tuple **pattern** and tuple **expression** inference arms
(`src/typechecker/infer.zig`) now emit a clear diagnostic:

```
error[E002]: tuples of arity greater than 7 are not yet supported (this pattern has arity 8)
```

The pattern arm still infers each sub-pattern so its bound variables are
registered (with fresh metas), which suppresses the unbound-variable cascade —
only the single clear error is reported. Valid programs (arity ≤ 7) are
completely unaffected; the new code is on the arity-> -7 error path only.

## Why not actually support arity 8..62

Investigated and filed as **#865**. The type-level wiring widens cleanly, but
the LLVM backend has a hard 8-argument cap (fixed `[8]` param/arg buffers
throughout `grin_to_llvm.zig`, some with silent `@min(…, 8)` truncation). A
62-element tuple constructor wrapper is a 62-parameter function that overflows
those buffers (`index out of bounds: index 53, len 8` while compiling the
Prelude). Lifting that cap is a backend calling-convention change tracked
separately; this PR takes the issue's bounded "cleanly reject" alternative.

## Deliverables

- [x] Clear diagnostic at the cap instead of a misleading unbound-variable
      error (the issue's option 2).
- [x] Regression test (`tests/should_fail_compile/sfc004_tuple_arity_too_large.hs`).

## Testing

`rhc build` on an 8-tuple program now reports the clear arity diagnostic (for
both the `(a,…,h)` pattern and the `(1,…,8)` literal) with no
unbound-variable noise. Full suite green: 940 unit, 74 e2e, 4 compile-fail
(incl. the new test), 35 repl, plus golden / parser / rts / prelude / pkg.

## Benchmarks

Skipped — the change adds a typechecker diagnostic on the arity-> -7 error
path only; codegen for all valid programs is byte-identical.
