### PR TITLE
#863: Fix derived Show for constructors with fields

### DIFF
--- a/src/deriving/builder.zig
+++ b/src/deriving/builder.zig
@@ -35,11 +35,23 @@ pub fn resetOccurrenceSpans() void {
 
 /// Derive a distinct span from `span`, preserving file + line (so diagnostics
 /// still point at the user's `deriving` clause) but assigning a fresh column.
+/// Column base for synthesised occurrence spans. Chosen far above any real
+/// source column so a freshened occurrence span never collides with a *raw*
+/// deriving-clause span (e.g. the instance's own `Show a` method constraint,
+/// which the typechecker keys at the data-declaration span, column 1). Without
+/// the offset the very first freshened occurrence lands at column 1 and
+/// collides — silently masked when another class is derived first (which bumps
+/// the counter past 1), which is exactly why `deriving (Show)` alone
+/// mis-resolved its field dictionary while `deriving (Eq, Show)` did not.
+/// See #863.
+const occ_col_base: u32 = 1_000_000;
+
 fn freshOccSpan(span: SourceSpan) SourceSpan {
     occ_seq += 1;
     const line = if (span.start.line > 0) span.start.line else 1;
-    const start = SourcePos.init(span.start.file_id, line, occ_seq);
-    const end = SourcePos.init(span.start.file_id, line, occ_seq + 1);
+    const col = occ_col_base + occ_seq;
+    const start = SourcePos.init(span.start.file_id, line, col);
+    const end = SourcePos.init(span.start.file_id, line, col + 1);
     return SourceSpan.init(start, end);
 }
 

--- a/tests/e2e/e2e_863_deriving_show_fields.hs
+++ b/tests/e2e/e2e_863_deriving_show_fields.hs
@@ -1,0 +1,26 @@
+-- e2e_863: Derived Show for constructors with fields.
+--
+-- Regression test for #863: deriving Show on a constructor that carries
+-- fields used to crash at runtime. The derived body's field call
+-- `show x0` was handed the instance's own dictionary (e.g. dict$Show$Age)
+-- instead of the field type's (dict$Show$Int), because the field's
+-- Show-constraint span collided with the instance method's own constraint
+-- span in the desugarer's evidence map. The bug only surfaced when Show was
+-- the first/only derived class (otherwise an earlier derivation shifted the
+-- synthesised-occurrence span counter and hid the collision).
+--
+-- Covers single-field, multi-field, and multi-constructor-with-fields, with
+-- Show derived ALONE so the regression is actually exercised.
+
+data Age = Age Int deriving (Show)
+
+data Point = Point Int Int deriving (Show)
+
+data Shape = Circle Int | Square Int Int deriving (Show)
+
+main :: IO ()
+main = do
+  putStrLn (show (Age 42))      -- Age 42
+  putStrLn (show (Point 1 2))   -- Point 1 2
+  putStrLn (show (Circle 5))    -- Circle 5
+  putStrLn (show (Square 3 4))  -- Square 3 4

--- a/tests/e2e/e2e_863_deriving_show_fields.stdout
+++ b/tests/e2e/e2e_863_deriving_show_fields.stdout
@@ -1,0 +1,4 @@
+Age 42
+Point 1 2
+Circle 5
+Square 3 4

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -236,6 +236,10 @@ test "e2e: e2e_851_deriving_fields (#851)" {
     try testE2e(std.testing.allocator, "e2e_851_deriving_fields");
 }
 
+test "e2e: e2e_863_deriving_show_fields (#863)" {
+    try testE2e(std.testing.allocator, "e2e_863_deriving_show_fields");
+}
+
 test "e2e: e2e_605_zero_field_thunk (#605)" {
     try testE2e(std.testing.allocator, "e2e_605_zero_field_thunk");
 }


### PR DESCRIPTION
Closes #863. Completes the `Show` half of #851 (Eq/Ord fixed in #864).

## Summary

Deriving `Show` on a constructor that carries fields crashed at runtime
(GPF / "Non-exhaustive patterns in case"). The derived body's field call
`show x0` (where `x0 :: Int`) was handed the instance's **own** dictionary
(`dict$Show$Age`) instead of the field type's (`dict$Show$Int`), so at runtime
it ran `Age`'s `show` on an `Int` → wrong-constructor dispatch → crash.

## Root cause

The desugarer's dictionary-evidence map is keyed by
`(var_unique, span_start, class_unique)`. Inside the `Show Age` instance, two
constraints share `var = show` and `class = Show`:

- the instance method's own `Show a` → `Show Age`, which the typechecker keys
  at the **data-declaration span** (column 1); and
- the field use `show x0` → `Show Int`, keyed at its synthesised-occurrence
  span.

#851 already gave each synthesised occurrence a distinct **column** via a
counter — but the counter started at `1`, exactly the data-declaration column,
so the *first* freshened occurrence collided with the instance's own
constraint and the field's `Show Int` evidence was overwritten by `Show Age`.

This is why the bug was **derivation-order-dependent**: `deriving (Eq, Show)`
or `(Ord, Show)` bumped the counter past 1 before Show's field was synthesised
(→ correct), while `deriving (Show)` alone or `(Show, Eq)` collided (→ crash).

```
deriving (Eq, Show) / (Ord, Show)  → field uses dict$Show$Int  ✓
deriving (Show) / (Show, Eq)       → field uses dict$Show$Age  ✗ (crash)
```

(Diagnosed by reading the desugared Core with `rhc core`, fixed in #867/#868.)

## Fix

Offset synthesised-occurrence span columns by a large base (`occ_col_base =
1_000_000`) in `src/deriving/builder.zig`, so a freshened occurrence span can
never collide with a raw deriving-clause span regardless of derivation order.
The deriving line is preserved, so diagnostics still point at the right place.

## Testing

`tests/e2e/e2e_863_deriving_show_fields.hs` — derives `Show` **alone** (so the
regression is exercised) on single-field, multi-field, and
multi-constructor-with-fields types → `Age 42 / Point 1 2 / Circle 5 /
Square 3 4`. Fails (crashes) before this change, passes after.

Full suite green: 940 unit, 77 e2e (incl. the new test), 26 cli-e2e, 35 repl,
plus golden / parser / rts / prelude / pkg / compile-fail.

## Benchmarks

Skipped — change is confined to `src/deriving/` (instance synthesis), not part
of the benchmarked perf surface; codegen for non-deriving programs is
unaffected (only synthesised span *columns* change).
