### PR TITLE
#904: Rewrite asinh/acosh/atanh default bodies with integer literals

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -443,7 +443,7 @@
 | [#898](https://github.com/adinapoli/rusholme/issues/898) | Thread superclass dictionaries into class default-method bodies (unblocks `asinh`/`acosh`/`atanh`) (epic [#845](https://github.com/adinapoli/rusholme/issues/845)) | [#889](https://github.com/adinapoli/rusholme/issues/889) | :green_circle: |
 | [#901](https://github.com/adinapoli/rusholme/issues/901) | Backend: case-block cache re-entry uses non-dominating pre-forced scrutinee — silent wrong code for multi-equation constructor patterns | — | :green_circle: |
 | [#907](https://github.com/adinapoli/rusholme/issues/907) | Shared-case cache key misses non-scrutinee forced vars → non-dominating IR | [#901](https://github.com/adinapoli/rusholme/issues/901) | :green_circle: |
-| [#904](https://github.com/adinapoli/rusholme/issues/904) | Rewrite `asinh`/`acosh`/`atanh` default bodies with integer literals once `fromInteger` lands | [#898](https://github.com/adinapoli/rusholme/issues/898), [#140](https://github.com/adinapoli/rusholme/issues/140), [#212](https://github.com/adinapoli/rusholme/issues/212) | :white_circle: |
+| [#904](https://github.com/adinapoli/rusholme/issues/904) | Rewrite `asinh`/`acosh`/`atanh` default bodies with integer literals once `fromInteger` lands | [#898](https://github.com/adinapoli/rusholme/issues/898), [#140](https://github.com/adinapoli/rusholme/issues/140), [#212](https://github.com/adinapoli/rusholme/issues/212) | :yellow_circle: |
 | [#573](https://github.com/adinapoli/rusholme/issues/573) | GRIN backend: polymorphic Prelude functions produce broken codegen | [#529](https://github.com/adinapoli/rusholme/issues/529) | :green_circle: |
 | [#569](https://github.com/adinapoli/rusholme/issues/569) | GRIN/LLVM backend: support dictionary-passing in codegen | [#556](https://github.com/adinapoli/rusholme/issues/556) | :green_circle: |
 | [#583](https://github.com/adinapoli/rusholme/issues/583) | Implement VarTagNode handling in LLVM backend for partial applications | — | :green_circle: |
@@ -597,6 +597,7 @@ These existing issues must be resolved before any Phase 1 work begins:
 | # | Issue | Deps | Status |
 |---|-------|------|--------|
 | [#658](https://github.com/adinapoli/rusholme/issues/658) | Epic: Phase 4 — Cabal compatibility (long-term north star) | Phase 3 complete | :white_circle: |
+| [#920](https://github.com/adinapoli/rusholme/issues/920) | build.zig bootstrap step does not track boot .hs sources — stale rhc-store after editing lib/ | [#837](https://github.com/adinapoli/rusholme/issues/837) | :white_circle: |
 
 ---
 

--- a/bench/results.json
+++ b/bench/results.json
@@ -6147,6 +6147,203 @@
           "ghc_stddev_ms": 1.496734601946597
         }
       }
+    },
+    {
+      "commit": "f418eff15871e3554b6089ddcc249537c067ba27",
+      "date": "2026-07-31T12:14:16Z",
+      "host": {
+        "os": "Linux 7.1.1-2-cachyos",
+        "cpu_model": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
+        "ghc_version": "9.10.3"
+      },
+      "opt_level": 2,
+      "runs": 7,
+      "programs": {
+        "binary_trees": {
+          "rhc_mean_ms": 3.0292771428571426,
+          "rhc_stddev_ms": 0.27511368007088066,
+          "rhc_immix_mean_ms": 102.6323347142857,
+          "rhc_immix_stddev_ms": 14.564565161327643,
+          "ghc_mean_ms": 1.908566142857143,
+          "ghc_stddev_ms": 0.2220170977443168
+        },
+        "build_list": {
+          "rhc_mean_ms": 0.859011,
+          "rhc_stddev_ms": 0.07625976032395239,
+          "rhc_immix_mean_ms": 1.067334,
+          "rhc_immix_stddev_ms": 0.10942279572374307,
+          "ghc_mean_ms": 1.1464554285714288,
+          "ghc_stddev_ms": 0.24502616276624906
+        },
+        "fannkuch": {
+          "rhc_mean_ms": 1.3828060000000002,
+          "rhc_stddev_ms": 0.11865574338817317,
+          "rhc_immix_mean_ms": 2.093095857142857,
+          "rhc_immix_stddev_ms": 0.13438641190912695,
+          "ghc_mean_ms": 0.9627720000000001,
+          "ghc_stddev_ms": 0.08102895583678711
+        },
+        "fasta": {
+          "rhc_mean_ms": 0.8488382857142858,
+          "rhc_stddev_ms": 0.07751740204993604,
+          "rhc_immix_mean_ms": 0.986447857142857,
+          "rhc_immix_stddev_ms": 0.0926675443209552,
+          "ghc_mean_ms": 1.1903222857142857,
+          "ghc_stddev_ms": 0.17704968530586196
+        },
+        "fib_rec": {
+          "rhc_mean_ms": 6.076117285714285,
+          "rhc_stddev_ms": 0.21177293212362647,
+          "rhc_immix_mean_ms": 6.841222428571429,
+          "rhc_immix_stddev_ms": 1.1300838779892786,
+          "ghc_mean_ms": 5.689087428571429,
+          "ghc_stddev_ms": 0.6699505462957339
+        },
+        "hanoi": {
+          "rhc_mean_ms": 80.77412585714286,
+          "rhc_stddev_ms": 4.502635115077519,
+          "rhc_immix_mean_ms": 147.05171457142856,
+          "rhc_immix_stddev_ms": 5.526377685771966,
+          "ghc_mean_ms": 108.57474857142857,
+          "ghc_stddev_ms": 12.976618772102775
+        },
+        "hof_chain": {
+          "rhc_mean_ms": 16.593882571428573,
+          "rhc_stddev_ms": 1.9942647103366071,
+          "rhc_immix_mean_ms": 10057.070568714285,
+          "rhc_immix_stddev_ms": 611.144207524778,
+          "ghc_mean_ms": 10.306725571428572,
+          "ghc_stddev_ms": 0.7657164330842626
+        },
+        "knucleotide": {
+          "rhc_mean_ms": 13.362627571428574,
+          "rhc_stddev_ms": 1.2852388050532162,
+          "rhc_immix_mean_ms": 25.669367285714284,
+          "rhc_immix_stddev_ms": 1.3685839463877396,
+          "ghc_mean_ms": 7.074620285714286,
+          "ghc_stddev_ms": 0.3396712763823843
+        },
+        "lazy": {
+          "rhc_mean_ms": 0.788276,
+          "rhc_stddev_ms": 0.13473496223079345,
+          "rhc_immix_mean_ms": 0.8762002857142859,
+          "rhc_immix_stddev_ms": 0.24050353298840493,
+          "ghc_mean_ms": 1.1621618571428571,
+          "ghc_stddev_ms": 0.27851827578421046
+        },
+        "mandelbrot": {
+          "rhc_mean_ms": 0.7339358571428571,
+          "rhc_stddev_ms": 0.09620152256145877,
+          "rhc_immix_mean_ms": 0.9159177142857143,
+          "rhc_immix_stddev_ms": 0.03949449617653194,
+          "ghc_mean_ms": 1.2406735714285717,
+          "ghc_stddev_ms": 0.07911377689095866
+        },
+        "matmul": {
+          "rhc_mean_ms": 152.48958414285715,
+          "rhc_stddev_ms": 23.296961460473092,
+          "rhc_immix_mean_ms": 168.96235499999997,
+          "rhc_immix_stddev_ms": 10.469501477007677,
+          "ghc_mean_ms": 47.43801085714285,
+          "ghc_stddev_ms": 4.10934535604239
+        },
+        "mergesort": {
+          "rhc_mean_ms": 0.9552700000000001,
+          "rhc_stddev_ms": 0.25666581315074544,
+          "rhc_immix_mean_ms": 1.052156,
+          "rhc_immix_stddev_ms": 0.21887794504395977,
+          "ghc_mean_ms": 1.2826078571428572,
+          "ghc_stddev_ms": 0.14623834970397762
+        },
+        "nbody_simple": {
+          "rhc_mean_ms": 16.053071714285714,
+          "rhc_stddev_ms": 3.4950118193723716,
+          "rhc_immix_mean_ms": 58.08340200000001,
+          "rhc_immix_stddev_ms": 6.279201181168723,
+          "ghc_mean_ms": 11.562088714285714,
+          "ghc_stddev_ms": 2.694119980702648
+        },
+        "nsieve": {
+          "rhc_mean_ms": 5.273683714285715,
+          "rhc_stddev_ms": 0.7887324394171352,
+          "rhc_immix_mean_ms": 8.838319857142858,
+          "rhc_immix_stddev_ms": 2.50756870589737,
+          "ghc_mean_ms": 3.3292920000000006,
+          "ghc_stddev_ms": 0.35201434472996507
+        },
+        "pidigits": {
+          "rhc_mean_ms": 0.7873945714285714,
+          "rhc_stddev_ms": 0.14528739121806955,
+          "rhc_immix_mean_ms": 1.4022108571428573,
+          "rhc_immix_stddev_ms": 0.309880741092133,
+          "ghc_mean_ms": 1.209843142857143,
+          "ghc_stddev_ms": 0.22716302287082182
+        },
+        "queens": {
+          "rhc_mean_ms": 364.4798064285714,
+          "rhc_stddev_ms": 13.467937771079004,
+          "rhc_immix_mean_ms": 505.23341899999997,
+          "rhc_immix_stddev_ms": 50.47848849577938,
+          "ghc_mean_ms": 125.98669685714286,
+          "ghc_stddev_ms": 11.967157922592117
+        },
+        "regex_dna": {
+          "rhc_mean_ms": 85.8077312857143,
+          "rhc_stddev_ms": 15.232919112257953,
+          "rhc_immix_mean_ms": 582.1856148571429,
+          "rhc_immix_stddev_ms": 30.61084649714875,
+          "ghc_mean_ms": 89.07683857142858,
+          "ghc_stddev_ms": 13.7963364181661
+        },
+        "reverse_complement": {
+          "rhc_mean_ms": 0.6869144285714286,
+          "rhc_stddev_ms": 0.04438286225131328,
+          "rhc_immix_mean_ms": 0.9434871428571427,
+          "rhc_immix_stddev_ms": 0.1825879109328149,
+          "ghc_mean_ms": 1.0456302857142858,
+          "ghc_stddev_ms": 0.09969378015656122
+        },
+        "rose_tree": {
+          "rhc_mean_ms": 0.6163227142857144,
+          "rhc_stddev_ms": 0.08890813275457295,
+          "rhc_immix_mean_ms": 0.600469,
+          "rhc_immix_stddev_ms": 0.037347141439026725,
+          "ghc_mean_ms": 0.8952515714285715,
+          "ghc_stddev_ms": 0.03272182315548826
+        },
+        "spectral_norm": {
+          "rhc_mean_ms": 0.8524510000000001,
+          "rhc_stddev_ms": 0.09372470105936144,
+          "rhc_immix_mean_ms": 1.104449142857143,
+          "rhc_immix_stddev_ms": 0.08219505950973897,
+          "ghc_mean_ms": 1.1247044285714285,
+          "ghc_stddev_ms": 0.07415118158612878
+        },
+        "sum_to": {
+          "rhc_mean_ms": 0.7172334285714285,
+          "rhc_stddev_ms": 0.12395860422180886,
+          "rhc_immix_mean_ms": 2.297478142857144,
+          "rhc_immix_stddev_ms": 0.7392688255182569,
+          "ghc_mean_ms": 0.8824540000000002,
+          "ghc_stddev_ms": 0.0628005974945037
+        },
+        "tak": {
+          "rhc_mean_ms": 0.7685104285714287,
+          "rhc_stddev_ms": 0.18970935616345438,
+          "rhc_immix_mean_ms": 0.818632142857143,
+          "rhc_immix_stddev_ms": 0.13388054713491,
+          "ghc_mean_ms": 1.0782984285714288,
+          "ghc_stddev_ms": 0.053623144750680043
+        },
+        "tree_sum": {
+          "rhc_mean_ms": 2.2333317142857148,
+          "rhc_stddev_ms": 0.26658126061216575,
+          "rhc_immix_mean_ms": 3.1139694285714286,
+          "rhc_immix_stddev_ms": 0.2001908759424841,
+          "ghc_mean_ms": 1.684953428571429,
+          "ghc_stddev_ms": 0.13717343956327352
+        }
+      }
     }
   ]
 }

--- a/lib/ghc-internal/GHC/Base.hs
+++ b/lib/ghc-internal/GHC/Base.hs
@@ -231,18 +231,15 @@ class Fractional a => Floating a where
   sinh    :: a -> a
   cosh    :: a -> a
   tanh    :: a -> a
-  -- The Report bodies spell the constants as integer literals (`1`, `2`),
-  -- which need `fromInteger` — not available yet (#140 / #212).  `pi / pi`
-  -- is the multiplicative unit of `a` computed from class methods alone:
-  -- for IEEE types x/x is exactly 1 for any finite non-zero x, so these
-  -- are bit-for-bit the literal-based bodies.  Rewrite with literals once
-  -- `fromInteger` lands (tracked in #904).
+  -- Haskell 2010 default bodies.  The integer literals desugar to
+  -- `fromInteger` applications (#140), resolved through the `Num`
+  -- superclass dictionary threaded into the default binding (#898).
   asinh   :: a -> a
-  asinh x = log (x + sqrt (x*x + pi/pi))
+  asinh x = log (x + sqrt (x*x + 1))
   acosh   :: a -> a
-  acosh x = log (x + sqrt (x*x - pi/pi))
+  acosh x = log (x + sqrt (x*x - 1))
   atanh   :: a -> a
-  atanh x = (log (pi/pi + x) - log (pi/pi - x)) / (pi/pi + pi/pi)
+  atanh x = (log (1 + x) - log (1 - x)) / 2
 
 instance Floating Double where
   pi      = 3.141592653589793

--- a/src/modules/compile_env.zig
+++ b/src/modules/compile_env.zig
@@ -412,6 +412,10 @@ pub const CompileEnv = struct {
         // in scope (e.g. `minBound`, `succ`), which then diverge from the
         // class method's unique recorded in ClassEnv.
         for (iface.class_infos) |ci| {
+            // Record imported class names so the renamer can detect a
+            // visible `Num` under `NoImplicitPrelude` and enable the
+            // `fromInteger` literal rewrite (#904).
+            try env.visible_class_names.put(env.alloc, ci.name.base, {});
             for (ci.methods) |m| {
                 const method_name = Name{
                     .base = m.name.base,
@@ -527,6 +531,13 @@ pub const CompileEnv = struct {
         defer rename_env.deinit();
         // Seed with names from imported modules only (not all compiled modules).
         try self.seedRenamerFromImports(&rename_env, module.imports);
+        // Under `NoImplicitPrelude` the `fromInteger` literal rewrite (#140)
+        // is suppressed — unless a `Num` class is visible anyway: declared by
+        // this very module (as `GHC.Base` does) or imported.  In that case the
+        // rewrite is sound and required for the numeric class's own default
+        // bodies (#904).
+        if (no_implicit_prelude and rename_env.hasVisibleNumClass(module.declarations))
+            rename_env.enableOverloadedIntLiterals();
         const renamed = try renamer_mod.rename(module, &rename_env);
         if (self.diags.hasErrors()) return null;
 

--- a/src/renamer/renamer.zig
+++ b/src/renamer/renamer.zig
@@ -189,10 +189,18 @@ pub const RenameEnv = struct {
     /// *type* comes from `GHC.Base`.  Under `NoImplicitPrelude` the boot
     /// module is not loaded, so that name would be untyped in the
     /// typechecker; there we leave the literal monomorphic (`Int`), matching
-    /// pre-#140 behaviour.  A `NoImplicitPrelude` module that genuinely wants
-    /// overloaded literals (by importing its own `fromInteger`) is out of
-    /// scope for now — tracked in #912.
+    /// pre-#140 behaviour — UNLESS the module itself declares or imports a
+    /// `Num` class (e.g. `GHC.Base`, which *defines* the wired-in
+    /// `Num`/`fromInteger` under `NoImplicitPrelude`).  That visibility
+    /// refinement is #904's enabling change; arbitrary `NoImplicitPrelude`
+    /// modules importing a differently-named `fromInteger` remain out of
+    /// scope — tracked in #912.
     overload_int_literals: bool,
+    /// Set of class type names declared by (or imported into) the module
+    /// being renamed.  Consulted only under `NoImplicitPrelude` to decide
+    /// whether `overload_int_literals` may flip on: the rewrite needs a
+    /// visible `Num` class to type `fromInteger` against (#904).
+    visible_class_names: std.StringHashMapUnmanaged(void) = .empty,
 
     pub fn init(
         alloc: std.mem.Allocator,
@@ -215,6 +223,34 @@ pub const RenameEnv = struct {
     pub fn deinit(self: *RenameEnv) void {
         self.scope.deinit();
         self.con_field_order.deinit(self.alloc);
+        self.visible_class_names.deinit(self.alloc);
+    }
+
+    /// Enable the `fromInteger` literal rewrite (#140) for a
+    /// `NoImplicitPrelude` module that nevertheless has a `Num` class in
+    /// scope — either because the module *is* the boot module that defines
+    /// it (`GHC.Base`), or because it imports one.  Without this, integer
+    /// literals in such modules stay monomorphic `Int`, which breaks the
+    /// numeric class's own default bodies (`asinh`/`acosh`/`atanh`, #904).
+    ///
+    /// No-op for ordinary modules (the rewrite is already on whenever the
+    /// implicit Prelude is in scope).
+    pub fn enableOverloadedIntLiterals(self: *RenameEnv) void {
+        self.overload_int_literals = true;
+    }
+
+    /// Whether the module being renamed has a `Num` class in scope despite
+    /// `NoImplicitPrelude`: declared by the module itself (as `GHC.Base`
+    /// does) or imported (seeded into `visible_class_names` by the driver).
+    pub fn hasVisibleNumClass(self: *const RenameEnv, decls: []const ast.Decl) bool {
+        if (self.visible_class_names.contains("Num")) return true;
+        for (decls) |d| {
+            switch (d) {
+                .Class => |cd| if (std.mem.eql(u8, cd.class_name, "Num")) return true,
+                else => {},
+            }
+        }
+        return false;
     }
 
     /// Allocate a fresh `Name` for a new binding site.
@@ -643,6 +679,10 @@ pub fn rename(module: ast.Module, env: *RenameEnv) !RenamedModule {
                 try top_names.put(env.alloc, fd.binding_name, n);
             },
             .Class => |cd| {
+                // Record the declared class so the `fromInteger` literal
+                // rewrite can detect a visible `Num` even under
+                // `NoImplicitPrelude` (#904).
+                try env.visible_class_names.put(env.alloc, cd.class_name, {});
                 // Register class name in scope, reusing the existing
                 // name if already bound (e.g. from populateBuiltins for
                 // well-known classes like Eq, Ord, Show).
@@ -3026,4 +3066,100 @@ test "rename #736: Negate desugars to App(negate, e)" {
     try testing.expect(body == .App);
     try testing.expect(body.App.fn_expr.* == .Var);
     try testing.expectEqualStrings("negate", body.App.fn_expr.Var.name.base);
+}
+
+test "rename #904: literal stays monomorphic Int under NoImplicitPrelude without Num" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var supply = UniqueSupply{};
+    var diags = DiagnosticCollector.init();
+    defer diags.deinit(alloc);
+
+    var env = try RenameEnv.init(alloc, &supply, &diags, true);
+    defer env.deinit();
+
+    // NoImplicitPrelude, no Num declared or imported → no rewrite.
+    try testing.expect(!env.hasVisibleNumClass(&.{}));
+    try testing.expect(!env.overload_int_literals);
+
+    const lit = ast.Expr{ .Lit = .{ .Int = .{ .value = 1, .span = testSpan() } } };
+    const decls = [_]ast.Decl{.{ .FunBind = .{
+        .name = "f",
+        .equations = &.{.{
+            .patterns = &.{},
+            .rhs = .{ .UnGuarded = lit },
+            .where_clause = null,
+            .span = testSpan(),
+        }},
+        .span = testSpan(),
+    } }};
+    const module = makeModule(&decls);
+    const rm = try rename(module, &env);
+    try testing.expect(!diags.hasErrors());
+
+    const body = rm.declarations[0].FunBind.equations[0].rhs.UnGuarded;
+    try testing.expect(body == .Lit);
+}
+
+test "rename #904: literal rewrites to fromInteger under NoImplicitPrelude when Num is declared" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var supply = UniqueSupply{};
+    var diags = DiagnosticCollector.init();
+    defer diags.deinit(alloc);
+
+    var env = try RenameEnv.init(alloc, &supply, &diags, true);
+    defer env.deinit();
+
+    // The module declares its own `Num` class (as GHC.Base does), so the
+    // driver enables the rewrite even under NoImplicitPrelude.
+    const num_decl = ast.Decl{ .Class = .{
+        .context = null,
+        .class_name = "Num",
+        .tyvars = &.{"a"},
+        .fundeps = &.{},
+        .methods = &.{},
+        .span = testSpan(),
+    } };
+    try testing.expect(env.hasVisibleNumClass(&.{num_decl}));
+    env.enableOverloadedIntLiterals();
+
+    const lit = ast.Expr{ .Lit = .{ .Int = .{ .value = 1, .span = testSpan() } } };
+    const decls = [_]ast.Decl{ num_decl, .{ .FunBind = .{
+        .name = "f",
+        .equations = &.{.{
+            .patterns = &.{},
+            .rhs = .{ .UnGuarded = lit },
+            .where_clause = null,
+            .span = testSpan(),
+        }},
+        .span = testSpan(),
+    } } };
+    const module = makeModule(&decls);
+    const rm = try rename(module, &env);
+    try testing.expect(!diags.hasErrors());
+
+    const body = rm.declarations[1].FunBind.equations[0].rhs.UnGuarded;
+    try testing.expect(body == .App);
+    try testing.expect(body.App.fn_expr.* == .Var);
+    try testing.expectEqualStrings("fromInteger", body.App.fn_expr.Var.name.base);
+}
+
+test "rename #904: imported Num class enables the literal rewrite" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    var supply = UniqueSupply{};
+    var diags = DiagnosticCollector.init();
+    defer diags.deinit(alloc);
+
+    var env = try RenameEnv.init(alloc, &supply, &diags, true);
+    defer env.deinit();
+
+    // Simulates the driver seeding class names from an imported module's
+    // interface (seedRenamerFromIface).
+    try env.visible_class_names.put(alloc, "Num", {});
+    try testing.expect(env.hasVisibleNumClass(&.{}));
 }


### PR DESCRIPTION
Closes #904

## Summary

Rewrites the `asinh`/`acosh`/`atanh` class-default bodies in `GHC.Base` to the Haskell 2010 Report spelling with integer literals (`1`, `2`), dropping the `pi/pi` workaround introduced under #898.

This required an enabling change: `GHC.Base.hs` carries `{-# LANGUAGE NoImplicitPrelude #-}`, and the #140 `fromInteger` literal rewrite was suppressed under that pragma — correct for user modules (no boot `Num` to type against), wrong for the boot module that *defines* `Num`/`fromInteger`.  The renamer now enables the rewrite under `NoImplicitPrelude` when a `Num` class is visible: declared by the module itself (detected via `RenameEnv.hasVisibleNumClass` over the declarations) or imported (class names seeded from upstream interfaces via the new `visible_class_names` set in `seedRenamerFromIface`).

## Deliverables

- [x] Rewrite the three default bodies to the literal-based Report form
- [x] Drop the explanatory `pi/pi` workaround comment
- [x] `tests/e2e/e2e_898_floating_defaults.hs` passes unchanged
- [x] Regression unit tests for the NoImplicitPrelude/Num-visibility gate (3 new renamer tests)
- [x] Follow-up issue filed for the shortcoming surfaced during this work: #920 (build.zig bootstrap does not track boot `.hs` sources — stale `rhc-store` silently reused after editing `lib/`)
- [x] Bench results refreshed (touches `lib/ghc-internal/`)

## Testing

- `nix develop --command zig build` — full build incl. fresh stage-2 boot-store bootstrap: OK
- `nix develop --command zig build test --summary all` — 952 unit + 97 e2e + 78 parser + 26 golden + REPL/CLI/WASM suites all pass
- `e2e_898_floating_defaults` output diffed against `.stdout`: identical
- Bench comparison vs previous entry: long-running programs within noise (queens −29.2%, knucleotide −12.8%, hanoi +0.2%, fib_rec −3.6%, matmul +4.0%); sub-ms programs >+20% are hyperfine noise-floor effects, none plausibly attributable to this change (the edited default bodies are not exercised by any bench program)

## Notes

- #904 lists #212 as a dependency; only the `fromInteger` half (already landed in #140 with the interim `Int` carrier) is needed here, as the issue's deliverable states.
- The custom-`fromInteger` `NoImplicitPrelude` case remains out of scope, still tracked in #912.
