### PR TITLE
#901: Backend: key the case-block cache by scrutinee SSA value (silent wrong code for multi-equation constructor patterns)

### DIFF
--- a/bench/results.json
+++ b/bench/results.json
@@ -5359,6 +5359,203 @@
           "ghc_stddev_ms": 0.14954335704833474
         }
       }
+    },
+    {
+      "commit": "0ad206cecd384891de6f87681f6e3fdbc696260c",
+      "date": "2026-07-03T12:21:28Z",
+      "host": {
+        "os": "Linux 7.1.1-2-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "binary_trees": {
+          "rhc_mean_ms": 4.417367428571429,
+          "rhc_stddev_ms": 0.6059833742245897,
+          "rhc_immix_mean_ms": 107.67709171428572,
+          "rhc_immix_stddev_ms": 20.16937833851508,
+          "ghc_mean_ms": 1.7137262857142859,
+          "ghc_stddev_ms": 0.126362619820518
+        },
+        "build_list": {
+          "rhc_mean_ms": 0.9207414285714287,
+          "rhc_stddev_ms": 0.16431233728974534,
+          "rhc_immix_mean_ms": 0.9754797142857144,
+          "rhc_immix_stddev_ms": 0.03105164120039541,
+          "ghc_mean_ms": 1.1558042857142858,
+          "ghc_stddev_ms": 0.040145189067160886
+        },
+        "fannkuch": {
+          "rhc_mean_ms": 1.4079794285714284,
+          "rhc_stddev_ms": 0.0898305905651617,
+          "rhc_immix_mean_ms": 2.0024008571428573,
+          "rhc_immix_stddev_ms": 0.04348316293474433,
+          "ghc_mean_ms": 1.0649328571428571,
+          "ghc_stddev_ms": 0.22189627893712605
+        },
+        "fasta": {
+          "rhc_mean_ms": 1.030487,
+          "rhc_stddev_ms": 0.093400207137529,
+          "rhc_immix_mean_ms": 1.0477175714285714,
+          "rhc_immix_stddev_ms": 0.14210535766918053,
+          "ghc_mean_ms": 1.0222165714285716,
+          "ghc_stddev_ms": 0.08657436606728564
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 5.863180428571429,
+          "rhc_stddev_ms": 0.05767669084028432,
+          "rhc_immix_mean_ms": 6.816410571428572,
+          "rhc_immix_stddev_ms": 1.3679109033721042,
+          "ghc_mean_ms": 6.1212412857142855,
+          "ghc_stddev_ms": 0.426107607973117
+        },
+        "hanoi": {
+          "rhc_mean_ms": 81.30960471428573,
+          "rhc_stddev_ms": 4.0435348031473115,
+          "rhc_immix_mean_ms": 150.40403571428573,
+          "rhc_immix_stddev_ms": 6.672190534143186,
+          "ghc_mean_ms": 106.36898614285714,
+          "ghc_stddev_ms": 5.764654966648637
+        },
+        "hof_chain": {
+          "rhc_mean_ms": 26.979511000000006,
+          "rhc_stddev_ms": 1.8403772012885478,
+          "rhc_immix_mean_ms": 9377.923906714284,
+          "rhc_immix_stddev_ms": 1099.7727630772688,
+          "ghc_mean_ms": 10.799266142857142,
+          "ghc_stddev_ms": 1.7227521721104122
+        },
+        "knucleotide": {
+          "rhc_mean_ms": 16.48753857142857,
+          "rhc_stddev_ms": 3.456450103107082,
+          "rhc_immix_mean_ms": 21.719909,
+          "rhc_immix_stddev_ms": 5.213452679802257,
+          "ghc_mean_ms": 7.916980285714286,
+          "ghc_stddev_ms": 0.6894634638953479
+        },
+        "lazy": {
+          "rhc_mean_ms": 0.8268204285714287,
+          "rhc_stddev_ms": 0.1150763946730709,
+          "rhc_immix_mean_ms": 0.8440572857142858,
+          "rhc_immix_stddev_ms": 0.08842887030586465,
+          "ghc_mean_ms": 1.1756225714285717,
+          "ghc_stddev_ms": 0.054937695185416274
+        },
+        "mandelbrot": {
+          "rhc_mean_ms": 0.6811077142857143,
+          "rhc_stddev_ms": 0.04999740301827116,
+          "rhc_immix_mean_ms": 0.9674188571428571,
+          "rhc_immix_stddev_ms": 0.03967649001372883,
+          "ghc_mean_ms": 1.4393015714285715,
+          "ghc_stddev_ms": 0.08949520518787052
+        },
+        "matmul": {
+          "rhc_mean_ms": 150.69450314285717,
+          "rhc_stddev_ms": 20.219249696570316,
+          "rhc_immix_mean_ms": 163.3447442857143,
+          "rhc_immix_stddev_ms": 6.76180466608153,
+          "ghc_mean_ms": 48.94409428571429,
+          "ghc_stddev_ms": 6.824446565155295
+        },
+        "mergesort": {
+          "rhc_mean_ms": 0.9953607142857144,
+          "rhc_stddev_ms": 0.0943391611080543,
+          "rhc_immix_mean_ms": 1.0501292857142859,
+          "rhc_immix_stddev_ms": 0.10045325937754053,
+          "ghc_mean_ms": 1.164200142857143,
+          "ghc_stddev_ms": 0.11402374013837147
+        },
+        "nbody_simple": {
+          "rhc_mean_ms": 16.247918714285717,
+          "rhc_stddev_ms": 3.202576711716558,
+          "rhc_immix_mean_ms": 57.167645857142844,
+          "rhc_immix_stddev_ms": 8.384407540365341,
+          "ghc_mean_ms": 11.385664285714288,
+          "ghc_stddev_ms": 2.3798270251426343
+        },
+        "nsieve": {
+          "rhc_mean_ms": 5.584676000000001,
+          "rhc_stddev_ms": 0.5747433802794079,
+          "rhc_immix_mean_ms": 9.173891000000001,
+          "rhc_immix_stddev_ms": 2.9360678674575404,
+          "ghc_mean_ms": 3.2243102857142856,
+          "ghc_stddev_ms": 0.14018166427260761
+        },
+        "pidigits": {
+          "rhc_mean_ms": 0.8274120000000001,
+          "rhc_stddev_ms": 0.03166109600650826,
+          "rhc_immix_mean_ms": 1.3130362857142857,
+          "rhc_immix_stddev_ms": 0.2510368447085768,
+          "ghc_mean_ms": 1.1000164285714287,
+          "ghc_stddev_ms": 0.04966989409040838
+        },
+        "queens": {
+          "rhc_mean_ms": 585.1891408571428,
+          "rhc_stddev_ms": 68.75698322411931,
+          "rhc_immix_mean_ms": 527.0918204285715,
+          "rhc_immix_stddev_ms": 37.27322720201703,
+          "ghc_mean_ms": 119.02091114285716,
+          "ghc_stddev_ms": 14.63780829775894
+        },
+        "regex_dna": {
+          "rhc_mean_ms": 91.34753557142858,
+          "rhc_stddev_ms": 12.869049465192266,
+          "rhc_immix_mean_ms": 561.9868474285715,
+          "rhc_immix_stddev_ms": 48.286859543327914,
+          "ghc_mean_ms": 89.673837,
+          "ghc_stddev_ms": 18.07982752064415
+        },
+        "reverse_complement": {
+          "rhc_mean_ms": 0.7102428571428573,
+          "rhc_stddev_ms": 0.09141986389625356,
+          "rhc_immix_mean_ms": 0.7835417142857144,
+          "rhc_immix_stddev_ms": 0.07595841126940076,
+          "ghc_mean_ms": 1.0832007142857143,
+          "ghc_stddev_ms": 0.12721781616937447
+        },
+        "rose_tree": {
+          "rhc_mean_ms": 0.6629507142857144,
+          "rhc_stddev_ms": 0.13990646610827095,
+          "rhc_immix_mean_ms": 0.6465829999999999,
+          "rhc_immix_stddev_ms": 0.10127618966963561,
+          "ghc_mean_ms": 1.1408990000000003,
+          "ghc_stddev_ms": 0.2270563055852006
+        },
+        "spectral_norm": {
+          "rhc_mean_ms": 0.7151312857142857,
+          "rhc_stddev_ms": 0.03597756597619452,
+          "rhc_immix_mean_ms": 1.0969175714285713,
+          "rhc_immix_stddev_ms": 0.06301250622920589,
+          "ghc_mean_ms": 1.0158035714285716,
+          "ghc_stddev_ms": 0.07998937136031921
+        },
+        "sum_to": {
+          "rhc_mean_ms": 0.609024,
+          "rhc_stddev_ms": 0.03702955568191443,
+          "rhc_immix_mean_ms": 1.6916162857142858,
+          "rhc_immix_stddev_ms": 0.3123059423096281,
+          "ghc_mean_ms": 0.9661397142857143,
+          "ghc_stddev_ms": 0.1587681787310399
+        },
+        "tak": {
+          "rhc_mean_ms": 0.5673297142857142,
+          "rhc_stddev_ms": 0.08463708557859312,
+          "rhc_immix_mean_ms": 0.6675508571428572,
+          "rhc_immix_stddev_ms": 0.06721250739614013,
+          "ghc_mean_ms": 0.7647952857142859,
+          "ghc_stddev_ms": 0.02009152092894153
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 2.599987285714286,
+          "rhc_stddev_ms": 0.2885285216286912,
+          "rhc_immix_mean_ms": 3.2580797142857145,
+          "rhc_immix_stddev_ms": 0.4177400976184093,
+          "ghc_mean_ms": 1.8813925714285717,
+          "ghc_stddev_ms": 0.14143107458859852
+        }
+      }
     }
   ]
 }

--- a/src/backend/grin_to_llvm.zig
+++ b/src/backend/grin_to_llvm.zig
@@ -709,6 +709,13 @@ pub const RtsBackend = enum(u32) {
     }
 };
 
+/// Cache key for translated shared Case blocks: the GRIN node identity plus
+/// the SSA value the scrutinee resolves to at the entry site (#901).
+const CaseCacheKey = struct {
+    node: usize,
+    scrut: usize,
+};
+
 pub const GrinTranslator = struct {
     ctx: llvm.Context,
     module: llvm.Module,
@@ -744,10 +751,19 @@ pub const GrinTranslator = struct {
     /// Per-function cache for translated GRIN Case expressions.  The
     /// sequential pattern-match desugarer creates shared fallback nodes
     /// (a DAG) that would be re-translated exponentially without caching.
-    /// Keyed by the GRIN expression pointer (as usize); value is the LLVM
-    /// basic block where the translated case's dispatch logic starts.
+    ///
+    /// Keyed by the GRIN expression pointer AND the scrutinee's currently
+    /// resolved SSA value (#901): the translated block embeds that value
+    /// (possibly a pre-forced rebinding from `noteForcedScrutinee` that
+    /// only dominates the creating path), so re-entering it from a context
+    /// where the scrutinee resolves differently would use a non-dominating
+    /// SSA value — invalid IR that silently miscompiles.  Sibling
+    /// alternatives of the same enclosing case resolve the same value
+    /// (the rebinding happens at the dispatch, before the alternatives),
+    /// so the exponential fallback-DAG shape still shares.  Value is the
+    /// LLVM basic block where the translated case's dispatch logic starts.
     /// Cleared at the start of each `translateDef` call.
-    case_entry_cache: std.AutoHashMap(usize, llvm.BasicBlock),
+    case_entry_cache: std.AutoHashMap(CaseCacheKey, llvm.BasicBlock),
     /// Persistent tag registry — owned externally (JIT engine or caller).
     registry: *TagRegistry,
     /// HPT-lite type environment for type-correct LLVM codegen.
@@ -817,7 +833,7 @@ pub const GrinTranslator = struct {
             .params = std.AutoHashMap(u64, llvm.Value).init(allocator),
             .whnf_vars = std.AutoHashMap(u64, void).init(allocator),
             .imm_vars = std.AutoHashMap(u64, void).init(allocator),
-            .case_entry_cache = std.AutoHashMap(usize, llvm.BasicBlock).init(allocator),
+            .case_entry_cache = std.AutoHashMap(CaseCacheKey, llvm.BasicBlock).init(allocator),
             .registry = registry,
             .type_env = TypeEnv.init(),
             .current_func = null,
@@ -1785,20 +1801,24 @@ pub const GrinTranslator = struct {
                 // node is re-translated at every occurrence, causing
                 // exponential blowup in basic blocks and compile time.
                 //
-                // Cache by GRIN expression pointer: if we've already
-                // translated this exact Case node, branch to its entry
-                // block instead of re-emitting the dispatch logic.
-                const expr_key = @intFromPtr(expr);
-                if (self.case_entry_cache.get(expr_key)) |cached_entry| {
-                    _ = c.LLVMBuildBr(self.builder, cached_entry);
-                    return;
+                // Cache by (GRIN node, resolved scrutinee value): if we've
+                // already translated this exact Case node against the same
+                // scrutinee SSA value, branch to its entry block instead of
+                // re-emitting the dispatch logic.  A differing scrutinee
+                // value means the cached block would use a non-dominating
+                // SSA value — re-translate instead (#901).
+                if (self.caseCacheKey(expr, case_.scrutinee)) |key| {
+                    if (self.case_entry_cache.get(key)) |cached_entry| {
+                        _ = c.LLVMBuildBr(self.builder, cached_entry);
+                        return;
+                    }
+                    // First encounter: create an entry block, cache it, then
+                    // translate the case normally.
+                    const case_entry = c.LLVMAppendBasicBlock(self.current_func, "case.shared");
+                    _ = c.LLVMBuildBr(self.builder, case_entry);
+                    llvm.positionBuilderAtEnd(self.builder, case_entry);
+                    self.case_entry_cache.put(key, case_entry) catch return error.OutOfMemory;
                 }
-                // First encounter: create an entry block, cache it, then
-                // translate the case normally.
-                const case_entry = c.LLVMAppendBasicBlock(self.current_func, "case.shared");
-                _ = c.LLVMBuildBr(self.builder, case_entry);
-                llvm.positionBuilderAtEnd(self.builder, case_entry);
-                self.case_entry_cache.put(expr_key, case_entry) catch return error.OutOfMemory;
                 try self.translateCase(case_.scrutinee, case_.alts);
             },
             .Store => |val| try self.translateStore(val),
@@ -1895,6 +1915,21 @@ pub const GrinTranslator = struct {
         self.whnf_vars = snap.whnf;
         self.imm_vars = snap.imm;
         snap.* = undefined;
+    }
+
+    /// Compute the case-cache key for a Case node, or null when the case
+    /// must not be cached: only `Var` scrutinees with a resolved SSA
+    /// binding are cacheable, because the key must pin the exact value the
+    /// translated block embeds (#901).  Unbound vars (globals/CAFs) and
+    /// non-Var scrutinees translate fresh at every occurrence.
+    fn caseCacheKey(
+        self: *const GrinTranslator,
+        expr: *const grin.Expr,
+        scrutinee: grin.Val,
+    ) ?CaseCacheKey {
+        if (scrutinee != .Var) return null;
+        const cur = self.params.get(scrutinee.Var.unique.value) orelse return null;
+        return .{ .node = @intFromPtr(expr), .scrut = @intFromPtr(cur) };
     }
 
     /// Record what the case dispatch just established about a variable
@@ -2121,20 +2156,24 @@ pub const GrinTranslator = struct {
                 // re-translating.  The cached code terminates with ret/br so
                 // control never returns — we emit a dead placeholder block for
                 // the caller to continue emitting without LLVM errors.
-                const expr_key = @intFromPtr(expr);
-                if (self.case_entry_cache.get(expr_key)) |cached_entry| {
-                    _ = c.LLVMBuildBr(self.builder, cached_entry);
-                    const dead_bb = c.LLVMAppendBasicBlock(self.current_func, "dead.cached");
-                    llvm.positionBuilderAtEnd(self.builder, dead_bb);
-                    return @as(?llvm.Value, c.LLVMConstPointerNull(ptrType()));
+                // Keyed by (GRIN node, resolved scrutinee value) so a
+                // re-entry with a different scrutinee binding re-translates
+                // instead of using a non-dominating SSA value (#901).
+                if (self.caseCacheKey(expr, case_expr.scrutinee)) |key| {
+                    if (self.case_entry_cache.get(key)) |cached_entry| {
+                        _ = c.LLVMBuildBr(self.builder, cached_entry);
+                        const dead_bb = c.LLVMAppendBasicBlock(self.current_func, "dead.cached");
+                        llvm.positionBuilderAtEnd(self.builder, dead_bb);
+                        return @as(?llvm.Value, c.LLVMConstPointerNull(ptrType()));
+                    }
+                    // First encounter: create an entry block and cache it before
+                    // translating, so that subsequent encounters of this shared
+                    // Case node can branch here directly.
+                    const case_entry = c.LLVMAppendBasicBlock(self.current_func, "caseval.shared");
+                    _ = c.LLVMBuildBr(self.builder, case_entry);
+                    llvm.positionBuilderAtEnd(self.builder, case_entry);
+                    self.case_entry_cache.put(key, case_entry) catch return error.OutOfMemory;
                 }
-                // First encounter: create an entry block and cache it before
-                // translating, so that subsequent encounters of this shared
-                // Case node can branch here directly.
-                const case_entry = c.LLVMAppendBasicBlock(self.current_func, "caseval.shared");
-                _ = c.LLVMBuildBr(self.builder, case_entry);
-                llvm.positionBuilderAtEnd(self.builder, case_entry);
-                self.case_entry_cache.put(expr_key, case_entry) catch return error.OutOfMemory;
                 return try self.translateCaseToValue(case_expr.scrutinee, case_expr.alts, result_name);
             },
             else => {

--- a/tests/e2e/e2e_901_shared_case_dominance.hs
+++ b/tests/e2e/e2e_901_shared_case_dominance.hs
@@ -1,0 +1,40 @@
+-- e2e: shared case-block cache dominance (#901).
+--
+-- The match compiler shares fallback subtrees (a DAG); the backend caches
+-- their translated blocks.  Before #901 the cache was keyed by GRIN node
+-- only, so re-entering a shared block from a context with a different
+-- scrutinee binding used a non-dominating pre-forced SSA value — silently
+-- wrong results (eqCoin Tails Tails was False).  Exercises the plain
+-- function shape, the idiomatic hand-written Eq instance shape, and a
+-- three-constructor variant.
+module Main where
+
+data Coin = Heads | Tails
+
+eqCoin :: Coin -> Coin -> Bool
+eqCoin Heads Heads = True
+eqCoin Tails Tails = True
+eqCoin _ _ = False
+
+data Signal = Red | Amber | Green
+
+instance Eq Signal where
+  Red == Red = True
+  Amber == Amber = True
+  Green == Green = True
+  _ == _ = False
+  x /= y = not (x == y)
+
+main :: IO ()
+main = do
+  print (eqCoin Heads Heads)
+  print (eqCoin Heads Tails)
+  print (eqCoin Tails Heads)
+  print (eqCoin Tails Tails)
+  print (Red == Red)
+  print (Amber == Amber)
+  print (Green == Green)
+  print (Red == Green)
+  print (Green == Amber)
+  print (Amber /= Amber)
+  print (Red /= Green)

--- a/tests/e2e/e2e_901_shared_case_dominance.stdout
+++ b/tests/e2e/e2e_901_shared_case_dominance.stdout
@@ -1,0 +1,11 @@
+True
+False
+False
+True
+True
+True
+True
+False
+False
+False
+True

--- a/tests/e2e_test_runner.zig
+++ b/tests/e2e_test_runner.zig
@@ -216,6 +216,10 @@ test "e2e: e2e_889_superclass_entailment (#889)" {
     try testE2e(std.testing.allocator, "e2e_889_superclass_entailment");
 }
 
+test "e2e: e2e_901_shared_case_dominance (#901)" {
+    try testE2e(std.testing.allocator, "e2e_901_shared_case_dominance");
+}
+
 test "e2e: e2e_884_double_adt_fields (#884)" {
     try testE2e(std.testing.allocator, "e2e_884_double_adt_fields");
 }


### PR DESCRIPTION
Closes #901

## Summary
Fixes a silent miscompile in the GRIN→LLVM backend: the per-function cache of translated `Case` blocks was keyed by GRIN node pointer alone, but a translated block embeds the SSA value its scrutinee resolved to at creation time — possibly a pre-forced rebinding (`noteForcedScrutinee`, #800) that only dominates the path where the block was first emitted. Re-entering the block via a cache hit from a different context used a non-dominating SSA value: invalid IR that LLVM (unverified at -O0) compiles to garbage reads.

Observable as wrong answers on the most idiomatic Haskell there is:

```haskell
eqCoin Heads Heads = True
eqCoin Tails Tails = True
eqCoin _ _ = False
-- eqCoin Tails Tails ⇒ False on main; True after this fix
```

(The match compiler shares the `case arg_1 of Tails -> …` fallback subtree between the outer `Tails` alternative and the `Heads`-path rematch; the block was created inside the Heads path.) Every hand-written `instance Eq T` of the `C1 == C1 = True; …; _ == _ = False` shape hits this; under other tag layouts it segfaults (LLVM `unreachable` on garbage dispatch).

## Fix
Cache key = **(GRIN node pointer, resolved scrutinee SSA value)**. Sibling alternatives of the same enclosing case resolve the same value — the rebinding happens at the dispatch, before the alternatives — so the exponential fallback-DAG shape the cache exists for still shares. A re-entry with a different binding re-translates the subtree, emitting its own force. Non-`Var` scrutinees and unresolved vars (globals/CAFs) are no longer cached. Applied to both cache sites (statement context `translateExpr` and value context `translateExprToValue`).

## Testing
- `e2e_901_shared_case_dominance` (output vs GHC 9.10.3): all four `eqCoin` constructor combinations, the idiomatic hand-written `Eq` instance shape, and a three-constructor variant, `/=` included. Verified at `-O0` and `-O2`.
- Full suite green: 947 unit + 91 e2e + parser/golden/compile-fail/prelude/repl/cli/wasm/pkg.

## Benchmarks
Fresh entry committed. All bench binaries are **byte-identical** to main-built ones (`cmp`) — no bench program re-enters a shared case with a differing binding — so the timing deltas in this entry (queens +16%, regex_dna +22%, …) are machine noise, corroborated by same-session A/B hyperfine (queens, regex_dna, nbody_simple, hof_chain binaries all byte-identical (cmp) between main-built and branch-built compilers).

## Note
Found while working on #898: its e2e test used the `C1 == C1` instance idiom and returned wrong answers — bisected down to this pre-existing backend bug (reproduces on main with no typeclasses involved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)