### PR TITLE
#765: Fix nullary class-method CAFs and imported type-con resolution

### DIFF
--- a/bench/results.json
+++ b/bench/results.json
@@ -2601,6 +2601,203 @@
           "ghc_stddev_ms": 0.14610953380255523
         }
       }
+    },
+    {
+      "commit": "8be042c47e4be55f95e2a218aed65b300f113ebd",
+      "date": "2026-06-17T08:14:19Z",
+      "host": {
+        "os": "Linux 7.0.11-1-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "binary_trees": {
+          "rhc_mean_ms": 3.6416921428571434,
+          "rhc_stddev_ms": 0.22957893136307075,
+          "rhc_immix_mean_ms": 99.85083871428573,
+          "rhc_immix_stddev_ms": 15.99215266689681,
+          "ghc_mean_ms": 1.9713187142857145,
+          "ghc_stddev_ms": 0.1910305852786532
+        },
+        "build_list": {
+          "rhc_mean_ms": 0.7926025714285716,
+          "rhc_stddev_ms": 0.05270704285911307,
+          "rhc_immix_mean_ms": 0.9455474285714286,
+          "rhc_immix_stddev_ms": 0.04642922692606867,
+          "ghc_mean_ms": 1.1289834285714284,
+          "ghc_stddev_ms": 0.05251568702415538
+        },
+        "fannkuch": {
+          "rhc_mean_ms": 1.383169857142857,
+          "rhc_stddev_ms": 0.1716196478752055,
+          "rhc_immix_mean_ms": 1.9876818571428574,
+          "rhc_immix_stddev_ms": 0.10646942400274455,
+          "ghc_mean_ms": 0.924412142857143,
+          "ghc_stddev_ms": 0.05874433180154083
+        },
+        "fasta": {
+          "rhc_mean_ms": 0.7901734285714288,
+          "rhc_stddev_ms": 0.06058808565182085,
+          "rhc_immix_mean_ms": 0.889361,
+          "rhc_immix_stddev_ms": 0.03774123477488956,
+          "ghc_mean_ms": 1.1163318571428573,
+          "ghc_stddev_ms": 0.0580966203074056
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 5.962039428571429,
+          "rhc_stddev_ms": 0.3189201432160601,
+          "rhc_immix_mean_ms": 7.494916714285714,
+          "rhc_immix_stddev_ms": 0.5265797224772694,
+          "ghc_mean_ms": 5.843392285714286,
+          "ghc_stddev_ms": 0.6386518015684064
+        },
+        "hanoi": {
+          "rhc_mean_ms": 83.53447942857143,
+          "rhc_stddev_ms": 8.209390104815437,
+          "rhc_immix_mean_ms": 141.34955614285712,
+          "rhc_immix_stddev_ms": 9.563194543324846,
+          "ghc_mean_ms": 95.626242,
+          "ghc_stddev_ms": 9.174199559403608
+        },
+        "hof_chain": {
+          "rhc_mean_ms": 24.644681571428574,
+          "rhc_stddev_ms": 3.1047752589488584,
+          "rhc_immix_mean_ms": 8946.814354142856,
+          "rhc_immix_stddev_ms": 570.4759002298641,
+          "ghc_mean_ms": 10.000301000000002,
+          "ghc_stddev_ms": 0.9398001903294835
+        },
+        "knucleotide": {
+          "rhc_mean_ms": 15.291628000000003,
+          "rhc_stddev_ms": 2.8511367815461495,
+          "rhc_immix_mean_ms": 24.41062942857143,
+          "rhc_immix_stddev_ms": 0.9759882805880843,
+          "ghc_mean_ms": 7.364459714285715,
+          "ghc_stddev_ms": 0.23666681819857657
+        },
+        "lazy": {
+          "rhc_mean_ms": 0.740023,
+          "rhc_stddev_ms": 0.06891491756990403,
+          "rhc_immix_mean_ms": 0.8086138571428573,
+          "rhc_immix_stddev_ms": 0.07595579798678653,
+          "ghc_mean_ms": 1.0312001428571427,
+          "ghc_stddev_ms": 0.05061638442055614
+        },
+        "mandelbrot": {
+          "rhc_mean_ms": 0.6156177142857143,
+          "rhc_stddev_ms": 0.08023820947801674,
+          "rhc_immix_mean_ms": 0.8464872857142858,
+          "rhc_immix_stddev_ms": 0.01970425115479977,
+          "ghc_mean_ms": 1.4017391428571429,
+          "ghc_stddev_ms": 0.0826384546955967
+        },
+        "matmul": {
+          "rhc_mean_ms": 123.43520485714286,
+          "rhc_stddev_ms": 15.41415841938155,
+          "rhc_immix_mean_ms": 163.98016342857142,
+          "rhc_immix_stddev_ms": 26.117559484863246,
+          "ghc_mean_ms": 48.744963142857145,
+          "ghc_stddev_ms": 7.130664082961615
+        },
+        "mergesort": {
+          "rhc_mean_ms": 0.9435951428571429,
+          "rhc_stddev_ms": 0.2253390118905502,
+          "rhc_immix_mean_ms": 1.030985142857143,
+          "rhc_immix_stddev_ms": 0.09097718891097292,
+          "ghc_mean_ms": 1.223159857142857,
+          "ghc_stddev_ms": 0.18625665228158392
+        },
+        "nbody_simple": {
+          "rhc_mean_ms": 15.662945285714287,
+          "rhc_stddev_ms": 4.330010593916745,
+          "rhc_immix_mean_ms": 61.911609,
+          "rhc_immix_stddev_ms": 8.059340757470759,
+          "ghc_mean_ms": 12.622129428571428,
+          "ghc_stddev_ms": 2.593826732936998
+        },
+        "nsieve": {
+          "rhc_mean_ms": 5.433346428571428,
+          "rhc_stddev_ms": 0.9385793973139862,
+          "rhc_immix_mean_ms": 9.206847,
+          "rhc_immix_stddev_ms": 1.9078193236693914,
+          "ghc_mean_ms": 3.4758450000000005,
+          "ghc_stddev_ms": 0.16380687299988358
+        },
+        "pidigits": {
+          "rhc_mean_ms": 0.9273094285714286,
+          "rhc_stddev_ms": 0.08552338174218234,
+          "rhc_immix_mean_ms": 1.1436565714285714,
+          "rhc_immix_stddev_ms": 0.05912189994651484,
+          "ghc_mean_ms": 1.1718881428571428,
+          "ghc_stddev_ms": 0.05457559614708326
+        },
+        "queens": {
+          "rhc_mean_ms": 550.4948654285716,
+          "rhc_stddev_ms": 34.51289543939116,
+          "rhc_immix_mean_ms": 485.2049371428571,
+          "rhc_immix_stddev_ms": 18.826331920421588,
+          "ghc_mean_ms": 120.04594957142858,
+          "ghc_stddev_ms": 15.768439502265235
+        },
+        "regex_dna": {
+          "rhc_mean_ms": 84.76262557142859,
+          "rhc_stddev_ms": 11.73482511430412,
+          "rhc_immix_mean_ms": 711.3664054285714,
+          "rhc_immix_stddev_ms": 35.9955733968408,
+          "ghc_mean_ms": 75.50640357142858,
+          "ghc_stddev_ms": 10.436155095250918
+        },
+        "reverse_complement": {
+          "rhc_mean_ms": 0.6395198571428572,
+          "rhc_stddev_ms": 0.055976724307008674,
+          "rhc_immix_mean_ms": 0.7095751428571431,
+          "rhc_immix_stddev_ms": 0.0257204453527317,
+          "ghc_mean_ms": 1.0186197142857143,
+          "ghc_stddev_ms": 0.07545395883520463
+        },
+        "rose_tree": {
+          "rhc_mean_ms": 0.6829031428571429,
+          "rhc_stddev_ms": 0.16073002891020768,
+          "rhc_immix_mean_ms": 0.7206237142857143,
+          "rhc_immix_stddev_ms": 0.210848003794767,
+          "ghc_mean_ms": 0.9152785714285715,
+          "ghc_stddev_ms": 0.0357544189569958
+        },
+        "spectral_norm": {
+          "rhc_mean_ms": 0.6985020000000001,
+          "rhc_stddev_ms": 0.0443892016223165,
+          "rhc_immix_mean_ms": 1.0105427142857144,
+          "rhc_immix_stddev_ms": 0.06565228066288398,
+          "ghc_mean_ms": 0.9463204285714288,
+          "ghc_stddev_ms": 0.06396800292556985
+        },
+        "sum_to": {
+          "rhc_mean_ms": 0.6344714285714285,
+          "rhc_stddev_ms": 0.07102184053715951,
+          "rhc_immix_mean_ms": 1.6183122857142855,
+          "rhc_immix_stddev_ms": 0.22518190251417797,
+          "ghc_mean_ms": 0.9862555714285715,
+          "ghc_stddev_ms": 0.0814480846958297
+        },
+        "tak": {
+          "rhc_mean_ms": 0.6774167142857144,
+          "rhc_stddev_ms": 0.058769484546869734,
+          "rhc_immix_mean_ms": 0.7444660000000001,
+          "rhc_immix_stddev_ms": 0.04524298395699973,
+          "ghc_mean_ms": 1.1208702857142858,
+          "ghc_stddev_ms": 0.06970563637591604
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 2.4039897142857147,
+          "rhc_stddev_ms": 0.24359755905093017,
+          "rhc_immix_mean_ms": 2.997816714285715,
+          "rhc_immix_stddev_ms": 0.08190361943714546,
+          "ghc_mean_ms": 1.7812894285714287,
+          "ghc_stddev_ms": 0.09488985337196167
+        }
+      }
     }
   ]
 }

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -345,6 +345,40 @@ pub const CompileEnv = struct {
         return merged;
     }
 
+    /// Collect type-constructor name → renamed `Name` mappings from every
+    /// module the current module imports.  The typechecker uses this to
+    /// resolve type-constructor names appearing in user type signatures
+    /// (e.g. `:: Ordering`) to the *same* unique the type's data declaration
+    /// — and therefore its class instances — were registered under.
+    ///
+    /// Without this, an imported non-builtin type constructor used in a
+    /// signature falls back to `unique = 0` (see `astTypeToHTypeWithScope`),
+    /// which fails to unify with the real type and makes its instances
+    /// (`Show Ordering`, `Bounded Ordering`, …) appear missing.  Builtin types
+    /// (`Int`, `Bool`, `Char`, `Maybe`, …) escape this because they are
+    /// special-cased in `knownTypeByName`.
+    pub fn collectTypeConNamesFromImports(
+        self: *const CompileEnv,
+        alloc: std.mem.Allocator,
+        imports: []const ast_mod.ImportDecl,
+    ) std.mem.Allocator.Error!infer_mod.TypeConNames {
+        var merged: infer_mod.TypeConNames = .empty;
+        for (imports) |imp| {
+            const iface = self.ifaces.get(imp.module_name) orelse continue;
+            for (iface.data_decls) |dd| {
+                // First binding wins; current module's own decls override
+                // later inside `inferModule`.
+                if (!merged.contains(dd.name)) {
+                    try merged.put(alloc, dd.name, Name{
+                        .base = dd.name,
+                        .unique = .{ .value = dd.unique },
+                    });
+                }
+            }
+        }
+        return merged;
+    }
+
     /// Seed a `RenameEnv` from a single module interface.
     fn seedRenamerFromIface(
         env: *renamer_mod.RenameEnv,
@@ -513,7 +547,13 @@ pub const CompileEnv = struct {
         // so that the typechecker can resolve class constraints (e.g. Show).
         try self.seedClassEnvFromImports(&infer_ctx.class_env, module.imports);
 
-        var module_types = try infer_mod.inferModule(&infer_ctx, renamed, null);
+        // Seed type-constructor names from imports so signatures referencing
+        // imported non-builtin types (e.g. `:: Ordering`) resolve to the same
+        // unique their instances were registered under.
+        var ext_type_con_names = try self.collectTypeConNamesFromImports(self.alloc, module.imports);
+        defer ext_type_con_names.deinit(self.alloc);
+
+        var module_types = try infer_mod.inferModule(&infer_ctx, renamed, &ext_type_con_names);
         defer module_types.deinit(self.alloc);
         if (self.diags.hasErrors()) return null;
 

--- a/src/typechecker/env.zig
+++ b/src/typechecker/env.zig
@@ -133,7 +133,27 @@ pub const TyScheme = struct {
             subst[i] = .{ .id = id, .node = node };
         }
 
-        const ty = (try instantiateType(self.body, subst, alloc, supply)).*;
+        const body_ptr = try instantiateType(self.body, subst, alloc, supply);
+        // If the body *is* a substituted binder node — e.g. a nullary class
+        // method `minBound :: Bounded a => a` whose body is the bare class
+        // tyvar — copying it by value below would sever the alias with the
+        // instantiated constraints (which keep the shared pointer in
+        // `wanted[].ty`).  A later `unifyNow(inst.ty, Bool)` would then solve
+        // only the value copy, leaving the constraint's metavar unsolved and
+        // producing no dictionary evidence.  Wrap it in a Meta indirection so
+        // the by-value `ty` still chases to the shared cell — mirroring the
+        // `Con`-argument handling in `instantiateType`.
+        var aliases_binder = false;
+        for (subst) |s| {
+            if (body_ptr == s.node) {
+                aliases_binder = true;
+                break;
+            }
+        }
+        const ty = if (aliases_binder)
+            HType{ .Meta = .{ .id = supply.fresh().id, .ref = body_ptr } }
+        else
+            body_ptr.*;
 
         // Instantiate constraints: substitute binders with fresh metas.
         // IMPORTANT: we store the pointer returned by instantiateType, not

--- a/tests/e2e/e2e_765_nullary_method_caf.hs
+++ b/tests/e2e/e2e_765_nullary_method_caf.hs
@@ -1,0 +1,29 @@
+-- #765: nullary class-method CAFs apply their dictionary evidence, and
+-- imported non-builtin types (Ordering) used in signatures resolve to the
+-- unique their instances were registered under.
+module Main where
+
+loBool :: Bool
+loBool = minBound
+
+hiBool :: Bool
+hiBool = maxBound
+
+loOrd :: Ordering
+loOrd = minBound
+
+hiOrd :: Ordering
+hiOrd = maxBound
+
+-- An Ordering used directly in a type annotation must also resolve.
+mid :: Ordering
+mid = EQ
+
+main :: IO ()
+main = do
+    print loBool
+    print hiBool
+    print loOrd
+    print hiOrd
+    print mid
+    print (compare (3 :: Int) 2)

--- a/tests/e2e/e2e_765_nullary_method_caf.hs
+++ b/tests/e2e/e2e_765_nullary_method_caf.hs
@@ -1,7 +1,19 @@
 -- #765: nullary class-method CAFs apply their dictionary evidence, and
 -- imported non-builtin types (Ordering) used in signatures resolve to the
 -- unique their instances were registered under.
+--
+-- Also covers #712: standalone `minBound`/`maxBound` on a user-defined
+-- type with derived instances (the remaining broken case there shared the
+-- nullary-CAF root cause).
 module Main where
+
+data Color = Red | Green | Blue deriving (Show, Eq, Ord, Enum, Bounded)
+
+loColor :: Color
+loColor = minBound
+
+hiColor :: Color
+hiColor = maxBound
 
 loBool :: Bool
 loBool = minBound
@@ -27,3 +39,11 @@ main = do
     print hiOrd
     print mid
     print (compare (3 :: Int) 2)
+    print (minBound :: Color)
+    print (maxBound :: Color)
+    print loColor
+    print hiColor
+    print (succ Red)
+    print (pred Blue)
+    print (fromEnum Green)
+    print (toEnum 2 :: Color)

--- a/tests/e2e/e2e_765_nullary_method_caf.stdout
+++ b/tests/e2e/e2e_765_nullary_method_caf.stdout
@@ -1,0 +1,6 @@
+False
+True
+LT
+GT
+EQ
+GT

--- a/tests/e2e/e2e_765_nullary_method_caf.stdout
+++ b/tests/e2e/e2e_765_nullary_method_caf.stdout
@@ -4,3 +4,11 @@ LT
 GT
 EQ
 GT
+Red
+Blue
+Red
+Blue
+Green
+Green
+1
+Blue

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -240,6 +240,10 @@ test "e2e: e2e_863_deriving_show_fields (#863)" {
     try testE2e(std.testing.allocator, "e2e_863_deriving_show_fields");
 }
 
+test "e2e: e2e_765_nullary_method_caf (#765)" {
+    try testE2e(std.testing.allocator, "e2e_765_nullary_method_caf");
+}
+
 test "e2e: e2e_605_zero_field_thunk (#605)" {
     try testE2e(std.testing.allocator, "e2e_605_zero_field_thunk");
 }

--- a/tests/prelude/p014_bounded.hs
+++ b/tests/prelude/p014_bounded.hs
@@ -1,8 +1,9 @@
 -- Prelude regression: Bounded(..) — minBound, maxBound (#759).
 --
--- xfail: nullary class-method CAFs miscompile — Bool segfaults at
--- runtime, Ordering fails to compile with a bogus "no instance for
--- `Show Ordering`" error.  Tracked in #765.
+-- Regression for #765: nullary class-method CAFs (`loBool = minBound`)
+-- now apply their dictionary evidence, and imported non-builtin types
+-- (`Ordering`) resolve to the unique their instances were registered
+-- under, so `Show`/`Bounded Ordering` are found.
 module Main where
 
 loBool :: Bool

--- a/tests/prelude/p014_bounded.properties
+++ b/tests/prelude/p014_bounded.properties
@@ -1,1 +1,0 @@
-xfail: nullary class-method CAFs (minBound/maxBound) miscompile — tracked in #765

--- a/tests/prelude_test_runner.zig
+++ b/tests/prelude_test_runner.zig
@@ -67,6 +67,6 @@ test "prelude: p013_hof_prelude_arg (xfail #764)" {
     try testPrelude(std.testing.allocator, "p013_hof_prelude_arg");
 }
 
-test "prelude: p014_bounded (xfail #765)" {
+test "prelude: p014_bounded" {
     try testPrelude(std.testing.allocator, "p014_bounded");
 }


### PR DESCRIPTION
Closes #765
Closes #712

## Summary

Nullary class-method CAFs (`loB :: Bool; loB = minBound`) miscompiled, and any
`Ordering` value failed to typecheck with a bogus `no instance for 'Show Ordering'`.
Two independent root causes, both fixed here.

### 1. Nullary class-method CAF lost its dictionary

`TyScheme.instantiate` copied the instantiated body **by value**. For a nullary
class method whose body IS the bare class tyvar (`minBound :: Bounded a => a`),
the returned RHS type was a value-copy of the shared metavar — no longer aliased
to the instantiated constraint (which keeps the shared pointer). The caller's
`unifyNow(rhs, Bool)` then solved only the copy, leaving the constraint's metavar
unsolved → no evidence → the bare unsaturated selector was emitted and crashed at
runtime (forcing a function value as a `Bool` → non-exhaustive `case`). Methods
with a function-shaped body (`(+)`, …) were unaffected because nested pointers
preserve aliasing.

**Fix:** wrap the body in a `Meta` indirection when it aliases a substituted
binder, mirroring the existing `Con`-argument handling in `instantiateType`.

### 2. Imported non-builtin type constructors resolved to `unique = 0`

The multi-module build built `type_con_names` only from the current module's own
data declarations, never seeding from imports. An imported non-builtin type used
in a signature (`:: Ordering`) resolved to `unique = 0` and failed to unify with
the real type its instances were registered under — hence the bogus missing-
instance errors and `cannot unify 'Ordering' with 'Ordering'`. Builtins
(`Int`, `Bool`, `Char`, `Maybe`, …) escaped via `knownTypeByName`.

**Fix:** add `collectTypeConNamesFromImports` and seed `inferModule` with it.

## Deliverables
- [x] `print (loB :: Bool)` where `loB = minBound` prints `False`.
- [x] Same for `Ordering` (prints `LT`) without the bogus missing-instance error.
- [x] Un-xfail `tests/prelude/p014_bounded.hs`.

## Testing
- `zig build test --summary all` — all green (940 unit, 78 e2e, 14 prelude, 78 parser, …).
- New e2e `e2e_765_nullary_method_caf` covers Bool/Ordering CAFs, a direct
  `:: Ordering` annotation, and `compare`.
- Bench refreshed: compile-time-only change, no runtime regression (only sub-1 ms
  programs move, within noise; long-runners ±noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

