### PR TITLE
#867: Load the full boot Prelude in rhc core/grin (unblocks IR inspection)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -621,91 +621,32 @@ fn cmdCheck(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
 /// Parse, check, and desugar a Haskell source file to Core IR.
 /// Prints the resulting Core IR to stdout.
 fn cmdCore(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
-    const source = readSourceFile(allocator, io, file_path) catch |err| {
-        var stderr_buf: [4096]u8 = undefined;
-        var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
-        const stderr = &stderr_fw.interface;
-        switch (err) {
-            error.FileNotFound => try stderr.print("rhc: file not found: {s}\n", .{file_path}),
-            error.AccessDenied => try stderr.print("rhc: permission denied: {s}\n", .{file_path}),
-            else => try stderr.print("rhc: cannot read file '{s}': {}\n", .{ file_path, err }),
-        }
-        try stderr.flush();
-        std.process.exit(1);
-    };
-    defer allocator.free(source);
-
-    const file_id: FileId = 1;
-
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const arena_alloc = arena.allocator();
 
-    var lexer = Lexer.init(arena_alloc, source, file_id);
-    var layout = LayoutProcessor.init(arena_alloc, &lexer);
-    var diags = DiagnosticCollector.init();
-    defer diags.deinit(arena_alloc);
-    layout.setDiagnostics(&diags);
+    const compile_env_mod = rusholme.modules.compile_env;
 
-    var parser = Parser.init(arena_alloc, &layout, &diags) catch {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    };
-    var module = parser.parseModule() catch {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    };
-    if (diags.hasErrors()) {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    }
+    // Compile the user file against the full boot Prelude stack (same path as
+    // `rhc build`), so Prelude symbols like `show`/`++` resolve and the dumped
+    // Core reflects what the compiler actually produces. `rhc core` assumes the
+    // implicit Prelude; NoImplicitPrelude programs are not specially handled.
+    const source_modules = try assembleSourceModules(arena_alloc, io, &.{file_path}, false, null);
 
-    var u_supply = rusholme.naming.unique.UniqueSupply{};
-    const no_implicit_prelude = module.language_extensions.contains(.NoImplicitPrelude);
-    var rename_env = try renamer_mod.RenameEnv.init(arena_alloc, &u_supply, &diags, no_implicit_prelude);
-    defer rename_env.deinit();
+    var effective_pkg_dbs: std.ArrayListUnmanaged([]const u8) = .empty;
+    const default_db = getDefaultPackageDb();
+    if (default_db.len > 0) try effective_pkg_dbs.append(arena_alloc, default_db);
 
-    // ── Load Prelude before user rename ───────────────────────────────
-    var mv_supply = htype_mod.MetaVarSupply{};
-    var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
-    try rusholme.tc.env.initBuiltins(&ty_env, &u_supply, no_implicit_prelude);
-
-    // Respect the NoImplicitPrelude language extension: only load Prelude
-    // when the user has NOT enabled NoImplicitPrelude.
-    var prelude_result: ?PreludeResult = null;
-    if (!no_implicit_prelude) {
-        var pipeline_core = rusholme.repl.pipeline.Pipeline.init(arena_alloc, io);
-        prelude_result = loadPrelude(arena_alloc, io, &pipeline_core, &u_supply, &rename_env, &ty_env, &mv_supply, &diags) catch null;
-    }
-
-    try deriving_mod.derive(arena_alloc, &module, &diags);
-    const renamed = try renamer_mod.rename(module, &rename_env);
-    if (diags.hasErrors()) {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
+    var session_result = try compile_env_mod.compileProgram(arena_alloc, io, source_modules, effective_pkg_dbs.items);
+    var session = &session_result.env;
+    defer session.deinit();
+    if (session_result.result.had_errors) {
+        try renderMultiFileDiagnostics(allocator, io, &session.diags);
         std.process.exit(1);
     }
 
-    var infer_ctx = infer_mod.InferCtx.init(arena_alloc, &ty_env, &mv_supply, &u_supply, &diags);
-    if (prelude_result) |pr| {
-        try infer_ctx.class_env.mergeFrom(&pr.class_env);
-    }
-    var module_types = try infer_mod.inferModule(&infer_ctx, renamed, null);
-    defer module_types.deinit(arena_alloc);
-    if (diags.hasErrors()) {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    }
-
-    // ── Desugar ────────────────────────────────────────────────────────
-    const ext_dict_names: ?*const rusholme.core.desugar.DesugarCtx.DictNameMap = if (prelude_result) |*pr| &pr.dict_names else null;
-    const desugar_result = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags, &u_supply, ext_dict_names);
-    const core_prog = desugar_result.program;
-    if (diags.hasErrors()) {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    }
-
-    // ── Pretty-print ───────────────────────────────────────────────────
+    // ── Pretty-print the merged whole-program Core ─────────────────────
+    const core_prog = session_result.result.core;
     var stdout_buf: [4096]u8 = undefined;
     var stdout_fw: File.Writer = .init(.stdout(), io, &stdout_buf);
     var stdout = &stdout_fw.interface;
@@ -721,109 +662,34 @@ fn cmdCore(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
 /// Parse, check, desugar, lambda-lift, and translate to GRIN IR.
 /// Prints the resulting GRIN IR to stdout.
 fn cmdGrin(allocator: std.mem.Allocator, io: Io, file_path: []const u8) !void {
-    const source = readSourceFile(allocator, io, file_path) catch |err| {
-        var stderr_buf: [4096]u8 = undefined;
-        var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
-        const stderr = &stderr_fw.interface;
-        switch (err) {
-            error.FileNotFound => try stderr.print("rhc: file not found: {s}\n", .{file_path}),
-            error.AccessDenied => try stderr.print("rhc: permission denied: {s}\n", .{file_path}),
-            else => try stderr.print("rhc: cannot read file '{s}': {}\n", .{ file_path, err }),
-        }
-        try stderr.flush();
-        std.process.exit(1);
-    };
-    defer allocator.free(source);
-
-    const file_id: FileId = 1;
-
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const arena_alloc = arena.allocator();
 
-    // ── Parse ──────────────────────────────────────────────────────────
-    var lexer = Lexer.init(arena_alloc, source, file_id);
-    var layout = LayoutProcessor.init(arena_alloc, &lexer);
-    var diags = DiagnosticCollector.init();
-    defer diags.deinit(arena_alloc);
-    layout.setDiagnostics(&diags);
+    const compile_env_mod = rusholme.modules.compile_env;
 
-    var parser = Parser.init(arena_alloc, &layout, &diags) catch {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    };
-    var module = parser.parseModule() catch {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    };
-    if (diags.hasErrors()) {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
+    // Compile the user file against the full boot Prelude stack so Prelude
+    // symbols resolve (see `cmdCore` / `assembleSourceModules`).
+    const source_modules = try assembleSourceModules(arena_alloc, io, &.{file_path}, false, null);
+
+    var effective_pkg_dbs: std.ArrayListUnmanaged([]const u8) = .empty;
+    const default_db = getDefaultPackageDb();
+    if (default_db.len > 0) try effective_pkg_dbs.append(arena_alloc, default_db);
+
+    var session_result = try compile_env_mod.compileProgram(arena_alloc, io, source_modules, effective_pkg_dbs.items);
+    var session = &session_result.env;
+    defer session.deinit();
+    if (session_result.result.had_errors) {
+        try renderMultiFileDiagnostics(allocator, io, &session.diags);
         std.process.exit(1);
     }
 
-    // ── Rename ─────────────────────────────────────────────────────────
-    var u_supply = rusholme.naming.unique.UniqueSupply{};
-    const no_implicit_prelude = module.language_extensions.contains(.NoImplicitPrelude);
-    var rename_env = try renamer_mod.RenameEnv.init(arena_alloc, &u_supply, &diags, no_implicit_prelude);
-    defer rename_env.deinit();
-
-    // ── Load Prelude before user rename ───────────────────────────────
-    var mv_supply = htype_mod.MetaVarSupply{};
-    var ty_env = try rusholme.tc.env.TyEnv.init(arena_alloc);
-    try rusholme.tc.env.initBuiltins(&ty_env, &u_supply, no_implicit_prelude);
-
-    // Respect the NoImplicitPrelude language extension: only load Prelude
-    // when the user has NOT enabled NoImplicitPrelude.
-    var prelude_result: ?PreludeResult = null;
-    if (!no_implicit_prelude) {
-        var pipeline_grin = rusholme.repl.pipeline.Pipeline.init(arena_alloc, io);
-        prelude_result = loadPrelude(arena_alloc, io, &pipeline_grin, &u_supply, &rename_env, &ty_env, &mv_supply, &diags) catch null;
-    }
-
-    try deriving_mod.derive(arena_alloc, &module, &diags);
-    const renamed = try renamer_mod.rename(module, &rename_env);
-    if (diags.hasErrors()) {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    }
-
-    // ── Typecheck ──────────────────────────────────────────────────────
-    var infer_ctx = infer_mod.InferCtx.init(arena_alloc, &ty_env, &mv_supply, &u_supply, &diags);
-    if (prelude_result) |pr| {
-        try infer_ctx.class_env.mergeFrom(&pr.class_env);
-    }
-    var module_types = try infer_mod.inferModule(&infer_ctx, renamed, null);
-    defer module_types.deinit(arena_alloc);
-    if (diags.hasErrors()) {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    }
-
-    // ── Desugar ────────────────────────────────────────────────────────
-    const ext_dict_names: ?*const rusholme.core.desugar.DesugarCtx.DictNameMap = if (prelude_result) |*pr| &pr.dict_names else null;
-    const desugar_result = try rusholme.core.desugar.desugarModule(arena_alloc, renamed, &module_types, &diags, &u_supply, ext_dict_names);
-    const core_prog = desugar_result.program;
-    if (diags.hasErrors()) {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    }
-
-    // ── Lambda lift ────────────────────────────────────────────────────
-    const ext_scope_1 = try collectExternalScope(arena_alloc, &module_types);
-    const lift_result_1 = try rusholme.core.lift.lambdaLift(arena_alloc, core_prog, ext_scope_1, 0);
-    const core_lifted = lift_result_1.program;
-    if (diags.hasErrors()) {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    }
-
-    // ── Translate to GRIN ───────────────────────────────────────────────
-    const grin_result = try rusholme.grin.translate.translateProgram(arena_alloc, core_lifted, null, null, null, null, 0);
+    // ── Lambda lift + translate the merged whole-program Core to GRIN ──
+    // The merged Core is self-contained (boot stack is source-compiled into
+    // it), so there is no external scope.
+    const lift_result = try rusholme.core.lift.lambdaLift(arena_alloc, session_result.result.core, null, 0);
+    const grin_result = try rusholme.grin.translate.translateProgram(arena_alloc, lift_result.program, null, null, null, null, 0);
     const grin_prog = grin_result.program;
-    if (diags.hasErrors()) {
-        try renderDiagnostics(allocator, io, &diags, file_id, file_path, source);
-        std.process.exit(1);
-    }
 
     // ── Pretty-print ───────────────────────────────────────────────────
     var stdout_buf: [4096]u8 = undefined;
@@ -1066,6 +932,86 @@ fn loadPrelude(
 /// - native: compiles to native executable via LLVM
 /// - wasm: compiles to WebAssembly binary (.wasm)
 /// - jit, c: not yet implemented
+/// Assemble the source-module list a multi-module compile needs: the boot
+/// Prelude stack (`RHC.Prim` → … → `Prelude`, in dependency order, skipping any
+/// the user shadows by module name) followed by the user's own files, with
+/// monotonic `file_id`s (boot modules take the low IDs).
+///
+/// Shared by `cmdBuild` and the IR-dump subcommands so they all see the full
+/// layered Prelude — without it, dumps compiled a user file against only
+/// `lib/Prelude.hs`, leaving `show`, `++`, etc. unbound.
+///
+/// `artifact_dir` only affects whether boot modules carry a `source_path` (used
+/// to auto-write `.rhi`); pass `null` for dumps. A missing boot module warns and
+/// is skipped; an unreadable user file is fatal (exits).
+fn assembleSourceModules(
+    arena_alloc: std.mem.Allocator,
+    io: Io,
+    file_paths: []const []const u8,
+    no_boot: bool,
+    artifact_dir: ?[]const u8,
+) std.mem.Allocator.Error![]rusholme.modules.compile_env.SourceModule {
+    const compile_env_mod = rusholme.modules.compile_env;
+    var source_modules: std.ArrayListUnmanaged(compile_env_mod.SourceModule) = .empty;
+
+    var user_module_names: std.StringHashMapUnmanaged(void) = .empty;
+    for (file_paths) |fp| {
+        const mod_name = try rusholme.modules.module_graph.inferModuleName(arena_alloc, fp);
+        try user_module_names.put(arena_alloc, mod_name, {});
+    }
+
+    var next_file_id: u32 = 0;
+    if (!no_boot) {
+        for (boot_modules) |boot| {
+            if (user_module_names.contains(boot.module_name)) continue;
+            const boot_path = boot.pathFn();
+            if (readSourceFile(arena_alloc, io, boot_path)) |boot_source| {
+                try source_modules.append(arena_alloc, .{
+                    .module_name = boot.module_name,
+                    .source = boot_source,
+                    .file_id = next_file_id,
+                    .source_path = if (artifact_dir == null) boot_path else null,
+                });
+                next_file_id += 1;
+            } else |err| {
+                var stderr_buf: [4096]u8 = undefined;
+                var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
+                const stderr = &stderr_fw.interface;
+                switch (err) {
+                    error.FileNotFound => stderr.print("rhc: warning: boot module '{s}' not found at '{s}'; using built-in names only\n", .{ boot.module_name, boot_path }) catch {},
+                    else => stderr.print("rhc: warning: cannot read boot module '{s}' at '{s}': {}; using built-in names only\n", .{ boot.module_name, boot_path, err }) catch {},
+                }
+                stderr.flush() catch {};
+            }
+        }
+    }
+
+    for (file_paths) |fp| {
+        const source = readSourceFile(arena_alloc, io, fp) catch |err| {
+            var stderr_buf: [4096]u8 = undefined;
+            var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
+            const stderr = &stderr_fw.interface;
+            switch (err) {
+                error.FileNotFound => stderr.print("rhc: file not found: {s}\n", .{fp}) catch {},
+                error.AccessDenied => stderr.print("rhc: permission denied: {s}\n", .{fp}) catch {},
+                else => stderr.print("rhc: cannot read file '{s}': {}\n", .{ fp, err }) catch {},
+            }
+            stderr.flush() catch {};
+            std.process.exit(1);
+        };
+        const mod_name = extractSourceModuleName(source) orelse
+            try rusholme.modules.module_graph.inferModuleName(arena_alloc, fp);
+        try source_modules.append(arena_alloc, .{
+            .module_name = mod_name,
+            .source = source,
+            .file_id = next_file_id,
+        });
+        next_file_id += 1;
+    }
+
+    return source_modules.toOwnedSlice(arena_alloc);
+}
+
 fn cmdBuild(
     allocator: std.mem.Allocator,
     io: Io,
@@ -1089,7 +1035,6 @@ fn cmdBuild(
     const arena_alloc = arena.allocator();
 
     const compile_env_mod = rusholme.modules.compile_env;
-    var source_modules: std.ArrayListUnmanaged(compile_env_mod.SourceModule) = .empty;
 
     // Prepend the baked-in default package db so user `rhc build` picks up
     // pre-built boot artifacts without needing an explicit
@@ -1101,98 +1046,16 @@ fn cmdBuild(
     const default_db = getDefaultPackageDb();
     if (default_db.len > 0) try effective_pkg_dbs.append(arena_alloc, default_db);
 
-    // ── Auto-prepend boot modules unless the user explicitly passed them ─
-    //
-    // The boot modules (`RHC.Prim`, `Prelude`, …) form the layered
-    // Prelude stack.  We prepend them in declared dependency order so
-    // the module graph topo-sorts them ahead of user code.  An entry is
-    // skipped when the user has already supplied a file whose inferred
-    // module name matches — this lets a test or a custom Prelude shadow
-    // a boot module wholesale.
-    var user_module_names: std.StringHashMapUnmanaged(void) = .empty;
-    for (file_paths) |fp| {
-        const mod_name = try rusholme.modules.module_graph.inferModuleName(arena_alloc, fp);
-        try user_module_names.put(arena_alloc, mod_name, {});
-    }
+    // Boot Prelude stack (unless `--no-boot`) + the user's files, with
+    // monotonic file_ids. See `assembleSourceModules`. We still source-prepend
+    // the boot stack even when `effective_pkg_dbs` carries `.rhi`/`.bc`
+    // artifacts: the LLVM tag registry and `__rhc_force` module are built from
+    // the *fresh* per-module GRIN, and cached modules contribute none, so a
+    // cache-only force module would be incomplete and fail to link (full
+    // cache-only codegen is tracked separately).
+    const source_modules = try assembleSourceModules(arena_alloc, io, file_paths, no_boot, artifact_dir);
 
-    // File IDs are assigned monotonically; boot modules take the low IDs.
-    var next_file_id: u32 = 0;
-
-    // `--no-boot` skips the auto-prepend entirely.  This is the bootstrap
-    // mode used by `build.zig` when compiling the boot packages themselves
-    // — RHC.Prim has nothing to depend on, GHC.Base depends only on
-    // RHC.Prim (resolved via `--package-db`), and so on.  User-mode builds
-    // always want the prepend.
-    if (!no_boot) {
-        for (boot_modules) |boot| {
-        if (user_module_names.contains(boot.module_name)) continue;
-        // NOTE: even when `effective_pkg_dbs` carries a full set of
-        // boot-module `.rhi`+`.bc` artifacts, we currently still
-        // source-prepend the boot stack.  Skipping the prepend lets
-        // the cached code path provide the interfaces, but the LLVM
-        // tag registry and `__rhc_force` module are built from the
-        // *fresh* per-module GRIN — cached modules contribute no
-        // GRIN to that registry, so the resulting force module is
-        // incomplete and the link fails.  Full cache-only codegen is
-        // tracked separately (see PR-C scope notes in the issue).
-        const boot_path = boot.pathFn();
-        if (readSourceFile(arena_alloc, io, boot_path)) |boot_source| {
-            try source_modules.append(arena_alloc, .{
-                .module_name = boot.module_name,
-                .source = boot_source,
-                .file_id = next_file_id,
-                // When emitting to an artifact dir we drop `source_path` so
-                // `compile_env.zig` does NOT auto-write `.rhi` next to the
-                // source.  The store-canonical `.rhi` is written explicitly
-                // below into `<artifact_dir>/<Module/Path>.rhi`.
-                .source_path = if (artifact_dir == null) boot_path else null,
-            });
-            next_file_id += 1;
-        } else |err| {
-            // A missing boot module is non-fatal in development: warn and
-            // continue without it.  User modules still get wired-in names
-            // from `initBuiltins` / `populateWiredIn`.  This matches the
-            // pre-split behaviour for a missing Prelude.
-            var stderr_buf: [4096]u8 = undefined;
-            var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
-            const stderr = &stderr_fw.interface;
-            switch (err) {
-                error.FileNotFound => try stderr.print("rhc: warning: boot module '{s}' not found at '{s}'; using built-in names only\n", .{ boot.module_name, boot_path }),
-                else => try stderr.print("rhc: warning: cannot read boot module '{s}' at '{s}': {}; using built-in names only\n", .{ boot.module_name, boot_path, err }),
-            }
-            try stderr.flush();
-        }
-        }
-    }
-
-    for (file_paths) |fp| {
-        const source = readSourceFile(arena_alloc, io, fp) catch |err| {
-            var stderr_buf: [4096]u8 = undefined;
-            var stderr_fw: File.Writer = .init(.stderr(), io, &stderr_buf);
-            const stderr = &stderr_fw.interface;
-            switch (err) {
-                error.FileNotFound => try stderr.print("rhc: file not found: {s}\n", .{fp}),
-                error.AccessDenied => try stderr.print("rhc: permission denied: {s}\n", .{fp}),
-                else => try stderr.print("rhc: cannot read file '{s}': {}\n", .{ fp, err }),
-            }
-            try stderr.flush();
-            std.process.exit(1);
-        };
-        // Prefer the source-declared `module Foo where` name over the
-        // path-inferred one so a file whose path doesn't mirror its module
-        // (e.g. `lib/base/Data/List.hs` declaring `module Data.List where`)
-        // still topo-sorts and resolves imports correctly.
-        const mod_name = extractSourceModuleName(source) orelse
-            try rusholme.modules.module_graph.inferModuleName(arena_alloc, fp);
-        try source_modules.append(arena_alloc, .{
-            .module_name = mod_name,
-            .source = source,
-            .file_id = next_file_id,
-        });
-        next_file_id += 1;
-    }
-
-    var session_result = try compile_env_mod.compileProgram(arena_alloc, io, source_modules.items, effective_pkg_dbs.items);
+    var session_result = try compile_env_mod.compileProgram(arena_alloc, io, source_modules, effective_pkg_dbs.items);
     var session = &session_result.env;
     defer session.deinit();
 

--- a/tests/repl/cli_e2e_tests.zig
+++ b/tests/repl/cli_e2e_tests.zig
@@ -91,6 +91,49 @@ fn runRepl(allocator: std.mem.Allocator, input: []const u8) !ReplResult {
     };
 }
 
+/// Spawn `rhc <args...>` (no interactive stdin) and return collected output
+/// after the process exits. Used for the non-interactive IR-dump subcommands.
+fn runRhc(allocator: std.mem.Allocator, args: []const []const u8) !ReplResult {
+    const io = testing.io;
+
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    try argv.append(allocator, "zig-out/bin/rhc");
+    try argv.appendSlice(allocator, args);
+
+    var child = try process.spawn(io, .{
+        .argv = argv.items,
+        .stdin = .pipe,
+        .stdout = .pipe,
+        .stderr = .pipe,
+    });
+    errdefer child.kill(io);
+
+    // The dump subcommands read no stdin; close it immediately so they never block.
+    child.stdin.?.close(io);
+    child.stdin = null;
+
+    var multi_reader_buffer: File.MultiReader.Buffer(2) = undefined;
+    var multi_reader: File.MultiReader = undefined;
+    multi_reader.init(allocator, io, multi_reader_buffer.toStreams(), &.{ child.stdout.?, child.stderr.? });
+    defer multi_reader.deinit();
+
+    while (true) {
+        multi_reader.fill(64, .none) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => |e| return e,
+        };
+    }
+    try multi_reader.checkAnyError();
+
+    const term = try child.wait(io);
+    const stdout_slice = try multi_reader.toOwnedSlice(0);
+    errdefer allocator.free(stdout_slice);
+    const stderr_slice = try multi_reader.toOwnedSlice(1);
+
+    return .{ .stdout = stdout_slice, .stderr = stderr_slice, .term = term };
+}
+
 /// Assert that `haystack` contains `needle`. On failure, prints both
 /// for easier debugging.
 fn expectContains(haystack: []const u8, needle: []const u8) !void {
@@ -357,4 +400,25 @@ test "cli e2e: over-saturated application arguments are lazy (#546)" {
     // Blocked on over-saturated application handling in the JIT backend.
     // tracked in: https://github.com/adinapoli/rusholme/issues/546
     return;
+}
+
+// ── IR-dump subcommands load the full boot Prelude (#867) ─────────────────
+
+test "cli e2e: rhc core resolves the full Prelude (show/++) — #867" {
+    // e2e_show_basic uses `show` (defined in GHC.Base, re-exported by Prelude).
+    // Before #867 the dump path only loaded lib/Prelude.hs, leaving `show`
+    // unbound; `rhc core` aborted instead of dumping Core.
+    const result = try runRhc(testing.allocator, &.{ "core", "tests/e2e/e2e_show_basic.hs" });
+    defer result.deinit(testing.allocator);
+
+    try testing.expectEqual(process.Child.Term{ .exited = 0 }, result.term);
+    try expectContains(result.stdout, "Core Program");
+}
+
+test "cli e2e: rhc grin resolves the full Prelude (show/++) — #867" {
+    const result = try runRhc(testing.allocator, &.{ "grin", "tests/e2e/e2e_show_basic.hs" });
+    defer result.deinit(testing.allocator);
+
+    try testing.expectEqual(process.Child.Term{ .exited = 0 }, result.term);
+    try expectContains(result.stdout, "GRIN Program");
 }


### PR DESCRIPTION
Closes #867.

## Summary

`rhc core` / `rhc grin` compiled the target file against only `lib/Prelude.hs`
(via `loadPrelude`), **not** the layered boot stack
(`RHC.Prim → Data.Function → GHC.Base → Data.* → Prelude`). Since `show`, `++`,
etc. live in `GHC.Base`/`base` and are only re-exported by `Prelude`, they were
left unbound and the dump aborted:

```
$ rhc core foo.hs        # foo uses `show`
error[E002]: unbound variable `show` in typechecker (renamer bug?)
error[E003]: variable not in scope: `++`
rhc: aborting due to 2 errors
```

This made the IR-dump tools useless for essentially any real program and
blocked Core/GRIN inspection while debugging (e.g. the derived-`Show`
dictionary bug #863).

## Fix

Both commands now route through the same boot-aware `compileProgram` path as
`rhc build`:

- Extracted `assembleSourceModules` (boot stack + user files, monotonic
  file_ids, user-shadow skipping) from `cmdBuild` — which now calls it too
  (behaviour-preserving; net −73 lines).
- `rhc core` prints the merged whole-program Core (`CompileResult.core`).
- `rhc grin` lambda-lifts that merged Core (no external scope — it's
  self-contained) and translates to GRIN.

`rhc check` / `rhc ll` still use the old single-file `loadPrelude` path; lifting
them is noted as a follow-up in #867.

## Testing

Two new cli-e2e tests (`tests/repl/cli_e2e_tests.zig`) spawn `rhc core` /
`rhc grin` on a `show`-using program and assert exit 0 + Core/GRIN output —
both fail before this change, pass after. Full suite green: 940 unit, 76 e2e,
26 cli-e2e, 35 repl, plus golden/parser/rts/prelude/pkg/compile-fail.

Manual: `rhc core show.hs` → 944 lines of merged Core; `rhc grin` → 2355 lines;
both exit 0.

## Benchmarks

Skipped — CLI/diagnostics plumbing only. The `cmdBuild` refactor is
behaviour-preserving (identical `source_modules` + `compileProgram` call), so
codegen is unchanged.
